### PR TITLE
Bug fixes: MeasurePrimaries OOB, color-space name consistency, light-theme checkbox

### DIFF
--- a/CHCFR21_DEUTSCH.rc
+++ b/CHCFR21_DEUTSCH.rc
@@ -3185,24 +3185,24 @@ BEGIN
     IDS_CUSTREDREF          "Custom Rot Referenz"
     IDS_CUSTGREENREF        "Custom Grün Referenz"
     IDS_CUSTBLUEREF         "Custom Blau Referenz"
-    IDS_UHDTVREDREF         "UHDTV P3 Rot Referenz"
-    IDS_UHDTVGREENREF       "UHDTV P3 Grün Referenz"
-    IDS_UHDTVBLUEREF        "UHDTV P3 Blau Referenz"
-    IDS_UHDTV2REDREF        "UHDTV Rec2020 Rot Referenz"
-    IDS_UHDTV2GREENREF      "UHDTV Rec2020 Grün Referenz"
-    IDS_UHDTV2BLUEREF       "UHDTV Rec2020 Blau Referenz"
+    IDS_UHDTVREDREF         "DCI-P3 Rot Referenz"
+    IDS_UHDTVGREENREF       "DCI-P3 Grün Referenz"
+    IDS_UHDTVBLUEREF        "DCI-P3 Blau Referenz"
+    IDS_UHDTV2REDREF        "Rec.2020 Rot Referenz"
+    IDS_UHDTV2GREENREF      "Rec.2020 Grün Referenz"
+    IDS_UHDTV2BLUEREF       "Rec.2020 Blau Referenz"
     IDS_CONFIGURESENSOR2    "Start/Stop Adaptive Integration"
-    IDS_UHDTV3REDREF        "UHDTV P3 in Rec2020 Rot Referenz"
-    IDS_UHDTV3GREENREF      "UHDTV P3 in Rec2020 Grün Referenz"
-    IDS_UHDTV3BLUEREF       "UHDTV P3 in Rec2020 Blau Referenz"
+    IDS_UHDTV3REDREF        "P3 in Rec.2020 Rot Referenz"
+    IDS_UHDTV3GREENREF      "P3 in Rec.2020 Grün Referenz"
+    IDS_UHDTV3BLUEREF       "P3 in Rec.2020 Blau Referenz"
     IDS_ABOUT_PATTERNS      "additional patterns - 2016"
-    IDS_UHDTV4REDREF        "UHDTV Rec709 in Rec2020 Rot Referenz"
+    IDS_UHDTV4REDREF        "Rec.709 in Rec.2020 Rot Referenz"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_UHDTV4GREENREF      "UHDTV Rec709 in Rec2020 Grün Referenz"
-    IDS_UHDTV4BLUEREF       "UHDTV Rec709 in Rec2020 Blau Referenz"
+    IDS_UHDTV4GREENREF      "Rec.709 in Rec.2020 Grün Referenz"
+    IDS_UHDTV4BLUEREF       "Rec.709 in Rec.2020 Blau Referenz"
 END
 
 STRINGTABLE

--- a/CHCFR21_ENGLISH.rc
+++ b/CHCFR21_ENGLISH.rc
@@ -3203,24 +3203,24 @@ BEGIN
     IDS_CUSTREDREF          "Custom Red Reference"
     IDS_CUSTGREENREF        "Custom Green Reference"
     IDS_CUSTBLUEREF         "Custon Blue Reference"
-    IDS_UHDTVREDREF         "UHDTV P3 Red Reference"
-    IDS_UHDTVGREENREF       "UHDTV P3 Green Reference"
-    IDS_UHDTVBLUEREF        "UHDTV P3 Blue Reference"
-    IDS_UHDTV2REDREF        "UHDTV Rec2020 Red Reference"
-    IDS_UHDTV2GREENREF      "UHDTV Rec2020 Green Reference"
-    IDS_UHDTV2BLUEREF       "UHDTV Rec2020 Blue Reference"
+    IDS_UHDTVREDREF         "DCI-P3 Red Reference"
+    IDS_UHDTVGREENREF       "DCI-P3 Green Reference"
+    IDS_UHDTVBLUEREF        "DCI-P3 Blue Reference"
+    IDS_UHDTV2REDREF        "Rec.2020 Red Reference"
+    IDS_UHDTV2GREENREF      "Rec.2020 Green Reference"
+    IDS_UHDTV2BLUEREF       "Rec.2020 Blue Reference"
     IDS_CONFIGURESENSOR2    "Start/Stop Adaptive Integration"
