### PR TITLE
Bump version to 4.0.2.0

### DIFF
--- a/CHCFR21_DEUTSCH.rc
+++ b/CHCFR21_DEUTSCH.rc
@@ -348,7 +348,7 @@ CAPTION "Über HCFR Colorimeter"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
     CONTROL         IDB_LOGO,IDC_STATIC,"Static",SS_BITMAP,7,7,172,62
-    LTEXT           "Version 4.0.1.0",IDC_STATIC_VERSION,7,76,119,8,SS_NOPREFIX
+    LTEXT           "Version 4.0.2.0",IDC_STATIC_VERSION,7,76,119,8,SS_NOPREFIX
     LTEXT           "Copyright (C) 2012-2026 Hcfr Project\nCopyright (C) 2005-2008 Association Homecinema Francophone",IDC_STATIC2,7,88,168,29
     LTEXT           "hcfr.sourceforge.net",IDC_HOMECINEMA_HYPERLINK,7,120,80,8
     LTEXT           "IDC_PLACEHOLDER",IDC_PLACEHOLDER,4,136,177,117
@@ -2593,8 +2593,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 4,0,1,0
- PRODUCTVERSION 4,0,1,0
+ FILEVERSION 4,0,2,0
+ PRODUCTVERSION 4,0,2,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -2612,12 +2612,12 @@ BEGIN
             VALUE "Comments", "Under GPL Licence"
             VALUE "CompanyName", "Association Homecinema Francophone"
             VALUE "FileDescription", "HCFR Colorimeter resources"
-            VALUE "FileVersion", "4.0.1.0"
+            VALUE "FileVersion", "4.0.2.0"
             VALUE "InternalName", "CHCFR21_DEUTSCH"
             VALUE "LegalCopyright", "Copyright (C) 2005-2026"
             VALUE "OriginalFilename", "CHCFR21_DEUTSCH.DLL"
             VALUE "ProductName", "HCFR Colorimeter German language"
-            VALUE "ProductVersion", "4.0.1.0"
+            VALUE "ProductVersion", "4.0.2.0"
         END
     END
     BLOCK "VarFileInfo"
@@ -2785,7 +2785,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDR_MAINFRAME           "HCFR Colorimeter - 4.0.1.0"
+    IDR_MAINFRAME           "HCFR Colorimeter - 4.0.2.0"
     IDR_MESURETYPE          "\nFarbmessungen\nFarbmessungen\nColorHCFR Datei (*.chc)\n.chc\nCOLORHCFR\nHCFR Farbmessungen"
 END
 

--- a/CHCFR21_ENGLISH.rc
+++ b/CHCFR21_ENGLISH.rc
@@ -337,7 +337,7 @@ CAPTION "About HCFR Colorimeter"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
     CONTROL         IDB_LOGO,IDC_STATIC,"Static",SS_BITMAP,7,7,172,62
-    LTEXT           "Version 4.0.1.0",IDC_STATIC_VERSION,7,76,119,8,SS_NOPREFIX
+    LTEXT           "Version 4.0.2.0",IDC_STATIC_VERSION,7,76,119,8,SS_NOPREFIX
     LTEXT           "Copyright (C) 2012-2026 Hcfr Project\nCopyright (C) 2005-2008 Association Homecinema Francophone",IDC_STATIC2,7,88,168,24
     LTEXT           "hcfr.sourceforge.net",IDC_HOMECINEMA_HYPERLINK,7,119,80,8
     LTEXT           "IDC_PLACEHOLDER",IDC_PLACEHOLDER,4,136,177,117
@@ -2727,8 +2727,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 4.0.1.0
- PRODUCTVERSION 4.0.1.0
+ FILEVERSION 4.0.2.0
+ PRODUCTVERSION 4.0.2.0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -2746,12 +2746,12 @@ BEGIN
             VALUE "Comments", "Under GPL Licence"
             VALUE "CompanyName", "Association Homecinema Francophone"
             VALUE "FileDescription", "HCFR Colorimeter resources"
