### PR TITLE
Installer: version-stamped MSI filename (HCFR-<version>.msi)

### DIFF
--- a/ColorHCFR_VS2019.vdproj
+++ b/ColorHCFR_VS2019.vdproj
@@ -669,7 +669,7 @@
         "DisplayName" = "8:Release"
         "IsDebugOnly" = "11:FALSE"
         "IsReleaseOnly" = "11:TRUE"
-        "OutputFilename" = "8:Release\\Installer\\HCFR.msi"
+        "OutputFilename" = "8:Release\\Installer\\HCFR-4.0.2.0.msi"
         "PackageFilesAs" = "3:2"
         "PackageFileSize" = "3:-2147483648"
         "CabType" = "3:1"


### PR DESCRIPTION
Makes the built installer self-identifying: the VS2019 setup project's `OutputFilename` changes from the generic `Release\Installer\HCFR.msi` to `Release\Installer\HCFR-4.0.2.0.msi`, so the build output (and the release download) carries the version.

### Caveat — not automatic
A vdproj `OutputFilename` is a **static string** (no version macro), so this has to be **re-stamped to the new version on every release**, as part of the version bump. Once merged I'll add it to the "Version locations" / release-recipe checklist so it's bumped alongside the `.rc`/`.vdproj` `ProductVersion`.

Only the VS2019 project (the one we actually build/release) is changed; the legacy `ColorHCFR_2019.vdproj` is left as-is.

Not merging — leaving this for your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)