-    IDS_UHDTV3REDREF        "UHDTV P3 in Rec2020 Red Reference"
-    IDS_UHDTV3GREENREF      "UHDTV P3 in Rec2020 Green Reference"
-    IDS_UHDTV3BLUEREF       "UHDTV P3 in Rec2020 Blue Reference"
+    IDS_UHDTV3REDREF        "P3 in Rec.2020 Red Reference"
+    IDS_UHDTV3GREENREF      "P3 in Rec.2020 Green Reference"
+    IDS_UHDTV3BLUEREF       "P3 in Rec.2020 Blue Reference"
     IDS_ABOUT_PATTERNS      "additional patterns - 2016"
-    IDS_UHDTV4REDREF        "UHDTV Rec709 in Rec2020 Red Reference"
+    IDS_UHDTV4REDREF        "Rec.709 in Rec.2020 Red Reference"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_UHDTV4GREENREF      "UHDTV Rec709 in Rec2020 Green Reference"
-    IDS_UHDTV4BLUEREF       "UHDTV Rec709 in Rec2020 Blue Reference"
+    IDS_UHDTV4GREENREF      "Rec.709 in Rec.2020 Green Reference"
+    IDS_UHDTV4BLUEREF       "Rec.709 in Rec.2020 Blue Reference"
 END
 
 STRINGTABLE

--- a/CHCFR21_ESPANOL.rc
+++ b/CHCFR21_ESPANOL.rc
@@ -3325,24 +3325,24 @@ BEGIN
     IDS_CUSTREDREF          "Custom Red Reference"
     IDS_CUSTGREENREF        "Custom Green Reference"
     IDS_CUSTBLUEREF         "Custon Blue Reference"
-    IDS_UHDTVREDREF         "UHDTV P3 Red Reference"
-    IDS_UHDTVGREENREF       "UHDTV P3 Green Reference"
-    IDS_UHDTVBLUEREF        "UHDTV P3 Blue Reference"
-    IDS_UHDTV2REDREF        "UHDTV Rec2020 Red Reference"
-    IDS_UHDTV2GREENREF      "UHDTV Rec2020 Green Reference"
-    IDS_UHDTV2BLUEREF       "UHDTV Rec2020 Blue Reference"
+    IDS_UHDTVREDREF         "DCI-P3 Red Reference"
+    IDS_UHDTVGREENREF       "DCI-P3 Green Reference"
+    IDS_UHDTVBLUEREF        "DCI-P3 Blue Reference"
+    IDS_UHDTV2REDREF        "Rec.2020 Red Reference"
+    IDS_UHDTV2GREENREF      "Rec.2020 Green Reference"
+    IDS_UHDTV2BLUEREF       "Rec.2020 Blue Reference"
     IDS_CONFIGURESENSOR2    "Start/Stop Adaptive Integration"
-    IDS_UHDTV3REDREF        "UHDTV P3 in Rec2020 Red Reference"
-    IDS_UHDTV3GREENREF      "UHDTV P3 in Rec2020 Green Reference"
-    IDS_UHDTV3BLUEREF       "UHDTV P3 in Rec2020 Blue Reference"
+    IDS_UHDTV3REDREF        "P3 in Rec.2020 Red Reference"
+    IDS_UHDTV3GREENREF      "P3 in Rec.2020 Green Reference"
+    IDS_UHDTV3BLUEREF       "P3 in Rec.2020 Blue Reference"
     IDS_ABOUT_PATTERNS      "additional patterns - 2016"
-    IDS_UHDTV4REDREF        "UHDTV Rec709 in Rec2020 Red Reference"
+    IDS_UHDTV4REDREF        "Rec.709 in Rec.2020 Red Reference"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_UHDTV4GREENREF      "UHDTV Rec709 in Rec2020 Green Reference"
-    IDS_UHDTV4BLUEREF       "UHDTV Rec709 in Rec2020 Blue Reference"
+    IDS_UHDTV4GREENREF      "Rec.709 in Rec.2020 Green Reference"
+    IDS_UHDTV4BLUEREF       "Rec.709 in Rec.2020 Blue Reference"
 END
 
 STRINGTABLE