-            VALUE "FileVersion", "4.0.1.0"
+            VALUE "FileVersion", "4.0.2.0"
             VALUE "InternalName", "CHCFR21_ENGLISH"
             VALUE "LegalCopyright", "Copyright (C) 2005-2026"
             VALUE "OriginalFilename", "CHCFR21_ENGLISH.DLL"
             VALUE "ProductName", "HCFR Colorimeter English langage"
-            VALUE "ProductVersion", "4.0.1.0"
+            VALUE "ProductVersion", "4.0.2.0"
         END
     END
     BLOCK "VarFileInfo"
@@ -2794,7 +2794,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDR_MAINFRAME           "HCFR Colorimeter - 4.0.1.0"
+    IDR_MAINFRAME           "HCFR Colorimeter - 4.0.2.0"
     IDR_MESURETYPE          "\nColor Measures\nColor_Measures\nColorHCFR File (*.chc)\n.chc\nCOLORHCFR\nHCFR Color Measures"
 END
 

--- a/CHCFR21_ESPANOL.rc
+++ b/CHCFR21_ESPANOL.rc
@@ -417,7 +417,7 @@ CAPTION "About HCFR Colorimeter"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
     CONTROL         223,IDC_STATIC,"Static",SS_BITMAP,7,7,172,62
-    LTEXT           "Version 4.0.1.0",IDC_STATIC_VERSION,7,76,119,8,SS_NOPREFIX
+    LTEXT           "Version 4.0.2.0",IDC_STATIC_VERSION,7,76,119,8,SS_NOPREFIX
     LTEXT           "Copyright (C) 2012-2026 Hcfr Project\nCopyright (C) 2005-2008 Association Homecinema Francophone",IDC_STATIC2,7,88,168,24
     LTEXT           "hcfr.sourceforge.net",IDC_HOMECINEMA_HYPERLINK,7,119,80,8
     LTEXT           "IDC_PLACEHOLDER",IDC_PLACEHOLDER,4,136,177,117
@@ -2854,8 +2854,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 4.0.1.0
- PRODUCTVERSION 4.0.1.0
+ FILEVERSION 4.0.2.0
+ PRODUCTVERSION 4.0.2.0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -2873,12 +2873,12 @@ BEGIN
             VALUE "Comments", "Under GPL Licence"
             VALUE "CompanyName", "Association Homecinema Francophone"
             VALUE "FileDescription", "HCFR Colorimeter resources"
-            VALUE "FileVersion", "4.0.1.0"
+            VALUE "FileVersion", "4.0.2.0"
             VALUE "InternalName", "CHCFR21_ENGLISH"
             VALUE "LegalCopyright", "Copyright (C) 2005-2026"
             VALUE "OriginalFilename", "CHCFR21_ENGLISH.DLL"
             VALUE "ProductName", "HCFR Colorimeter English langage"
-            VALUE "ProductVersion", "4.0.1.0"
+            VALUE "ProductVersion", "4.0.2.0"
         END
     END
     BLOCK "VarFileInfo"
@@ -2916,7 +2916,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDR_MAINFRAME           "HCFR Colorimeter - 4.0.1.0"
+    IDR_MAINFRAME           "HCFR Colorimeter - 4.0.2.0"
     IDR_MESURETYPE          "\nColor Measures\nColor_Measures\nColorHCFR File (*.chc)\n.chc\nCOLORHCFR\nHCFR Color Measures"
 END
 

--- a/CHCFR21_FRANCAIS.rc
+++ b/CHCFR21_FRANCAIS.rc
@@ -755,7 +755,7 @@ CAPTION "A propos du Colorimètre HCFR"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
     CONTROL         IDB_LOGO,IDC_STATIC,"Static",SS_BITMAP,7,7,172,62
-    LTEXT           "Version 4.0.1.0",IDC_STATIC_VERSION,7,76,119,8,SS_NOPREFIX
+    LTEXT           "Version 4.0.2.0",IDC_STATIC_VERSION,7,76,119,8,SS_NOPREFIX
     LTEXT           "Copyright (C) 2012-2026 Hcfr Project\nCopyright (C) 2005-2008 Association Homecinema Francophone",IDC_STATIC2,7,88,168,28
     LTEXT           "hcfr.sourceforge.net",IDC_HOMECINEMA_HYPERLINK,7,119,80,8
     LTEXT           "IDC_PLACEHOLDER",IDC_PLACEHOLDER,4,136,177,117
