### PR TITLE
Settings migration + Adaptive low light / References UI fixes

### DIFF
--- a/CHCFR21_DEUTSCH.rc
+++ b/CHCFR21_DEUTSCH.rc
@@ -2946,7 +2946,7 @@ BEGIN
     IDS_STD_P3IN2020  "P3 in Rec.2020"
     IDS_STD_709IN2020  "Rec.709 in Rec.2020"
     IDS_STD_CUSTOM  "Benutzerdefiniert"
-    IDS_AVG_LOW_LIGHT  "Mittelung bei wenig Licht"
+    IDS_AVG_LOW_LIGHT  "Adaptives Schwachlicht"
     IDS_GEN_OUTPUT  "Musterausgabe"
     IDS_GEN_OUT_FULLSCREEN  "Desktop - Vollbild"
     IDS_GEN_OUT_OVERLAY  "Desktop - Overlay"

--- a/CHCFR21_ENGLISH.rc
+++ b/CHCFR21_ENGLISH.rc
@@ -2955,7 +2955,7 @@ BEGIN
     IDS_STD_P3IN2020  "P3 in Rec.2020"
     IDS_STD_709IN2020  "Rec.709 in Rec.2020"
     IDS_STD_CUSTOM  "Custom"
-    IDS_AVG_LOW_LIGHT  "Avg low light"
+    IDS_AVG_LOW_LIGHT  "Adaptive low light"
     IDS_GEN_OUTPUT  "Pattern output"
     IDS_GEN_OUT_FULLSCREEN  "Desktop - fullscreen"
     IDS_GEN_OUT_OVERLAY  "Desktop - overlay"

--- a/CHCFR21_ESPANOL.rc
+++ b/CHCFR21_ESPANOL.rc
@@ -3077,7 +3077,7 @@ BEGIN
     IDS_STD_P3IN2020  "P3 in Rec.2020"
     IDS_STD_709IN2020  "Rec.709 in Rec.2020"
     IDS_STD_CUSTOM  "Personalizado"
-    IDS_AVG_LOW_LIGHT  "Promediar luz baja"
+    IDS_AVG_LOW_LIGHT  "Poca luz adaptativa"
     IDS_GEN_OUTPUT  "Salida de patrón"
     IDS_GEN_OUT_FULLSCREEN  "Escritorio - pantalla completa"
     IDS_GEN_OUT_OVERLAY  "Escritorio - superposición"

--- a/CHCFR21_FRANCAIS.rc
+++ b/CHCFR21_FRANCAIS.rc
@@ -3169,7 +3169,7 @@ BEGIN
     IDS_STD_P3IN2020  "P3 in Rec.2020"
     IDS_STD_709IN2020  "Rec.709 in Rec.2020"
     IDS_STD_CUSTOM  "Personnalisé"
-    IDS_AVG_LOW_LIGHT  "Moyenne faible lumière"
+    IDS_AVG_LOW_LIGHT  "Faible lumière adaptative"
     IDS_GEN_OUTPUT  "Sortie des mires"
     IDS_GEN_OUT_FULLSCREEN  "Bureau - plein écran"
     IDS_GEN_OUT_OVERLAY  "Bureau - superposition"

--- a/CHCFR21_ITALIAN.rc
+++ b/CHCFR21_ITALIAN.rc
@@ -3155,7 +3155,7 @@ BEGIN
     IDS_STD_P3IN2020  "P3 in Rec.2020"
     IDS_STD_709IN2020  "Rec.709 in Rec.2020"
     IDS_STD_CUSTOM  "Personalizzato"
-    IDS_AVG_LOW_LIGHT  "Media luce bassa"
+    IDS_AVG_LOW_LIGHT  "Poca luce adattiva"
     IDS_GEN_OUTPUT  "Uscita pattern"
     IDS_GEN_OUT_FULLSCREEN  "Desktop - schermo intero"
     IDS_GEN_OUT_OVERLAY  "Desktop - overlay"

--- a/ColorHCFRConfig.cpp
+++ b/ColorHCFRConfig.cpp
@@ -67,6 +67,67 @@ static struct
 					   };
 
 
