### PR TITLE
Grayscale measures table: scrollbar, two-finger scroll, auto-fit, and measuring-column indicator

### DIFF
--- a/Measure.cpp
+++ b/Measure.cpp
@@ -5506,6 +5506,7 @@ void CMeasure::UpdateTstWnd (CDataSetDoc *pDoc, int i )
 		((CMainView*)pView)->minCol = i+1;
 		((CMainView*)pView)->last_minCol = i;
 		m_currentIndex = i+1;
+		((CMainView*)pView)->HighlightMeasuringColumn(i+1);
 		displaymode = ((CMainView*)pView)->m_displayMode;
 	}
 }

--- a/Tools/GridCtrl/GridCtrl.cpp
+++ b/Tools/GridCtrl/GridCtrl.cpp
@@ -556,6 +556,7 @@ BEGIN_MESSAGE_MAP(CGridCtrl, CWnd)
 #endif
 #if !defined(_WIN32_WCE) && (_MFC_VER >= 0x0421)
     ON_WM_MOUSEWHEEL()
+    ON_WM_MOUSEHWHEEL()
 #endif
     ON_MESSAGE(WM_SETFONT, OnSetFont)
     ON_MESSAGE(WM_GETFONT, OnGetFont)
@@ -5475,6 +5476,17 @@ BOOL CGridCtrl::InvalidateCellRect(const CCellRange& cellRange)
 #if !defined(_WIN32_WCE) && (_MFC_VER >= 0x0421)
 BOOL CGridCtrl::OnMouseWheel(UINT nFlags, short zDelta, CPoint pt)
 {
+    // Route the wheel to whichever axis can actually scroll. Some grids (e.g. the
+    // grayscale grid) fit vertically but overflow horizontally, so a plain wheel
+    // should scroll horizontally when there's nothing to scroll vertically.
+    // Holding Shift always forces horizontal scrolling.
+    BOOL bHorz = (nFlags & MK_SHIFT) || (m_nVScrollMax <= 0 && m_nHScrollMax > 0);
+    UINT nScrollMsg = bHorz ? WM_HSCROLL : WM_VSCROLL;
+    int  nLineUp    = bHorz ? SB_LINELEFT : SB_LINEUP;
+    int  nLineDown  = bHorz ? SB_LINERIGHT : SB_LINEDOWN;
+    int  nPageUp    = bHorz ? SB_PAGELEFT : SB_PAGEUP;
+    int  nPageDown  = bHorz ? SB_PAGERIGHT : SB_PAGEDOWN;
+
     // A m_nRowsPerWheelNotch value less than 0 indicates that the mouse
     // wheel scrolls whole pages, not just lines.
     if (m_nRowsPerWheelNotch == -1)
@@ -5485,14 +5497,14 @@ BOOL CGridCtrl::OnMouseWheel(UINT nFlags, short zDelta, CPoint pt)
 		{
             for (int i = 0; i < nPagesScrolled; i++)
 			{
-                PostMessage(WM_VSCROLL, SB_PAGEUP, 0);
+                PostMessage(nScrollMsg, nPageUp, 0);
 			}
 		}
         else
 		{
             for (int i = 0; i > nPagesScrolled; i--)
 			{
-                PostMessage(WM_VSCROLL, SB_PAGEDOWN, 0);
+                PostMessage(nScrollMsg, nPageDown, 0);
 			}
 		}
     }
@@ -5504,19 +5516,40 @@ BOOL CGridCtrl::OnMouseWheel(UINT nFlags, short zDelta, CPoint pt)
 		{
             for (int i = 0; i < nRowsScrolled; i++)
 			{
-                PostMessage(WM_VSCROLL, SB_LINEUP, 0);
+                PostMessage(nScrollMsg, nLineUp, 0);
 			}
 		}
         else
 		{
             for (int i = 0; i > nRowsScrolled; i--)
 			{
-                PostMessage(WM_VSCROLL, SB_LINEDOWN, 0);
+                PostMessage(nScrollMsg, nLineDown, 0);
 			}
 		}
     }
 
     return CWnd::OnMouseWheel(nFlags, zDelta, pt);
