### PR TITLE
Fix dark-mode menu separator line and MDIClient sunken border

### DIFF
--- a/MainFrm.cpp
+++ b/MainFrm.cpp
@@ -1012,6 +1012,16 @@ void CMDIClientWithLogo::OnSize(UINT nType, int cx, int cy)
 {
 	InvalidateRect ( NULL, TRUE );
 	Default ();
+	if ( GetConfig() && GetConfig()->m_darkTheme && m_hWnd )
+	{
+		LONG_PTR fxex = ::GetWindowLongPtr ( m_hWnd, GWL_EXSTYLE );
+		LONG_PTR fxex2 = fxex & ~(LONG_PTR)WS_EX_CLIENTEDGE;
+		if ( fxex2 != fxex )
+		{
+			::SetWindowLongPtr ( m_hWnd, GWL_EXSTYLE, fxex2 );
+			::SetWindowPos ( m_hWnd, NULL, 0,0,0,0, SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE );
+		}
+	}
 }
 
 BOOL CMDIClientWithLogo::OnEraseBkgnd(CDC* pDC) 

--- a/Tools/NewMenu/NewMenuBar.cpp
+++ b/Tools/NewMenu/NewMenuBar.cpp
@@ -1805,10 +1805,10 @@ BOOL CNewMenuBar::OnEraseBkgnd(CDC* pDC)
     ScreenToClient(clientRect);
     pDC->FillRect(clientRect,pBrush);
 	// Start of fx add
-	if(fxDrawMenuBorder)
+	if(fxDrawMenuBorder && !fxUseCustomColor)
 	{
 		clientRect.DeflateRect(0,0,0,2);
-		pDC->DrawEdge(clientRect,EDGE_ETCHED,BF_BOTTOM);	
+		pDC->DrawEdge(clientRect,EDGE_ETCHED,BF_BOTTOM);
 	}
 	// End of fx add
     pDC->SetBrushOrg(oldOrg);
@@ -1820,10 +1820,10 @@ BOOL CNewMenuBar::OnEraseBkgnd(CDC* pDC)
     ScreenToClient(clientRect);
     pDC->FillSolidRect(clientRect,CNewMenu::GetMenuBarColor());//FxGetSysColor(COLOR_3DLIGHT));
  	// Start of fx add
-	if(fxDrawMenuBorder)
+	if(fxDrawMenuBorder && !fxUseCustomColor)
 	{
 		clientRect.DeflateRect(0,0,0,2);
-		pDC->DrawEdge(clientRect,EDGE_ETCHED,BF_BOTTOM);	
+		pDC->DrawEdge(clientRect,EDGE_ETCHED,BF_BOTTOM);
 	}
 	// End of fx add
   }


### PR DESCRIPTION
## Summary

Two dark-theme-only painting artifacts in the main window, both fixed (light mode is byte-for-byte unchanged):

1. **Bright line directly under the menu bar** (between *File / View / Advanced / Help* and the toolbars). `CNewMenuBar::OnEraseBkgnd` drew an `EDGE_ETCHED` border at the menu's bottom via `DrawEdge()`, which uses **raw light system colors** (`COLOR_3DLIGHT`/`3DHILIGHT`) — subtle in light mode, glaring on dark. Now gated off in dark mode (`&& !fxUseCustomColor`) for the flat VS-style look.

2. **Sunken border around the window** (visible on the logo screen with no document open). MFC **re-adds** `WS_EX_CLIENTEDGE` to the MDIClient every time a document closes, so the existing one-time strip in `CMainFrame::OnCreate` wasn't enough. Now re-stripped in `CMDIClientWithLogo::OnSize` (fires on doc-close); the `ex2 != ex` guard keeps the `SetWindowPos(SWP_FRAMECHANGED)` non-recursive.

## Files
- `Tools/NewMenu/NewMenuBar.cpp` — gate the etched menu-bottom edge off in dark mode (both draw paths).
- `MainFrm.cpp` — re-strip MDIClient `WS_EX_CLIENTEDGE` in dark mode on resize.

## How it was found
A one-shot window-tree dump (`EnumChildWindows` → class / screen-rect / styles) pinned the exact culprits: the menu line is the menu bar's `DrawEdge`, and the sunken border is a re-added `WS_EX_CLIENTEDGE` on the MDIClient — not the control-bar/dock-bar border previously suspected.

## Testing
Builds clean (Debug | Win32). Verified on real hardware by the maintainer: both the menu line and the sunken border are gone in dark mode; light mode unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)