### PR TITLE
Add .chc backward-incompatibility warning to release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 # ColorHCFR 4.0.0.0 — Release Notes
 
+> ⚠️ **Not backward compatible.** Measurement files (`.chc`) saved with 4.0 use an updated format and **cannot be opened in earlier HCFR versions**. 4.0 still opens files from older versions, but not the other way around — **keep backups of important measurements before upgrading.**
+
 > ⚠️ **Developed with AI assistance.** This release was built with substantial help from Claude (Anthropic's AI). It has been tested on real hardware, but the development approach is new — please keep backups of your measurement data, report any issues you run into, and treat this as an early build.
 
 A major release rolling up instrument support, color-science, and a full UI/UX overhaul. (Supersedes the internal 3.5.5 work, which is included below.)


### PR DESCRIPTION
Adds a prominent warning that measurement files (`.chc`) saved with 4.0 use the updated serialization (v18) and **cannot be opened in earlier HCFR versions** (older builds throw on a higher version number). 4.0 still reads older files. Already applied to the live release body; this keeps the repo `RELEASE_NOTES.md` in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)