--- a/CHCFR21_FRANCAIS.rc
+++ b/CHCFR21_FRANCAIS.rc
@@ -3417,24 +3417,24 @@ BEGIN
     IDS_CUSTREDREF          "Référence rouge Custom"
     IDS_CUSTGREENREF        "Référence vert Custom"
     IDS_CUSTBLUEREF         "Référence bleu Custom"
-    IDS_UHDTVREDREF         "Référence rouge UHDTV P3"
-    IDS_UHDTVGREENREF       "Référence vert UHDTV P3"
-    IDS_UHDTVBLUEREF        "Référence bleu UHDTV P3"
-    IDS_UHDTV2REDREF        "Référence rouge UHDTV Rec2020"
-    IDS_UHDTV2GREENREF      "Référence vert UHDTV Rec2020"
-    IDS_UHDTV2BLUEREF       "Référence bleu UHDTV Rec2020"
+    IDS_UHDTVREDREF         "Référence rouge DCI-P3"
+    IDS_UHDTVGREENREF       "Référence vert DCI-P3"
+    IDS_UHDTVBLUEREF        "Référence bleu DCI-P3"
+    IDS_UHDTV2REDREF        "Référence rouge Rec.2020"
+    IDS_UHDTV2GREENREF      "Référence vert Rec.2020"
+    IDS_UHDTV2BLUEREF       "Référence bleu Rec.2020"
     IDS_CONFIGURESENSOR2    "Démarrer/arrêter l'Intégration Adaptative"
-    IDS_UHDTV3REDREF        "Référence rouge UHDTV P3 in Rec2020"
-    IDS_UHDTV3GREENREF      "Référence vert UHDTV P3 in Rec2020"
-    IDS_UHDTV3BLUEREF       "Référence bleu UHDTV P3 in Rec2020"
+    IDS_UHDTV3REDREF        "Référence rouge P3 in Rec.2020"
+    IDS_UHDTV3GREENREF      "Référence vert P3 in Rec.2020"
+    IDS_UHDTV3BLUEREF       "Référence bleu P3 in Rec.2020"
     IDS_ABOUT_PATTERNS      "Motifs Additionels- 2016"
-    IDS_UHDTV4REDREF        "Référence rouge UHDTV Rec709 in Rec2020"
+    IDS_UHDTV4REDREF        "Référence rouge Rec.709 in Rec.2020"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_UHDTV4GREENREF      "Référence vert UHDTV Rec709 in Rec2020"
-    IDS_UHDTV4BLUEREF       "Référence bleu UHDTV Rec709 in Rec2020"
+    IDS_UHDTV4GREENREF      "Référence vert Rec.709 in Rec.2020"
+    IDS_UHDTV4BLUEREF       "Référence bleu Rec.709 in Rec.2020"
 END
 
 STRINGTABLE

--- a/CHCFR21_ITALIAN.rc
+++ b/CHCFR21_ITALIAN.rc
@@ -3403,24 +3403,24 @@ BEGIN
     IDS_CUSTREDREF          "Riferimento rosso personalizzato"
     IDS_CUSTGREENREF        "Riferimento verde personalizzato"
     IDS_CUSTBLUEREF         "Riferimento blu personalizzato"
-    IDS_UHDTVREDREF         "Riferimento UHDTV P3 Rosso"
-    IDS_UHDTVGREENREF       "Riferimento UHDTV P3 Verde"
-    IDS_UHDTVBLUEREF        "Riferimento UHDTV P3 Blu"
-    IDS_UHDTV2REDREF        "Riferimento UHDTV Rec2020 Rosso"
-    IDS_UHDTV2GREENREF      "Riferimento UHDTV Rec2020 Verde"
-    IDS_UHDTV2BLUEREF       "Riferimento UHDTV Rec2020 Blu"
+    IDS_UHDTVREDREF         "Riferimento DCI-P3 Rosso"
+    IDS_UHDTVGREENREF       "Riferimento DCI-P3 Verde"
+    IDS_UHDTVBLUEREF        "Riferimento DCI-P3 Blu"
+    IDS_UHDTV2REDREF        "Riferimento Rec.2020 Rosso"
+    IDS_UHDTV2GREENREF      "Riferimento Rec.2020 Verde"
+    IDS_UHDTV2BLUEREF       "Riferimento Rec.2020 Blu"
     IDS_CONFIGURESENSOR2    "Integrazione adattativa Start/Stop"