+}
+
+// Horizontal wheel / two-finger horizontal trackpad swipe.
+void CGridCtrl::OnMouseHWheel(UINT nFlags, short zDelta, CPoint pt)
+{
+    int nNotch = (m_nRowsPerWheelNotch > 0) ? m_nRowsPerWheelNotch : 3;
+    int nLines = nNotch * zDelta / 120;
+
+    // For a horizontal wheel, a positive zDelta means scroll right.
+    if (nLines > 0)
+    {
+        for (int i = 0; i < nLines; i++)
+            PostMessage(WM_HSCROLL, SB_LINERIGHT, 0);
+    }
+    else
+    {
+        for (int i = 0; i > nLines; i--)
+            PostMessage(WM_HSCROLL, SB_LINELEFT, 0);
+    }
+
+    CWnd::OnMouseHWheel(nFlags, zDelta, pt);
 }
 #endif // !defined(_WIN32_WCE) && (_MFC_VER >= 0x0421)
 

--- a/Tools/GridCtrl/GridCtrl.h
+++ b/Tools/GridCtrl/GridCtrl.h
@@ -773,6 +773,7 @@ protected: //GG
 #endif
 #if !defined(_WIN32_WCE) && (_MFC_VER >= 0x0421)
     afx_msg BOOL OnMouseWheel(UINT nFlags, short zDelta, CPoint pt);
+    afx_msg void OnMouseHWheel(UINT nFlags, short zDelta, CPoint pt);
 #endif
     afx_msg LRESULT OnSetFont(WPARAM hFont, LPARAM lParam);
     afx_msg LRESULT OnGetFont(WPARAM hFont, LPARAM lParam);

--- a/Views/MainView.cpp
+++ b/Views/MainView.cpp
@@ -862,6 +862,32 @@ void CMainView::AddColorToGrid(const ColorTriplet& color, GV_ITEM& Item, const c
     m_pSelectedColorGrid->SetItem(&Item);
 }
 