@@ -2891,8 +2891,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 4.0.1.0
- PRODUCTVERSION 4.0.1.0
+ FILEVERSION 4.0.2.0
+ PRODUCTVERSION 4.0.2.0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -2910,12 +2910,12 @@ BEGIN
             VALUE "Comments", "Under GPL Licence"
             VALUE "CompanyName", "Association Homecinema Francophone"
             VALUE "FileDescription", "Resources Colorimètre HCFR"
-            VALUE "FileVersion", "4.0.1.0"
+            VALUE "FileVersion", "4.0.2.0"
             VALUE "InternalName", "CHCFR21_FRANCAIS"
             VALUE "LegalCopyright", "Copyright (C) 2005-2026"
             VALUE "OriginalFilename", "CHCFR21_FRANCAIS.DLL"
             VALUE "ProductName", "Colorimètre HCFR langage Français"
-            VALUE "ProductVersion", "4.0.1.0"
+            VALUE "ProductVersion", "4.0.2.0"
         END
     END
     BLOCK "VarFileInfo"
@@ -3013,7 +3013,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDR_MAINFRAME           "Colorimètre HCFR - 4.0.1.0"
+    IDR_MAINFRAME           "Colorimètre HCFR - 4.0.2.0"
     IDR_MESURETYPE          "\nRelevé\nRelevé\nFichiers ColorHCFR (*.chc)\n.chc\nCOLORHCFR\nRelevé de couleurs HCFR"
 END
 

--- a/CHCFR21_ITALIAN.rc
+++ b/CHCFR21_ITALIAN.rc
@@ -340,7 +340,7 @@ CAPTION "Info su Colorimetro HCFR"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
     CONTROL         IDB_LOGO,IDC_STATIC,"Static",SS_BITMAP,7,7,172,62
-    LTEXT           "Version 4.0.1.0",IDC_STATIC_VERSION,7,76,119,8,SS_NOPREFIX
+    LTEXT           "Version 4.0.2.0",IDC_STATIC_VERSION,7,76,119,8,SS_NOPREFIX
     LTEXT           "Copyright (C) 2012-2026 Hcfr Project\nCopyright (C) 2005-2008 Association Homecinema Francophone",IDC_STATIC2,7,88,168,24
     LTEXT           "hcfr.sourceforge.net",IDC_HOMECINEMA_HYPERLINK,7,119,80,8
     LTEXT           "IDC_PLACEHOLDER",IDC_PLACEHOLDER,4,136,177,117
@@ -2872,8 +2872,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 4,0,1,0
- PRODUCTVERSION 4,0,1,0
+ FILEVERSION 4,0,2,0
+ PRODUCTVERSION 4,0,2,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -2891,12 +2891,12 @@ BEGIN
             VALUE "Comments", "Under GPL Licence"
             VALUE "CompanyName", "Association Homecinema Francophone"
             VALUE "FileDescription", "HCFR Colorimeter resources"
-            VALUE "FileVersion", "4.0.1.0"
+            VALUE "FileVersion", "4.0.2.0"
             VALUE "InternalName", "CHCFR21_ENGLISH"
             VALUE "LegalCopyright", "Copyright (C) 2005-2026"
             VALUE "OriginalFilename", "CHCFR21_ENGLISH.DLL"
             VALUE "ProductName", "HCFR Colorimeter English langage"
-            VALUE "ProductVersion", "4.0.1.0"
+            VALUE "ProductVersion", "4.0.2.0"
         END
     END
     BLOCK "VarFileInfo"
@@ -2994,7 +2994,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDR_MAINFRAME           "HCFR Colorimeter - 4.0.1.0"
+    IDR_MAINFRAME           "HCFR Colorimeter - 4.0.2.0"
     IDR_MESURETYPE          "\nColor Measures\nColor_Measures\nColorHCFR File (*.chc)\n.chc\nCOLORHCFR\nHCFR Color Measures"
 END
 

