### PR TITLE
PGenerator bug fixes, 4.0.1.0 release prep + installer cleanup

### DIFF
--- a/CHCFR21_DEUTSCH.rc
+++ b/CHCFR21_DEUTSCH.rc
@@ -348,7 +348,7 @@ CAPTION "Über HCFR Colorimeter"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
     CONTROL         IDB_LOGO,IDC_STATIC,"Static",SS_BITMAP,7,7,172,62
-    LTEXT           "Version 4.0.0.0",IDC_STATIC_VERSION,7,76,119,8,SS_NOPREFIX
+    LTEXT           "Version 4.0.1.0",IDC_STATIC_VERSION,7,76,119,8,SS_NOPREFIX
     LTEXT           "Copyright (C) 2012-2026 Hcfr Project\nCopyright (C) 2005-2008 Association Homecinema Francophone",IDC_STATIC2,7,88,168,29
     LTEXT           "hcfr.sourceforge.net",IDC_HOMECINEMA_HYPERLINK,7,120,80,8
     LTEXT           "IDC_PLACEHOLDER",IDC_PLACEHOLDER,4,136,177,117
@@ -2593,8 +2593,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 4,0,0,0
- PRODUCTVERSION 4,0,0,0
+ FILEVERSION 4,0,1,0
+ PRODUCTVERSION 4,0,1,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -2612,12 +2612,12 @@ BEGIN
             VALUE "Comments", "Under GPL Licence"
             VALUE "CompanyName", "Association Homecinema Francophone"
             VALUE "FileDescription", "HCFR Colorimeter resources"
-            VALUE "FileVersion", "4.0.0.0"
+            VALUE "FileVersion", "4.0.1.0"
             VALUE "InternalName", "CHCFR21_DEUTSCH"
             VALUE "LegalCopyright", "Copyright (C) 2005-2026"
             VALUE "OriginalFilename", "CHCFR21_DEUTSCH.DLL"
             VALUE "ProductName", "HCFR Colorimeter German language"
-            VALUE "ProductVersion", "4.0.0.0"
+            VALUE "ProductVersion", "4.0.1.0"
         END
     END
     BLOCK "VarFileInfo"
@@ -2785,7 +2785,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDR_MAINFRAME           "HCFR Colorimeter - 4.0.0.0"
+    IDR_MAINFRAME           "HCFR Colorimeter - 4.0.1.0"
     IDR_MESURETYPE          "\nFarbmessungen\nFarbmessungen\nColorHCFR Datei (*.chc)\n.chc\nCOLORHCFR\nHCFR Farbmessungen"
 END
 

--- a/CHCFR21_DEUTSCH.rc
+++ b/CHCFR21_DEUTSCH.rc
@@ -2975,7 +2975,7 @@ BEGIN
     IDS_GEN_BYPASS_VLUT  "Video-LUT umgehen"
     IDS_GEN_LOG_TRIPLETS  "RGB-Tripel anzeigen"
     IDS_GEN_USER_PATTERN  "PGenerator-Benutzermuster verwenden"
-    IDS_GEN_RGB_RANGE  "RGB-Bereich"
+    IDS_GEN_RGB_RANGE  "Musterbereich"
     IDS_GEN_NO_CAST  "Kein Google-Cast-Gerät gefunden"
     IDS_GEN_GRP_PATTERN  "Muster"
     IDS_GEN_GRP_BLANKING  "Dunkelschaltung"

--- a/CHCFR21_ENGLISH.rc
+++ b/CHCFR21_ENGLISH.rc
@@ -337,7 +337,7 @@ CAPTION "About HCFR Colorimeter"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
     CONTROL         IDB_LOGO,IDC_STATIC,"Static",SS_BITMAP,7,7,172,62
-    LTEXT           "Version 4.0.0.0",IDC_STATIC_VERSION,7,76,119,8,SS_NOPREFIX
+    LTEXT           "Version 4.0.1.0",IDC_STATIC_VERSION,7,76,119,8,SS_NOPREFIX
     LTEXT           "Copyright (C) 2012-2026 Hcfr Project\nCopyright (C) 2005-2008 Association Homecinema Francophone",IDC_STATIC2,7,88,168,24
     LTEXT           "hcfr.sourceforge.net",IDC_HOMECINEMA_HYPERLINK,7,119,80,8
     LTEXT           "IDC_PLACEHOLDER",IDC_PLACEHOLDER,4,136,177,117