+// Highlight the column currently being measured by selecting it in the grayscale
+// grid. Called from the measure loop (UpdateTstWnd, right before each blocking
+// reading) and from the continuous/background-measure update, so the user can see
+// which point is active. bForceRepaint=TRUE + UpdateWindow() paint it immediately,
+// before the UI thread blocks in the sensor read. Skipped while the grid is in
+// edit mode so we don't fight the user's manual edits.
+void CMainView::HighlightMeasuringColumn(int gridCol)
+{
+	if ( !m_pGrayScaleGrid || !::IsWindow(m_pGrayScaleGrid->GetSafeHwnd()) )
+		return;
+	if ( gridCol < 1 || gridCol >= m_pGrayScaleGrid->GetColumnCount() )
+		return;
+	if ( IsDlgButtonChecked(IDC_EDITGRID_CHECK) == BST_CHECKED )
+		return;
+
+	int maxRow = m_pGrayScaleGrid->GetRowCount() - 1;	// select the x/y/Y data rows of the column
+	if ( maxRow > 3 )
+		maxRow = 3;
+	if ( maxRow < 1 )
+		return;
+
+	m_pGrayScaleGrid->EnsureVisible(1, gridCol);
+	m_pGrayScaleGrid->SetSelectedRange(1, gridCol, maxRow, gridCol, TRUE);
+	m_pGrayScaleGrid->UpdateWindow();
+}
+
 void CMainView::RefreshSelection(bool b_minCol, bool inMeasure)
 {
 	int		i, aColorTemp;
@@ -5612,6 +5638,7 @@ void CMainView::OnDeleteGrayscale()
 
 void CMainView::UpdateMeasurementsAfterBkgndMeasure ()
 {
+	HighlightMeasuringColumn(last_minCol);	// indicate the active column during continuous/background measures
 	CColor	MeasuredColor=noDataColor;
 	double YWhite = -1;
 	double YWhiteRefDoc = -1;

--- a/Views/MainView.cpp
+++ b/Views/MainView.cpp
@@ -2231,19 +2231,36 @@ void CMainView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 
 		if ( ( lHint >= UPD_EVERYTHING && lHint <= UPD_FREEMEASURES ) || lHint == UPD_ARRAYSIZES || lHint == UPD_GENERALREFERENCES || lHint == UPD_DATAREFDOC || lHint == UPD_REFERENCEDATA )
 		{
-			if (m_pGrayScaleGrid)
-				m_pGrayScaleGrid->SetRedraw(FALSE);
-			// Suppress intermediate repaints while InitGrid tears the grid down and UpdateGrid refills it
-			// (otherwise it blanks to white between the two during a measurement update); repaint once below.
-			InitGrid(); // to update row labels (if colorReference setting has changed, or if lux values appeared)
-			if(m_pGrayScaleGrid)
-				UpdateGrid();
-			if(m_SelectedColor.isValid())
-				RefreshSelection(false,GetDocument()->GetMeasure()->m_binMeasure);
-			if (m_pGrayScaleGrid)
+			if ( lHint == UPD_EVERYTHING || lHint == UPD_ARRAYSIZES )
 			{
-				m_pGrayScaleGrid->SetRedraw(TRUE);
-				m_pGrayScaleGrid->Invalidate(FALSE);
+				// Structural change (e.g. the grayscale point count changed): rebuild and
+				// auto-fit the columns with redraw ENABLED, so the scroll bars and client
+				// rect are settled before ExpandColumnsToFit measures the available width.
+				// Sizing while redraw was off fit the columns to stale geometry, leaving the
+				// last column clipped by the always-present vertical scroll bar. This mirrors
+				// the OnSize path, which is why a manual window resize already corrected it.
+				InitGrid(true);
+				if(m_pGrayScaleGrid)
+					UpdateGrid();
+				if(m_SelectedColor.isValid())
+					RefreshSelection(false,GetDocument()->GetMeasure()->m_binMeasure);
+			}
+			else
+			{
+				if (m_pGrayScaleGrid)
+					m_pGrayScaleGrid->SetRedraw(FALSE);
+				// Suppress intermediate repaints while InitGrid tears the grid down and UpdateGrid refills it
+				// (otherwise it blanks to white between the two during a measurement update); repaint once below.
+				InitGrid();
+				if(m_pGrayScaleGrid)
+					UpdateGrid();
+				if(m_SelectedColor.isValid())
+					RefreshSelection(false,GetDocument()->GetMeasure()->m_binMeasure);
+				if (m_pGrayScaleGrid)
+				{
+					m_pGrayScaleGrid->SetRedraw(TRUE, TRUE);
+					m_pGrayScaleGrid->Invalidate(FALSE);
+				}
 			}
 		}
 		

--- a/Views/MainView.h
+++ b/Views/MainView.h
@@ -182,6 +182,7 @@ public:
 	void SetLastColor ( CColor & clr, bool inMeasure = FALSE )	{ m_LastColor = clr; GetDocument () -> SetLastColor ( clr ); if (!inMeasure) RefreshSelection (); }
 
 	void RefreshSelection (bool b_minCol = TRUE, bool inMeasure = FALSE);
+	void HighlightMeasuringColumn(int gridCol);
 
 // Operations
 public:


### PR DESCRIPTION
Fixes reported against the grayscale/measures table.

## Scrollbar, two-finger scroll, and column auto-fit (`f31b0e2e`)
- **Scrollbar thumb missing** when the grid extends beyond the view: changing the grayscale count rebuilt the grid inside a `SetRedraw(FALSE)` wrapper, so `ResetScrollBars()` no-op'd and the scroll range was never recomputed. Now `SetRedraw(TRUE, TRUE)` recomputes it.
- **Two-finger / mouse-wheel scroll did nothing** on a grid that overflows horizontally: `CGridCtrl::OnMouseWheel` only ever scrolled vertically. It now routes to the horizontal axis when there's no vertical range (or Shift is held), plus a new `OnMouseHWheel` for horizontal trackpad swipes.
- **Columns didn't auto-fit** on count change (only a window resize fixed it): the auto-fit ran on stale geometry while redraw was disabled. Structural updates now rebuild/auto-fit with redraw enabled — matching the `OnSize` path — so columns fit the table and the last column isn't clipped by the vertical scrollbar.

## "Currently measuring" column indicator (`f3be528c`)
The indicator that highlights the column being measured was lost when the earlier flashing fix removed `UpdateGrid`'s blanket `Refresh()`. Restored flash-safely via `CMainView::HighlightMeasuringColumn` (selects the active column with `SetSelectedRange`, which repaints only the changed cells, + `EnsureVisible`):
- Discrete sweeps: highlighted from `CMeasure::UpdateTstWnd`, called right before each blocking reading, so it tracks the column actually being measured (no one-point lag).
- Continuous/background measures: highlighted from `UpdateMeasurementsAfterBkgndMeasure`.

All changes build clean (Debug|Win32) and were verified on-screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)