-    IDS_UHDTV3REDREF        "Riferimento UHDTV P3 in Rec2020 Rosso"
-    IDS_UHDTV3GREENREF      "Riferimento UHDTV P3 in Rec2020 Verde"
-    IDS_UHDTV3BLUEREF       "Riferimento UHDTV P3 in Rec2020 Blu"
+    IDS_UHDTV3REDREF        "Riferimento P3 in Rec.2020 Rosso"
+    IDS_UHDTV3GREENREF      "Riferimento P3 in Rec.2020 Verde"
+    IDS_UHDTV3BLUEREF       "Riferimento P3 in Rec.2020 Blu"
     IDS_ABOUT_PATTERNS      "Pattern aggiuntivi - 2016"
-    IDS_UHDTV4REDREF        "Riferimento UHDTV Rec709 in Rec2020 Rosso"
+    IDS_UHDTV4REDREF        "Riferimento Rec.709 in Rec.2020 Rosso"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_UHDTV4GREENREF      "Riferimento UHDTV Rec709 in Rec2020 Verde"
-    IDS_UHDTV4BLUEREF       "Riferimento UHDTV Rec709 in Rec2020 Blu"
+    IDS_UHDTV4GREENREF      "Riferimento Rec.709 in Rec.2020 Verde"
+    IDS_UHDTV4BLUEREF       "Riferimento Rec.709 in Rec.2020 Blu"
 END
 
 STRINGTABLE

--- a/ColorHCFRConfig.cpp
+++ b/ColorHCFRConfig.cpp
@@ -48,6 +48,14 @@ static char THIS_FILE[]=__FILE__;
 #define LANG_PREFIX "CHCFR21_"
 #define HELP_PREFIX "ColorHCFR_"
 