@@ -2727,8 +2727,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 4.0.0.0
- PRODUCTVERSION 4.0.0.0
+ FILEVERSION 4.0.1.0
+ PRODUCTVERSION 4.0.1.0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -2746,12 +2746,12 @@ BEGIN
             VALUE "Comments", "Under GPL Licence"
             VALUE "CompanyName", "Association Homecinema Francophone"
             VALUE "FileDescription", "HCFR Colorimeter resources"
-            VALUE "FileVersion", "4.0.0.0"
+            VALUE "FileVersion", "4.0.1.0"
             VALUE "InternalName", "CHCFR21_ENGLISH"
             VALUE "LegalCopyright", "Copyright (C) 2005-2026"
             VALUE "OriginalFilename", "CHCFR21_ENGLISH.DLL"
             VALUE "ProductName", "HCFR Colorimeter English langage"
-            VALUE "ProductVersion", "4.0.0.0"
+            VALUE "ProductVersion", "4.0.1.0"
         END
     END
     BLOCK "VarFileInfo"
@@ -2794,7 +2794,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDR_MAINFRAME           "HCFR Colorimeter - 4.0.0.0"
+    IDR_MAINFRAME           "HCFR Colorimeter - 4.0.1.0"
     IDR_MESURETYPE          "\nColor Measures\nColor_Measures\nColorHCFR File (*.chc)\n.chc\nCOLORHCFR\nHCFR Color Measures"
 END
 

--- a/CHCFR21_ENGLISH.rc
+++ b/CHCFR21_ENGLISH.rc
@@ -2984,7 +2984,7 @@ BEGIN
     IDS_GEN_BYPASS_VLUT  "Bypass video LUT"
     IDS_GEN_LOG_TRIPLETS  "Show RGB triplets"
     IDS_GEN_USER_PATTERN  "Use PGenerator user pattern"
-    IDS_GEN_RGB_RANGE  "RGB range"
+    IDS_GEN_RGB_RANGE  "Pattern range"
     IDS_GEN_NO_CAST  "No Google Cast device found"
     IDS_GEN_GRP_PATTERN  "Pattern"
     IDS_GEN_GRP_BLANKING  "Blanking"

--- a/CHCFR21_ESPANOL.rc
+++ b/CHCFR21_ESPANOL.rc
@@ -417,7 +417,7 @@ CAPTION "About HCFR Colorimeter"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
     CONTROL         223,IDC_STATIC,"Static",SS_BITMAP,7,7,172,62
-    LTEXT           "Version 4.0.0.0",IDC_STATIC_VERSION,7,76,119,8,SS_NOPREFIX
+    LTEXT           "Version 4.0.1.0",IDC_STATIC_VERSION,7,76,119,8,SS_NOPREFIX
     LTEXT           "Copyright (C) 2012-2026 Hcfr Project\nCopyright (C) 2005-2008 Association Homecinema Francophone",IDC_STATIC2,7,88,168,24
     LTEXT           "hcfr.sourceforge.net",IDC_HOMECINEMA_HYPERLINK,7,119,80,8
     LTEXT           "IDC_PLACEHOLDER",IDC_PLACEHOLDER,4,136,177,117
@@ -2854,8 +2854,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 4.0.0.0
- PRODUCTVERSION 4.0.0.0
+ FILEVERSION 4.0.1.0
+ PRODUCTVERSION 4.0.1.0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -2873,12 +2873,12 @@ BEGIN
             VALUE "Comments", "Under GPL Licence"
             VALUE "CompanyName", "Association Homecinema Francophone"
             VALUE "FileDescription", "HCFR Colorimeter resources"
-            VALUE "FileVersion", "4.0.0.0"
+            VALUE "FileVersion", "4.0.1.0"
             VALUE "InternalName", "CHCFR21_ENGLISH"
             VALUE "LegalCopyright", "Copyright (C) 2005-2026"
             VALUE "OriginalFilename", "CHCFR21_ENGLISH.DLL"
             VALUE "ProductName", "HCFR Colorimeter English langage"
-            VALUE "ProductVersion", "4.0.0.0"
+            VALUE "ProductVersion", "4.0.1.0"
         END
     END
     BLOCK "VarFileInfo"