+// ---- One-time settings migration from a previous HCFR install ----
+// 4.0 keeps its config under %APPDATA% (the exe folder is read-only when
+// installed under Program Files). On first run, import the most recent
+// ColorHCFR.ini from a prior version: a writable old folder, a Program Files
+// install, or its UAC VirtualStore mirror.
+static bool HcfrFileWriteTime(LPCSTR p, FILETIME &ft)
+{
+	WIN32_FILE_ATTRIBUTE_DATA fad;
+	if (!GetFileAttributesEx(p, GetFileExInfoStandard, &fad)) return false;
+	if (fad.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) return false;
+	ft = fad.ftLastWriteTime;
+	return true;
+}
+static void HcfrScanForIni(LPCSTR baseDir, char *best, FILETIME &bestFt, bool &haveBest)
+{
+	if (!baseDir || !*baseDir) return;
+	char pattern[MAX_PATH];
+	sprintf(pattern, "%s\\ColorHCFR*", baseDir);
+	WIN32_FIND_DATA fd;
+	HANDLE h = FindFirstFile(pattern, &fd);
+	if (h == INVALID_HANDLE_VALUE) return;
+	do
+	{
+		if (!(fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) continue;
+		if (fd.cFileName[0] == '.') continue;
+		char cand[MAX_PATH];
+		sprintf(cand, "%s\\%s\\ColorHCFR.ini", baseDir, fd.cFileName);
+		FILETIME ft;
+		if (HcfrFileWriteTime(cand, ft) && (!haveBest || CompareFileTime(&ft, &bestFt) > 0))
+		{
+			strcpy(best, cand);
+			bestFt = ft;
+			haveBest = true;
+		}
+	} while (FindNextFile(h, &fd));
+	FindClose(h);
+}
+static void HcfrMigratePreviousIni(LPCSTR dest, LPCSTR exeDirIni)
+{
+	char best[MAX_PATH] = "";
+	FILETIME bestFt;
+	bool haveBest = false;
+	FILETIME ft;
+	if (exeDirIni && *exeDirIni && HcfrFileWriteTime(exeDirIni, ft))
+	{
+		strcpy(best, exeDirIni);
+		bestFt = ft;
+		haveBest = true;
+	}
+	HcfrScanForIni(getenv("ProgramFiles(x86)"), best, bestFt, haveBest);
+	const char *lad = getenv("LOCALAPPDATA");
+	if (lad && *lad)
+	{
+		char vs[MAX_PATH];
+		sprintf(vs, "%s\\VirtualStore\\Program Files (x86)", lad);
+		HcfrScanForIni(vs, best, bestFt, haveBest);
+	}
+	if (haveBest)
+		CopyFile(best, dest, TRUE);
+}
+
 CColorHCFRConfig::CColorHCFRConfig()
 {
 	char			szBuf [ 256 ];
@@ -96,6 +157,26 @@ CColorHCFRConfig::CColorHCFRConfig()
 	// Build log file name
 	lpStr = strrchr ( m_logFileName, (int) '\\' );
 	strcpy ( lpStr + 1, "ColorHCFR.log" );
+
+	// Config must live in a per-user writable location: the exe folder is
+	// read-only when installed under Program Files, and UAC virtualization is
+	// off for this build. Keep the INI and log under %APPDATA%\color; read-only
+	// files (help, language DLLs, res\images) still load from the exe folder.
+	{
+		const char *pAppData = getenv("APPDATA");
+		if (pAppData && *pAppData)
+		{
+			char szExeIni[MAX_PATH];
+			strcpy(szExeIni, m_iniFileName);
+			char szDir[MAX_PATH];
+			sprintf(szDir, "%s\\color", pAppData);
+			CreateDirectory(szDir, NULL);
+			sprintf(m_iniFileName, "%s\\ColorHCFR.ini", szDir);
+			sprintf(m_logFileName, "%s\\ColorHCFR.log", szDir);
+			if (GetFileAttributes(m_iniFileName) == INVALID_FILE_ATTRIBUTES)
+				HcfrMigratePreviousIni(m_iniFileName, szExeIni);
+		}
+	}
 
 	// Initialize language DLL, which is definitively loaded
 	strLang = GetProfileString ( "Options", "Language", "" );

--- a/ReferencesPropPage.cpp
+++ b/ReferencesPropPage.cpp
@@ -959,7 +959,7 @@ void CReferencesPropPage::BuildRuntimeLayout()
     m_pCdm2 = AddText(this, m_dynAll, NULL, font, M, "cd/m2", 127, 97, 18, 8);
 
     // Set target values manually: own row (HDR only).
-    MoveDlg(this, IDC_USER_OVERRIDE_TARGS, M, 12, 110, 270, 10);
+    MoveDlg(this, IDC_USER_OVERRIDE_TARGS, M, 12, 110, 256, 10);
     GetDlgItem(IDC_USER_OVERRIDE_TARGS)->SetWindowText(LS(IDS_REF_SETMANUAL));
 
     // --- SDR power-law / black compensation: one Gamma box (editable reference,

--- a/Tools/fxcolor.cpp
+++ b/Tools/fxcolor.cpp
@@ -593,33 +593,6 @@ void FxEnableDarkMode(BOOL bDark)
     if (pFlush) pFlush();
     FreeLibrary(hUx);
 }
-static LRESULT CALLBACK FxCheckSubclass(HWND hWnd, UINT msg, WPARAM wp, LPARAM lp, UINT_PTR uId, DWORD_PTR dwRef)
-{
-    if (msg == WM_ERASEBKGND) return 1;
-    if (msg == WM_MOUSEMOVE) { if (!GetProp(hWnd, _T("fxh"))) { SetProp(hWnd, _T("fxh"), (HANDLE)1); TRACKMOUSEEVENT t; t.cbSize=sizeof(t); t.dwFlags=TME_LEAVE; t.hwndTrack=hWnd; t.dwHoverTime=0; TrackMouseEvent(&t); InvalidateRect(hWnd, NULL, FALSE); } return DefSubclassProc(hWnd, msg, wp, lp); }
-    if (msg == WM_MOUSELEAVE) { RemoveProp(hWnd, _T("fxh")); InvalidateRect(hWnd, NULL, FALSE); return DefSubclassProc(hWnd, msg, wp, lp); }
-    if (msg == WM_SETFOCUS || msg == WM_KILLFOCUS) { InvalidateRect(hWnd, NULL, FALSE); return DefSubclassProc(hWnd, msg, wp, lp); }
-    if (msg != WM_PAINT) return DefSubclassProc(hWnd, msg, wp, lp);
-    PAINTSTRUCT ps; HDC hdc = BeginPaint(hWnd, &ps); RECT rc; GetClientRect(hWnd, &rc);
-    HBRUSH hbg = (HBRUSH)::SendMessage(GetParent(hWnd), WM_CTLCOLORSTATIC, (WPARAM)hdc, (LPARAM)hWnd); if (hbg) FillRect(hdc, &rc, hbg);
-    LONG st = GetWindowLong(hWnd, GWL_STYLE) & BS_TYPEMASK; BOOL isRadio = (st == BS_RADIOBUTTON || st == BS_AUTORADIOBUTTON); BOOL checked = (::SendMessage(hWnd, BM_GETCHECK, 0, 0) == BST_CHECKED); BOOL hot = (GetProp(hWnd, _T("fxh")) != NULL);
-    int h = rc.bottom - rc.top; int sz = h - 8; if (sz < 11) sz = 11; if (sz > 15) sz = 15; int top = rc.top + (h - sz) / 2; int left = rc.left + 1;
-    COLORREF fg = FxGetTextColor(); HPEN pen = CreatePen(PS_SOLID, hot ? 2 : 1, fg); HGDIOBJ oldPen = SelectObject(hdc, pen); HGDIOBJ oldBr = SelectObject(hdc, GetStockObject(NULL_BRUSH));
-    if (isRadio) { Ellipse(hdc, left, top, left + sz, top + sz); if (checked) { HBRUSH db = CreateSolidBrush(fg); HGDIOBJ ob = SelectObject(hdc, db); Ellipse(hdc, left + 4, top + 4, left + sz - 4, top + sz - 4); SelectObject(hdc, ob); DeleteObject(db); } }
-    else { RoundRect(hdc, left, top, left + sz, top + sz, 4, 4); if (checked) { MoveToEx(hdc, left + 3, top + sz / 2, NULL); LineTo(hdc, left + sz / 2 - 1, top + sz - 4); LineTo(hdc, left + sz - 3, top + 3); } }
-    SelectObject(hdc, oldPen); SelectObject(hdc, oldBr); DeleteObject(pen);
-    WCHAR buf[256]; buf[0] = 0; GetWindowTextW(hWnd, buf, 255);
-    RECT tr; tr.left = left + sz + 5; tr.top = rc.top; tr.right = rc.right; tr.bottom = rc.bottom;
-    SetBkMode(hdc, TRANSPARENT); SetTextColor(hdc, fg);
-    HFONT hf = (HFONT)::SendMessage(hWnd, WM_GETFONT, 0, 0); HGDIOBJ oldF = hf ? SelectObject(hdc, hf) : NULL;
-    DrawTextW(hdc, buf, -1, &tr, DT_LEFT | DT_VCENTER | DT_SINGLELINE); if (oldF) SelectObject(hdc, oldF); if (GetFocus() == hWnd) DrawFocusRect(hdc, &tr);
-    EndPaint(hWnd, &ps); return 0;
-}
-static void FxSubclassCheckRadio(HWND hWnd, BOOL bDark)
-{
-    if (bDark) SetWindowSubclass(hWnd, FxCheckSubclass, 1, 0); else RemoveWindowSubclass(hWnd, FxCheckSubclass, 1);
-    InvalidateRect(hWnd, NULL, TRUE);
-}
 static LRESULT CALLBACK FxRadioTextSubclass(HWND hWnd, UINT msg, WPARAM wp, LPARAM lp, UINT_PTR uId, DWORD_PTR dwRef)
 {
     if (msg == WM_ERASEBKGND) return 1;

--- a/Tools/fxcolor.cpp
+++ b/Tools/fxcolor.cpp
@@ -604,7 +604,7 @@ static LRESULT CALLBACK FxCheckSubclass(HWND hWnd, UINT msg, WPARAM wp, LPARAM l
     HBRUSH hbg = (HBRUSH)::SendMessage(GetParent(hWnd), WM_CTLCOLORSTATIC, (WPARAM)hdc, (LPARAM)hWnd); if (hbg) FillRect(hdc, &rc, hbg);
     LONG st = GetWindowLong(hWnd, GWL_STYLE) & BS_TYPEMASK; BOOL isRadio = (st == BS_RADIOBUTTON || st == BS_AUTORADIOBUTTON); BOOL checked = (::SendMessage(hWnd, BM_GETCHECK, 0, 0) == BST_CHECKED); BOOL hot = (GetProp(hWnd, _T("fxh")) != NULL);
     int h = rc.bottom - rc.top; int sz = h - 8; if (sz < 11) sz = 11; if (sz > 15) sz = 15; int top = rc.top + (h - sz) / 2; int left = rc.left + 1;
-    COLORREF fg = IsWindowEnabled(hWnd) ? FxGetTextColor() : FxGetSysColor(COLOR_GRAYTEXT); HPEN pen = CreatePen(PS_SOLID, hot ? 2 : 1, fg); HGDIOBJ oldPen = SelectObject(hdc, pen); HGDIOBJ oldBr = SelectObject(hdc, GetStockObject(NULL_BRUSH));
+    COLORREF fg = FxGetTextColor(); HPEN pen = CreatePen(PS_SOLID, hot ? 2 : 1, fg); HGDIOBJ oldPen = SelectObject(hdc, pen); HGDIOBJ oldBr = SelectObject(hdc, GetStockObject(NULL_BRUSH));
     if (isRadio) { Ellipse(hdc, left, top, left + sz, top + sz); if (checked) { HBRUSH db = CreateSolidBrush(fg); HGDIOBJ ob = SelectObject(hdc, db); Ellipse(hdc, left + 4, top + 4, left + sz - 4, top + sz - 4); SelectObject(hdc, ob); DeleteObject(db); } }
     else { RoundRect(hdc, left, top, left + sz, top + sz, 4, 4); if (checked) { MoveToEx(hdc, left + 3, top + sz / 2, NULL); LineTo(hdc, left + sz / 2 - 1, top + sz - 4); LineTo(hdc, left + sz - 3, top + 3); } }
     SelectObject(hdc, oldPen); SelectObject(hdc, oldBr); DeleteObject(pen);
@@ -614,10 +614,6 @@ static LRESULT CALLBACK FxCheckSubclass(HWND hWnd, UINT msg, WPARAM wp, LPARAM l
     HFONT hf = (HFONT)::SendMessage(hWnd, WM_GETFONT, 0, 0); HGDIOBJ oldF = hf ? SelectObject(hdc, hf) : NULL;
     DrawTextW(hdc, buf, -1, &tr, DT_LEFT | DT_VCENTER | DT_SINGLELINE); if (oldF) SelectObject(hdc, oldF); if (GetFocus() == hWnd) DrawFocusRect(hdc, &tr);
     EndPaint(hWnd, &ps); return 0;
-}
-void FxApplyFlatCheck(HWND hWnd)
-{
-    if (hWnd) { SetWindowSubclass(hWnd, FxCheckSubclass, 1, 0); InvalidateRect(hWnd, NULL, TRUE); }
 }
 static void FxSubclassCheckRadio(HWND hWnd, BOOL bDark)
 {
@@ -650,6 +646,10 @@ static LRESULT CALLBACK FxRadioTextSubclass(HWND hWnd, UINT msg, WPARAM wp, LPAR
     DrawTextW(hdc, buf, -1, &tr, DT_LEFT | DT_VCENTER | DT_SINGLELINE); if (oldF) SelectObject(hdc, oldF);
     if (GetFocus() == hWnd) { RECT cr = tr; DrawTextW(hdc, buf, -1, &cr, DT_CALCRECT | DT_SINGLELINE); RECT fr = tr; fr.right = tr.left + (cr.right - cr.left) + 2; DrawFocusRect(hdc, &fr); }
     EndPaint(hWnd, &ps); return 0;
+}
+void FxApplyFlatCheck(HWND hWnd)
+{
+    if (hWnd) { SetWindowSubclass(hWnd, FxRadioTextSubclass, 1, 0); InvalidateRect(hWnd, NULL, TRUE); }
 }
 static void FxSubclassRadio(HWND hWnd, BOOL bDark)
 {


### PR DESCRIPTION
Five buttoned-up fixes, stacked on top of the merged PR #14.

## Config persistence + migration
- **Store config under `%APPDATA%\color`** instead of the exe folder. When installed under Program Files the exe dir is read-only and UAC virtualization is off for this build, so settings silently failed to persist. INI + log now live in a per-user writable location; read-only assets (lang DLLs, `res\images`, help) still load from the exe dir.
- **One-time, one-way migration** from a previous HCFR install on first run: imports the newest `ColorHCFR.ini` found in the exe dir, `Program Files (x86)\ColorHCFR*`, or its UAC VirtualStore mirror. Uses `CopyFile(..., bFailIfExists=TRUE)` and only runs when no 4.0 INI exists yet — the old install's settings are never modified.

## UI fixes
- **Rename "Avg low light" → "Adaptive low light"** in all 5 languages (clearer wording, better fit).
- **Render that checkbox natively in light theme** — route it through `FxRadioTextSubclass` so it gets a native glyph and the parent background (no stray dark bar), matching every other Sensor-pane control.
- **Fit the "Set targets manually" checkbox inside its groupbox** on the References / PQ transfer-function page (was 270 dlu wide, overrunning the box border; now 256).

## Cleanup
- **Remove dead `FxCheckSubclass` / `FxSubclassCheckRadio`** — both became unreachable once `FxApplyFlatCheck` moved to `FxRadioTextSubclass`. No live path changes.

All byte-sensitive files edited via Latin-1 round-trip; non-ASCII byte counts verified unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)