### PR TITLE
Installer: new ProductCode so 4.0.2.0 upgrades 4.0.x in place

### DIFF
--- a/ColorHCFR_VS2019.vdproj
+++ b/ColorHCFR_VS2019.vdproj
@@ -6393,7 +6393,7 @@
         {
         "Name" = "8:Microsoft Visual Studio"
         "ProductName" = "8:HCFR"
-        "ProductCode" = "8:{4BF88344-B16A-424E-8FBC-732E6633E50B}"
+        "ProductCode" = "8:{B64FC50E-FA1A-4654-9BAF-B25CE6C6AE62}"
         "PackageCode" = "8:{7A8A0441-D466-4276-9010-22E9E3FE273D}"
         "UpgradeCode" = "8:{BF340A8C-5760-4352-B44E-37B4C150A159}"
         "AspNetVersion" = "8:2.0.50727.0"


### PR DESCRIPTION
Fixes the **"Another version of this product is already installed"** error when installing 4.0.2.0 over an existing 4.0.x install.

A VS setup project only performs a major upgrade (`RemovePreviousVersions`) when each release has a **new `ProductCode`** while keeping the same `UpgradeCode`. The 4.0.2.0 bump (and the 4.0.1.0 bump before it) changed only `ProductVersion`, so the MSI reused the prior `ProductCode` and Windows Installer refused to install over the installed version.

This assigns a fresh `ProductCode` for the 4.0.2.0 installer; `UpgradeCode` and `RemovePreviousVersions=TRUE` are unchanged, so 4.0.2 now removes the installed 4.0.x and installs cleanly. No app code or version-string change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)