@@ -2916,7 +2916,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDR_MAINFRAME           "HCFR Colorimeter - 4.0.0.0"
+    IDR_MAINFRAME           "HCFR Colorimeter - 4.0.1.0"
     IDR_MESURETYPE          "\nColor Measures\nColor_Measures\nColorHCFR File (*.chc)\n.chc\nCOLORHCFR\nHCFR Color Measures"
 END
 

--- a/CHCFR21_ESPANOL.rc
+++ b/CHCFR21_ESPANOL.rc
@@ -3106,7 +3106,7 @@ BEGIN
     IDS_GEN_BYPASS_VLUT  "Omitir LUT de vídeo"
     IDS_GEN_LOG_TRIPLETS  "Mostrar tripletas RGB"
     IDS_GEN_USER_PATTERN  "Usar patrón de usuario PGenerator"
-    IDS_GEN_RGB_RANGE  "Rango RGB"
+    IDS_GEN_RGB_RANGE  "Rango de patrón"
     IDS_GEN_NO_CAST  "No se encontró ningún dispositivo Google Cast"
     IDS_GEN_GRP_PATTERN  "Patrón"
     IDS_GEN_GRP_BLANKING  "Blanking"

--- a/CHCFR21_FRANCAIS.rc
+++ b/CHCFR21_FRANCAIS.rc
@@ -3198,7 +3198,7 @@ BEGIN
     IDS_GEN_BYPASS_VLUT  "Contourner la LUT vidéo"
     IDS_GEN_LOG_TRIPLETS  "Afficher les triplets RGB"
     IDS_GEN_USER_PATTERN  "Mire utilisateur PGenerator"
-    IDS_GEN_RGB_RANGE  "Plage RGB"
+    IDS_GEN_RGB_RANGE  "Plage de mire"
     IDS_GEN_NO_CAST  "Aucun périphérique Google Cast trouvé"
     IDS_GEN_GRP_PATTERN  "Mire"
     IDS_GEN_GRP_BLANKING  "Blanking"

--- a/CHCFR21_FRANCAIS.rc
+++ b/CHCFR21_FRANCAIS.rc
@@ -755,7 +755,7 @@ CAPTION "A propos du Colorimètre HCFR"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
     CONTROL         IDB_LOGO,IDC_STATIC,"Static",SS_BITMAP,7,7,172,62
-    LTEXT           "Version 4.0.0.0",IDC_STATIC_VERSION,7,76,119,8,SS_NOPREFIX
+    LTEXT           "Version 4.0.1.0",IDC_STATIC_VERSION,7,76,119,8,SS_NOPREFIX
     LTEXT           "Copyright (C) 2012-2026 Hcfr Project\nCopyright (C) 2005-2008 Association Homecinema Francophone",IDC_STATIC2,7,88,168,28
     LTEXT           "hcfr.sourceforge.net",IDC_HOMECINEMA_HYPERLINK,7,119,80,8
     LTEXT           "IDC_PLACEHOLDER",IDC_PLACEHOLDER,4,136,177,117
@@ -2891,8 +2891,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 4.0.0.0
- PRODUCTVERSION 4.0.0.0
+ FILEVERSION 4.0.1.0
+ PRODUCTVERSION 4.0.1.0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -2910,12 +2910,12 @@ BEGIN
             VALUE "Comments", "Under GPL Licence"
             VALUE "CompanyName", "Association Homecinema Francophone"
             VALUE "FileDescription", "Resources Colorimètre HCFR"
-            VALUE "FileVersion", "4.0.0.0"
+            VALUE "FileVersion", "4.0.1.0"
             VALUE "InternalName", "CHCFR21_FRANCAIS"
             VALUE "LegalCopyright", "Copyright (C) 2005-2026"
             VALUE "OriginalFilename", "CHCFR21_FRANCAIS.DLL"
             VALUE "ProductName", "Colorimètre HCFR langage Français"
-            VALUE "ProductVersion", "4.0.0.0"
+            VALUE "ProductVersion", "4.0.1.0"
         END
     END
     BLOCK "VarFileInfo"
@@ -3013,7 +3013,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDR_MAINFRAME           "Colorimètre HCFR - 4.0.0.0"
+    IDR_MAINFRAME           "Colorimètre HCFR - 4.0.1.0"
     IDR_MESURETYPE          "\nRelevé\nRelevé\nFichiers ColorHCFR (*.chc)\n.chc\nCOLORHCFR\nRelevé de couleurs HCFR"
 END
 

