### PR TITLE
Release prep: honest resize note + Start Menu shortcut

### DIFF
--- a/ColorHCFR_2019.vdproj
+++ b/ColorHCFR_2019.vdproj
@@ -6540,6 +6540,20 @@
             "Icon" = "8:_A6684703AD8A46A9A1DCA60E55B03837"
             "Feature" = "8:"
             }
+            "{970C0BB2-C7D0-45D7-ABFA-7EC378858BC0}:_6B8D4F2A0C3E5B7D9E1F2A4C6B8D0E2F"
+            {
+            "Name" = "8:ColorHCFR"
+            "Arguments" = "8:"
+            "Description" = "8:"
+            "ShowCmd" = "3:1"
+            "IconIndex" = "3:0"
+            "Transitive" = "11:FALSE"
+            "Target" = "8:_B67B0B3487F14058AFFDA8EFD8EB2AF0"
+            "Folder" = "8:_3373C97FF7544DF699FFB259C544FC42"
+            "WorkingFolder" = "8:_CBA93CD1FDCA460399C4B48902B51B88"
+            "Icon" = "8:_A6684703AD8A46A9A1DCA60E55B03837"
+            "Feature" = "8:"
+            }
         }
         "UserInterface"
         {

--- a/ColorHCFR_VS2019.vdproj
+++ b/ColorHCFR_VS2019.vdproj
@@ -6564,6 +6564,20 @@
             "Icon" = "8:_1EC5EAEDA13A4288B8E5B849F48619A8"
             "Feature" = "8:"
             }
+            "{970C0BB2-C7D0-45D7-ABFA-7EC378858BC0}:_5A7C3E1F9B2D4A6E8C0F1D3B5A7E9C2F"
+            {
+            "Name" = "8:ColorHCFR"
+            "Arguments" = "8:"
+            "Description" = "8:"
+            "ShowCmd" = "3:1"
+            "IconIndex" = "3:0"
+            "Transitive" = "11:FALSE"
+            "Target" = "8:_B67B0B3487F14058AFFDA8EFD8EB2AF0"
+            "Folder" = "8:_3373C97FF7544DF699FFB259C544FC42"
+            "WorkingFolder" = "8:_CBA93CD1FDCA460399C4B48902B51B88"
+            "Icon" = "8:_1EC5EAEDA13A4288B8E5B849F48619A8"
+            "Feature" = "8:"
+            }
         }
         "UserInterface"
         {

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -44,5 +44,4 @@ overhaul. (Supersedes the internal 3.5.5 work, which is included below.)
 - **Eliminated measurement flashing** — the data grids, group-box frames, and
   window no longer flicker during or after a measurement sweep.
 - **Installer fixes** — now creates a Start Menu shortcut (so HCFR shows up in
-  Start menu search), plus themed icons, splash, English UI, and required
-  runtime files (incl. `RB8PGenerator.dll`) are now packaged correctly.
+  Start menu search), plus themed icons, splash, and English installer UI.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -43,5 +43,6 @@ overhaul. (Supersedes the internal 3.5.5 work, which is included below.)
 ## Performance & Stability
 - **Eliminated measurement flashing** — the data grids, group-box frames, and
   window no longer flicker during or after a measurement sweep.
-- **Installer fixes** — themed icons, splash, English UI, and required runtime
-  files (incl. `RB8PGenerator.dll`) are now packaged correctly.
+- **Installer fixes** — now creates a Start Menu shortcut (so HCFR shows up in
+  Start menu search), plus themed icons, splash, English UI, and required
+  runtime files (incl. `RB8PGenerator.dll`) are now packaged correctly.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -43,6 +43,5 @@ overhaul. (Supersedes the internal 3.5.5 work, which is included below.)
 ## Performance & Stability
 - **Eliminated measurement flashing** — the data grids, group-box frames, and
   window no longer flicker during or after a measurement sweep.
-- **Smoother window resizing** when chart views are open.
 - **Installer fixes** — themed icons, splash, English UI, and required runtime
   files (incl. `RB8PGenerator.dll`) are now packaged correctly.


### PR DESCRIPTION
Two release-blocking fixes for 4.0.0.0:

**1. Drop unverified "smoother window resizing" claim** from `RELEASE_NOTES.md` — that resize-lag work was reverted/unresolved, so the line claimed a fix users may not experience.

**2. Installer now creates a Start Menu shortcut.** The setup project only created a *Desktop* shortcut (`Folder = DesktopFolder`), so the app never showed up in Start Menu search. Added a second shortcut under `ProgramMenuFolder` (Programs root) in both `ColorHCFR_VS2019.vdproj` and `ColorHCFR_2019.vdproj`, keeping the existing desktop icon. Verified in the built MSI's Shortcut table (entries now target both `ProgramMenuFolder` and `DesktopFolder`). Release-notes installer bullet updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)