--- a/CHCFR21_PATTERNS.rc
+++ b/CHCFR21_PATTERNS.rc
@@ -64,8 +64,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 4.0.1.0
- PRODUCTVERSION 4.0.1.0
+ FILEVERSION 4.0.2.0
+ PRODUCTVERSION 4.0.2.0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -81,12 +81,12 @@ BEGIN
         BLOCK "040c04b0"
         BEGIN
             VALUE "FileDescription", "CHCFR21_PATTERNS DLL"
-            VALUE "FileVersion", "4.0.1.0"
+            VALUE "FileVersion", "4.0.2.0"
             VALUE "InternalName", "CHCFR21_PATTERNS"
             VALUE "LegalCopyright", "Copyright (C) 2007-2026"
             VALUE "OriginalFilename", "CHCFR21_PATTERNS.DLL"
             VALUE "ProductName", "Bibliothèque de liaison dynamique CHCFR21_PATTERNS"
-            VALUE "ProductVersion", "4.0.1.0"
+            VALUE "ProductVersion", "4.0.2.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/ColorHCFR.rc
+++ b/ColorHCFR.rc
@@ -1,4 +1,4 @@
-// 4.0.1.0 Visual C++ generated resource script.
+// 4.0.2.0 Visual C++ generated resource script.
 //
 #include "resource.h"
 
@@ -70,8 +70,8 @@ IDR_APPICON             ICON                    "res\\icon1.ico"
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 4.0.1.0
- PRODUCTVERSION 4.0.1.0
+ FILEVERSION 4.0.2.0
+ PRODUCTVERSION 4.0.2.0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -88,12 +88,12 @@ BEGIN
         BEGIN
             VALUE "Comments", "Under GPL Licence"
             VALUE "FileDescription", "HCFR"
-            VALUE "FileVersion", "4.0.1.0"
+            VALUE "FileVersion", "4.0.2.0"
             VALUE "InternalName", "ColorHCFR"
             VALUE "LegalCopyright", "Copyright (c) 2005-2026"
             VALUE "OriginalFilename", "ColorHCFR.EXE"
             VALUE "ProductName", "HCFR"
-            VALUE "ProductVersion", "4.0.1.0"
+            VALUE "ProductVersion", "4.0.2.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/ColorHCFR_2019.vdproj
+++ b/ColorHCFR_2019.vdproj
@@ -6413,7 +6413,7 @@
         "RemovePreviousVersions" = "11:TRUE"
         "DetectNewerInstalledVersion" = "11:FALSE"
         "InstallAllUsers" = "11:TRUE"
-        "ProductVersion" = "8:4.0.1"
+        "ProductVersion" = "8:4.0.2"
         "Manufacturer" = "8:ColorHCFR"
         "ARPHELPTELEPHONE" = "8:"
         "ARPHELPLINK" = "8:https://www.avsforum.com/forum/139-display-calibration/1393853-hcfr-open-source-projector-display-calibration-software.html"

--- a/ColorHCFR_VS2019.vdproj
+++ b/ColorHCFR_VS2019.vdproj
@@ -6401,7 +6401,7 @@
         "RemovePreviousVersions" = "11:TRUE"
         "DetectNewerInstalledVersion" = "11:FALSE"
         "InstallAllUsers" = "11:TRUE"
-        "ProductVersion" = "8:4.0.1"
+        "ProductVersion" = "8:4.0.2"
         "Manufacturer" = "8:ColorHCFR"
         "ARPHELPTELEPHONE" = "8:"
         "ARPHELPLINK" = "8:https://www.avsforum.com/forum/139-display-calibration/1393853-hcfr-open-source-projector-display-calibration-software.html"


### PR DESCRIPTION
Version bump for the 4.0.2.0 bug-fix release (follows #22, the grayscale measures-table fixes).

Updates the app version (FILEVERSION/PRODUCTVERSION + display strings) in all 7 `.rc` files and the MSI `ProductVersion` (3-part `4.0.2`) in both `.vdproj`. Same byte-for-byte shape as the 4.0.1.0 bump (9 files, 41/41).

🤖 Generated with [Claude Code](https://claude.com/claude-code)