--- a/CHCFR21_ITALIAN.rc
+++ b/CHCFR21_ITALIAN.rc
@@ -3184,7 +3184,7 @@ BEGIN
     IDS_GEN_BYPASS_VLUT  "Ignora LUT video"
     IDS_GEN_LOG_TRIPLETS  "Mostra terne RGB"
     IDS_GEN_USER_PATTERN  "Usa pattern utente PGenerator"
-    IDS_GEN_RGB_RANGE  "Gamma RGB"
+    IDS_GEN_RGB_RANGE  "Gamma pattern"
     IDS_GEN_NO_CAST  "Nessun dispositivo Google Cast trovato"
     IDS_GEN_GRP_PATTERN  "Pattern"
     IDS_GEN_GRP_BLANKING  "Blanking"

--- a/CHCFR21_ITALIAN.rc
+++ b/CHCFR21_ITALIAN.rc
@@ -340,7 +340,7 @@ CAPTION "Info su Colorimetro HCFR"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
     CONTROL         IDB_LOGO,IDC_STATIC,"Static",SS_BITMAP,7,7,172,62
-    LTEXT           "Version 4.0.0.0",IDC_STATIC_VERSION,7,76,119,8,SS_NOPREFIX
+    LTEXT           "Version 4.0.1.0",IDC_STATIC_VERSION,7,76,119,8,SS_NOPREFIX
     LTEXT           "Copyright (C) 2012-2026 Hcfr Project\nCopyright (C) 2005-2008 Association Homecinema Francophone",IDC_STATIC2,7,88,168,24
     LTEXT           "hcfr.sourceforge.net",IDC_HOMECINEMA_HYPERLINK,7,119,80,8
     LTEXT           "IDC_PLACEHOLDER",IDC_PLACEHOLDER,4,136,177,117
@@ -2872,8 +2872,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 4,0,0,0
- PRODUCTVERSION 4,0,0,0
+ FILEVERSION 4,0,1,0
+ PRODUCTVERSION 4,0,1,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -2891,12 +2891,12 @@ BEGIN
             VALUE "Comments", "Under GPL Licence"
             VALUE "CompanyName", "Association Homecinema Francophone"
             VALUE "FileDescription", "HCFR Colorimeter resources"
-            VALUE "FileVersion", "4.0.0.0"
+            VALUE "FileVersion", "4.0.1.0"
             VALUE "InternalName", "CHCFR21_ENGLISH"
             VALUE "LegalCopyright", "Copyright (C) 2005-2026"
             VALUE "OriginalFilename", "CHCFR21_ENGLISH.DLL"
             VALUE "ProductName", "HCFR Colorimeter English langage"
-            VALUE "ProductVersion", "4.0.0.0"
+            VALUE "ProductVersion", "4.0.1.0"
         END
     END
     BLOCK "VarFileInfo"
@@ -2994,7 +2994,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDR_MAINFRAME           "HCFR Colorimeter - 4.0.0.0"
+    IDR_MAINFRAME           "HCFR Colorimeter - 4.0.1.0"
     IDR_MESURETYPE          "\nColor Measures\nColor_Measures\nColorHCFR File (*.chc)\n.chc\nCOLORHCFR\nHCFR Color Measures"
 END
 

--- a/CHCFR21_PATTERNS.rc
+++ b/CHCFR21_PATTERNS.rc
@@ -64,8 +64,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 4.0.0.0
- PRODUCTVERSION 4.0.0.0
+ FILEVERSION 4.0.1.0
+ PRODUCTVERSION 4.0.1.0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -81,12 +81,12 @@ BEGIN
         BLOCK "040c04b0"
         BEGIN
             VALUE "FileDescription", "CHCFR21_PATTERNS DLL"
-            VALUE "FileVersion", "4.0.0.0"
+            VALUE "FileVersion", "4.0.1.0"
             VALUE "InternalName", "CHCFR21_PATTERNS"
             VALUE "LegalCopyright", "Copyright (C) 2007-2026"
             VALUE "OriginalFilename", "CHCFR21_PATTERNS.DLL"
             VALUE "ProductName", "Bibliothèque de liaison dynamique CHCFR21_PATTERNS"