+CString GetColorStandardName(int nStandard)
+{
+	static const UINT ids[] = { IDS_STD_PALSECAM, IDS_STD_SDTV, IDS_STD_REC709, IDS_STD_REC709_75, IDS_STD_REC709_PLASMA, IDS_STD_SRGB, IDS_STD_DCIP3, IDS_STD_REC2020, IDS_STD_P3IN2020, IDS_STD_709IN2020, IDS_STD_CUSTOM };
+	CString s;
+	if (nStandard >= 0 && nStandard < (int)(sizeof(ids)/sizeof(ids[0]))) s.LoadString(ids[nStandard]);
+	return s;
+}
+
 static struct
 { LPCSTR	lpszLangCode;
   LPCSTR	lpszHelpName;

--- a/ColorHCFRConfig.h
+++ b/ColorHCFRConfig.h
@@ -38,6 +38,7 @@
 #include "AdvancedPropPage.h"
 #include "ToolbarPropPage.h"
 #include <map>
+extern CString GetColorStandardName(int nStandard);
 
 class CColorHCFRConfig  
 {

--- a/Export.cpp
+++ b/Export.cpp
@@ -762,7 +762,7 @@ bool CExport::SavePDF()
 	CCIEChartGrapher pCIE;
 	pCIE.SaveGraphFile(m_pDoc,CSize(dX,dY),filename1,2,95,TRUE);
 	CColorReference cRef = GetColorReference();
-	CString sName = cRef.standardName.c_str();
+	CString sName = GetColorStandardName(cRef.m_standard);
 	draw_image2(pdf, "color\\temp.png", 6, HPDF_Page_GetHeight (page) - 320 - 230, "CIE Diagram "+sName);
 	
 //SATS/LUM Chart

--- a/Measure.cpp
+++ b/Measure.cpp
@@ -4176,7 +4176,7 @@ BOOL CMeasure::MeasurePrimaries(CSensor *pSensor, CGenerator *pGenerator, CDataS
 	//convert to HDR levels if needed for psuedo color spaces
 	if (!(mode == 5 || mode == 7) && (GetColorReference().m_standard == UHDTV3 || GetColorReference().m_standard == UHDTV4))
 	{
-		for (int ci = 0; ci < 6; ci++)
+		for (int ci = 0; ci < 3; ci++)
 		{
 			ColorRGB clin = ContainerPrimaryLinear(GetColorReference(), ci);
 			for (int ck = 0; ck < 3; ck++)

--- a/ReferencesPropPage.cpp
+++ b/ReferencesPropPage.cpp
@@ -911,17 +911,7 @@ void CReferencesPropPage::BuildRuntimeLayout()
         {
             int sel = m_colorStandard;
             pStd->ResetContent();
-            pStd->AddString(LS(IDS_STD_PALSECAM));
-            pStd->AddString(LS(IDS_STD_SDTV));
-            pStd->AddString(LS(IDS_STD_REC709));
-            pStd->AddString(LS(IDS_STD_REC709_75));
-            pStd->AddString(LS(IDS_STD_REC709_PLASMA));
-            pStd->AddString(LS(IDS_STD_SRGB));
-            pStd->AddString(LS(IDS_STD_DCIP3));
-            pStd->AddString(LS(IDS_STD_REC2020));
-            pStd->AddString(LS(IDS_STD_P3IN2020));
-            pStd->AddString(LS(IDS_STD_709IN2020));
-            pStd->AddString(LS(IDS_STD_CUSTOM));
+            for (int i = 0; i <= CUSTOM; i++) pStd->AddString(GetColorStandardName(i));
             pStd->SetCurSel(sel);
         }
     }

--- a/Tools/fxcolor.cpp
+++ b/Tools/fxcolor.cpp
@@ -604,7 +604,7 @@ static LRESULT CALLBACK FxCheckSubclass(HWND hWnd, UINT msg, WPARAM wp, LPARAM l
     HBRUSH hbg = (HBRUSH)::SendMessage(GetParent(hWnd), WM_CTLCOLORSTATIC, (WPARAM)hdc, (LPARAM)hWnd); if (hbg) FillRect(hdc, &rc, hbg);
     LONG st = GetWindowLong(hWnd, GWL_STYLE) & BS_TYPEMASK; BOOL isRadio = (st == BS_RADIOBUTTON || st == BS_AUTORADIOBUTTON); BOOL checked = (::SendMessage(hWnd, BM_GETCHECK, 0, 0) == BST_CHECKED); BOOL hot = (GetProp(hWnd, _T("fxh")) != NULL);
     int h = rc.bottom - rc.top; int sz = h - 8; if (sz < 11) sz = 11; if (sz > 15) sz = 15; int top = rc.top + (h - sz) / 2; int left = rc.left + 1;
-    COLORREF fg = FxGetTextColor(); HPEN pen = CreatePen(PS_SOLID, hot ? 2 : 1, fg); HGDIOBJ oldPen = SelectObject(hdc, pen); HGDIOBJ oldBr = SelectObject(hdc, GetStockObject(NULL_BRUSH));
+    COLORREF fg = IsWindowEnabled(hWnd) ? FxGetTextColor() : FxGetSysColor(COLOR_GRAYTEXT); HPEN pen = CreatePen(PS_SOLID, hot ? 2 : 1, fg); HGDIOBJ oldPen = SelectObject(hdc, pen); HGDIOBJ oldBr = SelectObject(hdc, GetStockObject(NULL_BRUSH));
     if (isRadio) { Ellipse(hdc, left, top, left + sz, top + sz); if (checked) { HBRUSH db = CreateSolidBrush(fg); HGDIOBJ ob = SelectObject(hdc, db); Ellipse(hdc, left + 4, top + 4, left + sz - 4, top + sz - 4); SelectObject(hdc, ob); DeleteObject(db); } }
     else { RoundRect(hdc, left, top, left + sz, top + sz, 4, 4); if (checked) { MoveToEx(hdc, left + 3, top + sz / 2, NULL); LineTo(hdc, left + sz / 2 - 1, top + sz - 4); LineTo(hdc, left + sz - 3, top + 3); } }
     SelectObject(hdc, oldPen); SelectObject(hdc, oldBr); DeleteObject(pen);
@@ -614,6 +614,10 @@ static LRESULT CALLBACK FxCheckSubclass(HWND hWnd, UINT msg, WPARAM wp, LPARAM l
     HFONT hf = (HFONT)::SendMessage(hWnd, WM_GETFONT, 0, 0); HGDIOBJ oldF = hf ? SelectObject(hdc, hf) : NULL;
     DrawTextW(hdc, buf, -1, &tr, DT_LEFT | DT_VCENTER | DT_SINGLELINE); if (oldF) SelectObject(hdc, oldF); if (GetFocus() == hWnd) DrawFocusRect(hdc, &tr);
     EndPaint(hWnd, &ps); return 0;
+}
+void FxApplyFlatCheck(HWND hWnd)
+{
+    if (hWnd) { SetWindowSubclass(hWnd, FxCheckSubclass, 1, 0); InvalidateRect(hWnd, NULL, TRUE); }
 }
 static void FxSubclassCheckRadio(HWND hWnd, BOOL bDark)
 {

--- a/Tools/fxcolor.h
+++ b/Tools/fxcolor.h
@@ -42,4 +42,5 @@ extern COLORREF FxSaturateColor(int aSatPercent,COLORREF aColor);
 extern void ApplyDarkTitleBar(HWND hWnd, BOOL bDark);
 extern void FxEnableDarkMode(BOOL bDark);
 extern void FxApplyDarkModeTree(HWND hRoot, BOOL bDark);
+extern void FxApplyFlatCheck(HWND hWnd);
 #endif

--- a/Views/MainView.cpp
+++ b/Views/MainView.cpp
@@ -5891,6 +5891,7 @@ void CMainView::InitButtons()
 			m_avgLowLightCheck.SetFont(GetFont());
 			CString sAvg; sAvg.LoadString(IDS_AVG_LOW_LIGHT);
 			m_avgLowLightCheck.SetWindowText(sAvg);
+			if (!GetConfig()->m_darkTheme) FxApplyFlatCheck(m_avgLowLightCheck.GetSafeHwnd());
 		}
 		CSensor* pAvgS = GetDocument() ? GetDocument()->m_pSensor : NULL;
 		BOOL bAvgSup = (pAvgS != NULL && pAvgS->supportsAvg());

--- a/Views/MainView.cpp
+++ b/Views/MainView.cpp
@@ -4215,7 +4215,7 @@ void CMainView::UpdateGrid()
 		CString bbcstr,sdrstr;
 		bbcstr.Format("system gamma: %3.2f",BBC_gamma);
 
-		CString CS = GetColorReference().standardName.c_str();
+		CString CS = GetColorStandardName(GetColorReference().m_standard);
 		CString WP = GetColorReference().whiteName;
 
 		switch(GetConfig()->m_GammaOffsetType)


### PR DESCRIPTION
Four fixes found while reviewing the fork ahead of release. All build clean (Debug|Win32); the color-math fix and both visual fixes were verified.

## MeasurePrimaries out-of-bounds write (UHDTV3/UHDTV4 SDR) — `5a0aab17`
`CMeasure::MeasurePrimaries` declares `ColorRGBDisplay GenColors[5]`, but the custom-white pattern-overwrite block looped `ci < 6` — writing one element past the end of the array and clobbering the white (index 3) and black (index 4) patterns with the yellow/cyan linear values, for P3-in-Rec2020 (UHDTV3) and Rec709-in-Rec2020 (UHDTV4) in SDR.

`ColorRGBDisplay` derives from `Matrix` (heap-backed `std::vector`), so the out-of-bounds element's data pointer is garbage stack memory; the write risked a crash or heap corruption when starting a "Measure primaries" sweep in those modes. Bounded the loop to `ci < 3` (primaries only need R, G, B). The sibling blocks in `MeasureGrayScaleAndColors` / `MeasureSecondaries` use `GenColors[8]` and were already correct.

## Color-space names unified with the References dropdown — `792847d2`, `9fd2aab9`
The standard names were shown three different ways and disagreed (e.g. "UHDTV P3 in Rec2020" vs the dropdown's "P3 in Rec.2020"):
- CIE chart legend (`IDS_UHDTV*REF`) — relabeled to match the dropdown across all five language string tables.
- View info line + PDF export — were reading `CColorReference::standardName`. Added a single `GetColorStandardName(standard)` helper mapping each standard to its `IDS_STD_*` dropdown name; the dropdown now enumerates through it, and the View line and PDF resolve names through it. One localized source for all surfaces.

## Avg low light checkbox dark background in light theme — `6cbe42c5`
The Sensor-pane checkbox is created programmatically and kept the process immersive dark-mode default in light theme (the normal theming pass didn't override it for this control). Bypassed the Windows theme in light mode by hand-drawing it via the existing `FxCheckSubclass`, which fills its background from the parent (light) brush; also grey the label when the control is disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
