### PR TITLE
Eliminate MainView flashing during and after measurements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ UnitTests/tests.xml
 /.vscode
 /.claude
 *proj.user
+/flash_diag.log

--- a/Tools/GridCtrl/GridCtrl.cpp
+++ b/Tools/GridCtrl/GridCtrl.cpp
@@ -4319,7 +4319,13 @@ BOOL CGridCtrl::SetItem(const GV_ITEM* pItem)
     SetModified(TRUE, pItem->row, pItem->col);
 
     if (pItem->mask & GVIF_TEXT)
+    {
+        LPCTSTR _oldTxt = pCell->GetText();
+        BOOL _txtChg = (_oldTxt == NULL) || (_tcscmp(_oldTxt, (LPCTSTR)pItem->strText) != 0);
         pCell->SetText(pItem->strText);
+        if (_txtChg)
+            InvalidateCellRect(pItem->row, pItem->col);
+    }
     if (pItem->mask & GVIF_PARAM)
         pCell->SetData(pItem->lParam);
     if (pItem->mask & GVIF_IMAGE)
@@ -4564,7 +4570,10 @@ BOOL CGridCtrl::SetItemBkColour(int nRow, int nCol, COLORREF cr /* = CLR_DEFAULT
     if (!pCell)
         return FALSE;
 
+    BOOL _bkChg = (pCell->GetBackClr() != cr);
     pCell->SetBackClr(cr);
+    if (_bkChg)
+        InvalidateCellRect(nRow, nCol);
     return TRUE;
 }
 
@@ -4588,7 +4597,10 @@ BOOL CGridCtrl::SetItemFgColour(int nRow, int nCol, COLORREF cr /* = CLR_DEFAULT
     if (!pCell)
         return FALSE;
     
+    BOOL _fgChg = (pCell->GetTextClr() != cr);
     pCell->SetTextClr(cr);
+    if (_fgChg)
+        InvalidateCellRect(nRow, nCol);
     return TRUE;
 }
 

--- a/Tools/XPGroupBox.cpp
+++ b/Tools/XPGroupBox.cpp
@@ -102,6 +102,26 @@ void CXPGroupBox::OnPaint()
 	// TODO: Add your message handler code here
    	CRect	rectClient;
 	GetClientRect(rectClient);
+
+	{
+		CWnd* _pP = GetParent();
+		if (_pP != NULL)
+		{
+			CRect _myR; GetWindowRect(_myR);
+			for (CWnd* _pS = _pP->GetWindow(GW_CHILD); _pS != NULL; _pS = _pS->GetWindow(GW_HWNDNEXT))
+			{
+				if (_pS->GetSafeHwnd() == GetSafeHwnd()) continue;
+				if (!(_pS->GetStyle() & WS_VISIBLE)) continue;
+				CRect _sR; _pS->GetWindowRect(_sR);
+				CRect _iR;
+				if (_iR.IntersectRect(_myR, _sR))
+				{
+					CRect _cR(_sR); ScreenToClient(_cR);
+					dc.ExcludeClipRect(_cR);
+				}
+			}
+		}
+	}
 	
 	// Defalte Rect
 	rectClient.DeflateRect(1,1);
@@ -225,6 +245,26 @@ void CXPGroupBox::OnPaint()
 		pDC->SelectClipRgn(&rgn);
 		DrawGradient(pDC,rectTitle,colorTop,colorBottom,true);
 		pDC->SelectClipRgn(NULL);
+
+		{
+			CWnd* _pP2 = GetParent();
+			if (_pP2 != NULL)
+			{
+				CRect _myR2; GetWindowRect(_myR2);
+				for (CWnd* _pS2 = _pP2->GetWindow(GW_CHILD); _pS2 != NULL; _pS2 = _pS2->GetWindow(GW_HWNDNEXT))
+				{
+					if (_pS2->GetSafeHwnd() == GetSafeHwnd()) continue;
+					if (!(_pS2->GetStyle() & WS_VISIBLE)) continue;
+					CRect _sR2; _pS2->GetWindowRect(_sR2);
+					CRect _iR2;
+					if (_iR2.IntersectRect(_myR2, _sR2))
+					{
+						CRect _cR2(_sR2); ScreenToClient(_cR2);
+						dc.ExcludeClipRect(_cR2);
+					}
+				}
+			}
+		}
 		// End of fx add
 		
 		// Draw content area

--- a/Tools/XPGroupBox.cpp
+++ b/Tools/XPGroupBox.cpp
@@ -425,7 +425,7 @@ void CXPGroupBox::UpdateSurface()
 	RedrawWindow();
 
 	GetParent()->ScreenToClient(rc);
-	GetParent()->InvalidateRect(rc,TRUE);
+	GetParent()->InvalidateRect(rc,FALSE);
 	GetParent()->UpdateWindow();
 }
 
@@ -700,9 +700,14 @@ CXPGroupBox& CXPGroupBox::SetText(LPCTSTR lpszText)
 {
 	if(IsWindow(this->GetSafeHwnd())) 
 	{
-		m_strTitle = lpszText;
-		m_strTitle = _T(" ") + m_strTitle + _T(" ");
-		UpdateSurface();
+		CString _newTitle = _T(" ");
+		_newTitle += lpszText;
+		_newTitle += _T(" ");
+		if (_newTitle != m_strTitle)
+		{
+			m_strTitle = _newTitle;
+			UpdateSurface();
+		}
 	}
 	
 	return *this;

--- a/Tools/XPGroupBox.cpp
+++ b/Tools/XPGroupBox.cpp
@@ -612,8 +612,11 @@ CXPGroupBox& CXPGroupBox::SetFontSize(int nSize)
 //////////////////////////////////////////////////////////////////////////
 CXPGroupBox& CXPGroupBox::SetBorderColor(COLORREF clrBorder)
 {
-	m_clrBorder = clrBorder;
-	UpdateSurface();
+	if (m_clrBorder != clrBorder)
+	{
+		m_clrBorder = clrBorder;
+		UpdateSurface();
+	}
 	return *this;
 }
 
@@ -706,7 +709,14 @@ CXPGroupBox& CXPGroupBox::SetText(LPCTSTR lpszText)
 		if (_newTitle != m_strTitle)
 		{
 			m_strTitle = _newTitle;
-			UpdateSurface();
+			CClientDC _dc(this);
+			CFont* _pOldF = _dc.SelectObject(&m_font);
+			int _titleH = _dc.GetTextExtent(_T("Ag"), 2).cy + 3;
+			_dc.SelectObject(_pOldF);
+			CRect _rcT; GetClientRect(_rcT);
+			_rcT.bottom = _rcT.top + _titleH;
+			InvalidateRect(_rcT, FALSE);
+			UpdateWindow();
 		}
 	}
 	

--- a/Views/MainView.cpp
+++ b/Views/MainView.cpp
@@ -2098,7 +2098,8 @@ void CMainView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 	else
 	{
 		// Normal OnUpdate
-		CFormView::OnUpdate(pSender, lHint, pHint);
+		if ( !( (lHint >= UPD_PRIMARIES && lHint <= UPD_FREEMEASURES) || lHint == UPD_CC24SAT ) )
+			CFormView::OnUpdate(pSender, lHint, pHint);
 
 		if ( m_displayType == HCFR_SENSORRGB_VIEW )
 		{

--- a/Views/MainView.cpp
+++ b/Views/MainView.cpp
@@ -430,6 +430,7 @@ CMainView::CMainView()
 
 	m_pGrayScaleGrid = NULL;
 	m_pSelectedColorGrid = NULL;
+	m_nSelColorGridReadingType = -1;
 	m_pBgBrush= new CBrush(FxGetMenuBgColor());
 
 	m_pInfoWnd = NULL;
@@ -1835,6 +1836,13 @@ void CMainView::InitSelectedColorGrid()
 	if(m_pSelectedColorGrid==NULL)
 		return;
 
+	int nReadingType = GetDocument()->m_pSensor->ReadingType();
+	// Structure/labels depend only on the sensor reading type, which doesn't change during a run.
+	// Skip the full rebuild + autosize (a per-update flicker source) when nothing structural changed.
+	if ( m_pSelectedColorGrid->GetRowCount() == 24 && m_nSelColorGridReadingType == nReadingType )
+		return;
+	m_nSelColorGridReadingType = nReadingType;
+
 	m_pSelectedColorGrid->SetFixedColumnCount(1);
 
     m_pSelectedColorGrid->SetRowCount(24);
@@ -1845,7 +1853,7 @@ void CMainView::InitSelectedColorGrid()
 	m_pSelectedColorGrid->SetTrackFocusCell(TRUE);
 	m_pSelectedColorGrid->SetEditable(FALSE);
 	m_pSelectedColorGrid->EnableDragAndDrop(FALSE);
-	m_pSelectedColorGrid->SetDoubleBuffering(FALSE);
+	m_pSelectedColorGrid->SetDoubleBuffering(TRUE);	// double-buffer to reduce flicker while live values stream in
 
 	m_pSelectedColorGrid->SetDefCellMargin(3);
 
@@ -1946,7 +1954,8 @@ void CMainView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 	CFrameWnd * pFrame = (CFrameWnd *)(AfxGetApp()->m_pMainWnd);
 //	if (pFrame)
 //		pFrame->GetActiveFrame()->ActivateFrame();
-	pFrame->OnUpdateFrameMenu(NULL);
+	if ( lHint < UPD_REALTIME && lHint != UPD_FREEMEASUREAPPENDED )
+		pFrame->OnUpdateFrameMenu(NULL);
 	// TODO: add a general option for that ?
 	if ( 1 )
 	{
@@ -2103,11 +2112,20 @@ void CMainView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 
 		if ( ( lHint >= UPD_EVERYTHING && lHint <= UPD_FREEMEASURES ) || lHint == UPD_ARRAYSIZES || lHint == UPD_GENERALREFERENCES || lHint == UPD_DATAREFDOC || lHint == UPD_REFERENCEDATA )
 		{
+			if (m_pGrayScaleGrid)
+				m_pGrayScaleGrid->SetRedraw(FALSE);
+			// Suppress intermediate repaints while InitGrid tears the grid down and UpdateGrid refills it
+			// (otherwise it blanks to white between the two during a measurement update); repaint once below.
 			InitGrid(); // to update row labels (if colorReference setting has changed, or if lux values appeared)
 			if(m_pGrayScaleGrid)
 				UpdateGrid();
 			if(m_SelectedColor.isValid())
 				RefreshSelection(false,GetDocument()->GetMeasure()->m_binMeasure);
+			if (m_pGrayScaleGrid)
+			{
+				m_pGrayScaleGrid->SetRedraw(TRUE);
+				m_pGrayScaleGrid->Invalidate(FALSE);
+			}
 		}
 		
 		if ( lHint == UPD_FREEMEASUREAPPENDED )
@@ -3701,7 +3719,6 @@ void CMainView::UpdateGrid()
 		if ( m_displayMode == 12 )
 			UpdateContrastValuesInGrid ();
 
-		m_pGrayScaleGrid->Refresh();
 		
 		if ( m_displayMode == 0 || m_displayMode == 3 || m_displayMode == 4)
 		{
@@ -5948,6 +5965,14 @@ BOOL CMainView::OnEraseBkgnd(CDC* pDC)
 {
 	CRect windowRect;
 	GetClientRect(windowRect );
+	if (m_pGrayScaleGrid && m_pGrayScaleGrid->GetSafeHwnd() && (m_pGrayScaleGrid->GetStyle() & WS_VISIBLE))
+	{
+		CRect _gr; m_pGrayScaleGrid->GetWindowRect(&_gr); ScreenToClient(&_gr); pDC->ExcludeClipRect(&_gr);
+	}
+	if (m_pSelectedColorGrid && m_pSelectedColorGrid->GetSafeHwnd() && (m_pSelectedColorGrid->GetStyle() & WS_VISIBLE))
+	{
+		CRect _sr; m_pSelectedColorGrid->GetWindowRect(&_sr); ScreenToClient(&_sr); pDC->ExcludeClipRect(&_sr);
+	}
 
 	COLORREF colorTop,colorBottom;
 	FxGetMenuBgColors(colorTop,colorBottom);

--- a/Views/MainView.h
+++ b/Views/MainView.h
@@ -220,6 +220,7 @@ public:
 protected:
 	CGridCtrl* m_pGrayScaleGrid;
 	CGridCtrl* m_pSelectedColorGrid;
+	int m_nSelColorGridReadingType;	// gates selected-color grid rebuilds: reading type it was built for (-1 = unbuilt)
 	void OnGrayScaleGridBeginEdit(NMHDR *pNotifyStruct,LRESULT* pResult);
 	void OnGrayScaleGridEndEdit(NMHDR *pNotifyStruct,LRESULT* pResult);
 	void OnGrayScaleGridEndSelChange(NMHDR *pNotifyStruct,LRESULT* pResult);


### PR DESCRIPTION
## Summary
The main measurement view flashed badly while taking readings and at the end of a
sweep: the data grids blanked to white, the group-box title bar and frame edges
flickered, and the whole window flashed when a sweep completed. These were several
**independent GDI-repaint** problems (not UI-thread blocking — that freeze is separate;
see Follow-up). Fixed across 4 commits, validated on real hardware.

## What's fixed
- **Data grids blanking on every measurement point _and_ every column click** (the root
  cause). The `CXPGroupBox` panel frames fill their interior, which overlaps the data
  grids — their *sibling* windows on the form — and `UpdateSurface` repainted the whole
  frame on every `SetText`/`SetBorderColor`, which the grid update calls on every point
  and every selection change. So the group box painted over the grid → blank → repaint →
  flash. Fixed by excluding the overlapping sibling windows from the group-box fill
  (applied both before the frame fill and again after the title-gradient clip reset).
- **Title-bar flashing during sweeps** — `UpdateSurface` erased the parent under the whole
  frame each point. Now invalidates without erase, and only when the title text changed.
- **Frame/border/edge flicker during continuous measures** — `SetText` now repaints only
  the title strip; `SetBorderColor` only repaints when the colour actually changes.
- **Whole-window flash at sweep end** — `UpdateAllViews(UPD_GRAYSCALE)` hit
  `CFormView::OnUpdate`'s default full-form `Invalidate(TRUE)`. Skipped for
  measurement-completion hints; the targeted grid update already repaints what changed.

Supporting changes: per-cell invalidate-on-change in `CGridCtrl::SetItem` /
`SetItemBkColour` / `SetItemFgColour`; dropped `UpdateGrid`'s blanket grid `Refresh()`;
double-buffered the selected-color grid; guarded the per-update frame-menu refresh.

## Files
- `Tools/XPGroupBox.cpp` — the key fix (sibling-exclude + title-strip-only repaint).
- `Views/MainView.cpp` / `Views/MainView.h` — update-path guards, grid handling.
- `Tools/GridCtrl/GridCtrl.cpp` — invalidate-on-change.

## Validation
Real hardware (X-Rite i1 DisplayPro): grayscale sweeps, single + continuous measures, and
column clicks no longer flash; group-box styling and final results render correctly.
Builds clean Debug & Release | Win32.

## Out of scope / follow-up
The **UI freeze** (window unresponsive while the meter integrates) is a separate problem —
the measurement loops run on the UI thread and block on `pSensor->Measure*()`. Threading
would fix the freeze but not the flash, so it wasn't bundled here. The repo already has the
async template to build on (`BkgndThreadFunc` in `datasetdoc.cpp`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)