-            VALUE "ProductVersion", "4.0.0.0"
+            VALUE "ProductVersion", "4.0.1.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/ColorHCFR.rc
+++ b/ColorHCFR.rc
@@ -1,4 +1,4 @@
-// 4.0.0.0 Visual C++ generated resource script.
+// 4.0.1.0 Visual C++ generated resource script.
 //
 #include "resource.h"
 
@@ -70,8 +70,8 @@ IDR_APPICON             ICON                    "res\\icon1.ico"
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 4.0.0.0
- PRODUCTVERSION 4.0.0.0
+ FILEVERSION 4.0.1.0
+ PRODUCTVERSION 4.0.1.0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -88,12 +88,12 @@ BEGIN
         BEGIN
             VALUE "Comments", "Under GPL Licence"
             VALUE "FileDescription", "HCFR"
-            VALUE "FileVersion", "4.0.0.0"
+            VALUE "FileVersion", "4.0.1.0"
             VALUE "InternalName", "ColorHCFR"
             VALUE "LegalCopyright", "Copyright (c) 2005-2026"
             VALUE "OriginalFilename", "ColorHCFR.EXE"
             VALUE "ProductName", "HCFR"
-            VALUE "ProductVersion", "4.0.0.0"
+            VALUE "ProductVersion", "4.0.1.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/ColorHCFR_2019.vdproj
+++ b/ColorHCFR_2019.vdproj
@@ -6170,7 +6170,7 @@
             }
             "{3C67513D-01DD-4637-8A68-80971EB9504F}:_CBA93CD1FDCA460399C4B48902B51B88"
             {
-            "DefaultLocation" = "8:[ProgramFilesFolder]\\HCFR Calibration\\[ProductName]"
+            "DefaultLocation" = "8:[ProgramFilesFolder]\\[ProductName]"
             "Name" = "8:#1925"
             "AlwaysCreate" = "11:FALSE"
             "Condition" = "8:"
@@ -6404,10 +6404,10 @@
         "Product"
         {
         "Name" = "8:Microsoft Visual Studio"
-        "ProductName" = "8:ColorHCFR"
-        "ProductCode" = "8:{4B49A0A8-E86F-455B-A97D-CA1883B7E529}"
+        "ProductName" = "8:HCFR"
+        "ProductCode" = "8:{ECDD81B8-ED26-4B4A-9B16-B3E9E08FCD0F}"
         "PackageCode" = "8:{363576D1-5964-4B96-92A2-9C82C4229FC9}"
-        "UpgradeCode" = "8:{DB7FD0E2-11D3-4C2C-8B91-90B3306C7084}"
+        "UpgradeCode" = "8:{BF340A8C-5760-4352-B44E-37B4C150A159}"
         "AspNetVersion" = "8:2.0.50727.0"
         "RestartWWWService" = "11:FALSE"
         "RemovePreviousVersions" = "11:TRUE"

--- a/ColorHCFR_2019.vdproj
+++ b/ColorHCFR_2019.vdproj
@@ -6413,7 +6413,7 @@
         "RemovePreviousVersions" = "11:TRUE"
         "DetectNewerInstalledVersion" = "11:FALSE"
         "InstallAllUsers" = "11:TRUE"
-        "ProductVersion" = "8:4.0.0"
+        "ProductVersion" = "8:4.0.1"
         "Manufacturer" = "8:ColorHCFR"
         "ARPHELPTELEPHONE" = "8:"
         "ARPHELPLINK" = "8:https://www.avsforum.com/forum/139-display-calibration/1393853-hcfr-open-source-projector-display-calibration-software.html"

--- a/ColorHCFR_2019.vdproj
+++ b/ColorHCFR_2019.vdproj
@@ -5845,7 +5845,7 @@
             "SourcePath" = "8:..\\hcfr-code-bberu\\Tools\\pi\\RB8PGenerator.dll"
             "TargetName" = "8:RB8PGenerator.dll"
             "Tag" = "8:"
-            "Folder" = "8:_6BDD350839BC4C12B6956CC3487B571E"
+            "Folder" = "8:_CBA93CD1FDCA460399C4B48902B51B88"
             "Condition" = "8:"
             "Transitive" = "11:FALSE"
             "Vital" = "11:TRUE"

--- a/ColorHCFR_VS2019.vdproj
+++ b/ColorHCFR_VS2019.vdproj
@@ -5481,7 +5481,7 @@
             "SourcePath" = "8:Tools\\pi\\RB8PGenerator.dll"
             "TargetName" = "8:RB8PGenerator.dll"
             "Tag" = "8:"
-            "Folder" = "8:_6BDD350839BC4C12B6956CC3487B571E"
+            "Folder" = "8:_CBA93CD1FDCA460399C4B48902B51B88"
             "Condition" = "8:"
             "Transitive" = "11:FALSE"
             "Vital" = "11:TRUE"

--- a/ColorHCFR_VS2019.vdproj
+++ b/ColorHCFR_VS2019.vdproj
@@ -6169,7 +6169,7 @@
             }
             "{3C67513D-01DD-4637-8A68-80971EB9504F}:_CBA93CD1FDCA460399C4B48902B51B88"
             {
-            "DefaultLocation" = "8:[ProgramFilesFolder]\\HCFR Calibration\\[ProductName]"
+            "DefaultLocation" = "8:[ProgramFilesFolder]\\[ProductName]"
             "Name" = "8:#1925"
             "AlwaysCreate" = "11:FALSE"
             "Condition" = "8:"
@@ -6393,12 +6393,12 @@
         {
         "Name" = "8:Microsoft Visual Studio"
         "ProductName" = "8:HCFR"
-        "ProductCode" = "8:{4B49A0A8-E86F-455B-A97D-CA1883B7E529}"
+        "ProductCode" = "8:{4BF88344-B16A-424E-8FBC-732E6633E50B}"
         "PackageCode" = "8:{7A8A0441-D466-4276-9010-22E9E3FE273D}"
-        "UpgradeCode" = "8:{DB7FD0E2-11D3-4C2C-8B91-90B3306C7084}"
+        "UpgradeCode" = "8:{BF340A8C-5760-4352-B44E-37B4C150A159}"
         "AspNetVersion" = "8:2.0.50727.0"
         "RestartWWWService" = "11:FALSE"
-        "RemovePreviousVersions" = "11:FALSE"
+        "RemovePreviousVersions" = "11:TRUE"
         "DetectNewerInstalledVersion" = "11:FALSE"
         "InstallAllUsers" = "11:TRUE"
         "ProductVersion" = "8:4.0.1"

--- a/ColorHCFR_VS2019.vdproj
+++ b/ColorHCFR_VS2019.vdproj
@@ -6401,7 +6401,7 @@
         "RemovePreviousVersions" = "11:FALSE"
         "DetectNewerInstalledVersion" = "11:FALSE"
         "InstallAllUsers" = "11:TRUE"
-        "ProductVersion" = "8:4.0.0"
+        "ProductVersion" = "8:4.0.1"
         "Manufacturer" = "8:ColorHCFR"
         "ARPHELPTELEPHONE" = "8:"
         "ARPHELPLINK" = "8:https://www.avsforum.com/forum/139-display-calibration/1393853-hcfr-open-source-projector-display-calibration-software.html"

--- a/Generators/FullScreenWindow.cpp
+++ b/Generators/FullScreenWindow.cpp
@@ -63,6 +63,7 @@ CFullScreenWindow::CFullScreenWindow(BOOL bTestOverlay)
 	
 	m_nDisplayMode = GetConfig()->GetProfileInt("GDIGenerator","DisplayMode",DISPLAY_DEFAULT_MODE);
 	m_bDisableCursorHiding = FALSE;
+	m_bBlankScreen = FALSE;
 	m_b16_235 = GetConfig()->GetProfileInt("GDIGenerator","RGB_16_235",0);
 	m_busePic = GetConfig()->GetProfileInt("GDIGenerator","USEPIC",0);
 	m_bLinear = GetConfig()->GetProfileInt("GDIGenerator","LOADLINEAR",1);
@@ -1225,6 +1226,14 @@ void video_scale (CxImage *inImage)
 	//make sure we are foreground
 	::SetForegroundWindow(this->hWnd);
 	this->SetFocus();
+
+	// Screen blanking: plain black fill, no pattern rect / RGB triplets / ABL / settling.
+	if (m_bBlankScreen)
+	{
+		CBrush blackBrush(RGB(0,0,0));
+		dc.FillRect(&rect, &blackBrush);
+		return;
+	}
 	// Pattern Display Common Vars
 		CBrush		br0;
 		CRect		aRect;

--- a/Generators/FullScreenWindow.h
+++ b/Generators/FullScreenWindow.h
@@ -67,6 +67,7 @@ public:
 	UINT					m_nDisplayMode;
 	INT						m_ansiCcast;
 	BOOL					m_bDisableCursorHiding;
+	BOOL					m_bBlankScreen;		// when TRUE, OnPaint just fills the window solid black (screen blanking)
 	BOOL					m_bIRE;
 	BOOL					m_b16_235;
 	BOOL					m_busePic;

--- a/Generators/GDIGenerator.cpp
+++ b/Generators/GDIGenerator.cpp
@@ -599,7 +599,9 @@ BOOL CGDIGenerator::Init(UINT nbMeasure, bool isSpecial)
 	
 	bOnOtherMonitor = IsOnOtherMonitor ();
 
-	if ( ! bOnOtherMonitor )
+	BOOL bExternalSurface = ( m_nDisplayMode == DISPLAY_rPI || m_nDisplayMode == DISPLAY_ccast );
+
+	if ( ! bOnOtherMonitor && ! bExternalSurface )
 	{
 		// Deactivate blanking when generator window is on the same monitor
 		m_bBlankingCanceled = m_doScreenBlanking;

--- a/Generators/Generator.cpp
+++ b/Generators/Generator.cpp
@@ -64,6 +64,7 @@ CGenerator::CGenerator()
 
 	SetName("Not defined");  // Needs to be set for real generators
 	m_blankingWindow.m_bDisableCursorHiding = TRUE;
+	m_blankingWindow.m_bBlankScreen = TRUE;
 	ccwin = dw;
 }
 


### PR DESCRIPTION
PGenerator (Raspberry Pi) field-report fixes, the version bump for a 4.0.1.0 bug-fix release, and installer cleanup (install folder + upgrade behavior).

## Bug fixes
- **PGenerator install (DLL location):** `RB8PGenerator.dll` was installed to `{app}\Tools\` by both vdproj, but the app does `LoadLibrary("RB8PGenerator.dll")` which searches the exe dir (app root) → DLL effectively missing. Repointed its `File` entry's `Folder` to `TARGETDIR`.
- **Screen blanking with external-surface generators:** "Blank screen during measure" did nothing with the Pi/Chromecast generators because `CGDIGenerator::Init` force-disabled blanking on a single local monitor. External-surface outputs (`DISPLAY_rPI`, `DISPLAY_ccast`) never put the pattern on a local window, so the cancellation was wrong. Also made blanking draw a **plain black fill** (new `CFullScreenWindow::m_bBlankScreen`) instead of re-reading the registry and drawing the centered patch/triplets/ABL rect.
- **"RGB range" → "Pattern range":** `m_b16_235` sets the code values written into the test patches, not the Pi's HDMI signal range; the old "RGB range" label under "Signal" was misleading. Renamed `IDS_GEN_RGB_RANGE` in all 5 languages.

## Release prep
- **Version bump 4.0.0.0 → 4.0.1.0** across all 7 `.rc` files + MSI `ProductVersion` (3-part `4.0.1`) in both vdproj. (PATCH bump — bug fixes only. The 3-part MSI version is what Windows Installer uses for upgrade detection, so `4.0.1.0` not `4.0.0.1`.)

## Installer cleanup
- **Install folder simplified:** dropped the redundant `HCFR Calibration\` wrapper from `DefaultLocation` → installs to `Program Files (x86)\HCFR` instead of `…\HCFR Calibration\HCFR`. Realigned the `_2019` vdproj `ProductName` (`ColorHCFR` → `HCFR`) so both installers match.
- **Clean 4.x upgrades:** gave the 4.x line its own `UpgradeCode` + `RemovePreviousVersions=TRUE` + a fresh per-package `ProductCode`, so 4.0.1+ upgrade each other cleanly while leaving any installed **3.x untouched** (different UpgradeCode → side-by-side). An already-installed **4.0.0** used the old UpgradeCode and must be uninstalled once by hand; 4.0.1 onward upgrade automatically.

Builds clean Debug|Win32 (exe + all 5 satellite DLLs). MSI build/install behavior to be verified on a real machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)