### PR TITLE
Update all charts live during continuous measures, flicker-free

### DIFF
--- a/Views/CIEChartView.cpp
+++ b/Views/CIEChartView.cpp
@@ -2485,7 +2485,7 @@ void CCIEChartView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 		GetReferenceRect ( & Rect );
 		if (lHint != UPD_FREEMEASURES && lHint != UPD_REALTIME && lHint != UPD_FREEMEASUREAPPENDED && !GetDocument()->GetMeasure()->m_binMeasure)
 			m_Grapher.MakeBgBitmap(Rect,GetConfig()->m_bWhiteBkgndOnScreen);
-		Invalidate(TRUE);
+		RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW | RDW_ALLCHILDREN);
 	}
 	else
 	{

--- a/Views/GammaHistoView.cpp
+++ b/Views/GammaHistoView.cpp
@@ -444,7 +444,7 @@ void CGammaHistoView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 	if ( lHint == UPD_EVERYTHING || lHint == UPD_GRAYSCALEANDCOLORS || lHint == UPD_GRAYSCALE || lHint == UPD_DATAREFDOC || lHint == UPD_REFERENCEDATA  || lHint == UPD_FREEMEASUREAPPENDED || lHint >= UPD_REALTIME)
 	{
 		m_Grapher.UpdateGraph ( GetDocument () );
-		Invalidate(TRUE);
+		RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW | RDW_ALLCHILDREN);
 	}
 }
 

--- a/Views/GraphControl.cpp
+++ b/Views/GraphControl.cpp
@@ -327,6 +327,7 @@ void CGraphControl::ChangeScale()
 BEGIN_MESSAGE_MAP(CGraphControl, CWnd)
 	//{{AFX_MSG_MAP(CGraphControl)
 	ON_WM_PAINT()
+	ON_WM_ERASEBKGND()
 	ON_WM_SIZE()
 	ON_WM_CREATE()
 	//}}AFX_MSG_MAP
@@ -870,6 +871,11 @@ void CGraphControl::DrawAxis(CDC *pDC, CRect rect, BOOL bWhiteBkgnd)
 
 	pDC->SelectObject(pOldPen);
 	pDC->SelectObject(pOldFont);
+}
+
+BOOL CGraphControl::OnEraseBkgnd(CDC*)
+{
+	return TRUE;
 }
 
 void CGraphControl::OnPaint() 

--- a/Views/GraphControl.h
+++ b/Views/GraphControl.h
@@ -162,6 +162,7 @@ protected:
 protected:
 	//{{AFX_MSG(CGraphControl)
 	afx_msg void OnPaint();
+	afx_msg BOOL OnEraseBkgnd(CDC* pDC);
 	afx_msg void OnSize(UINT nType, int cx, int cy);
 	afx_msg int OnCreate(LPCREATESTRUCT lpCreateStruct);
 	//}}AFX_MSG

--- a/Views/MainView.cpp
+++ b/Views/MainView.cpp
@@ -6013,8 +6013,7 @@ void CMainView::UpdateMeasurementsAfterBkgndMeasure ()
 	}
 	else
 	{
-		m_pGrayScaleGrid->SetSelectedRange(-1,-1,-1,-1);
-		m_pGrayScaleGrid->SetFocusCell(-1,-1);
+		HighlightMeasuringColumn(last_minCol);
 	}
 
 	SetSelectedColor ( MeasuredColor );

--- a/Views/NearBlackHistoView.cpp
+++ b/Views/NearBlackHistoView.cpp
@@ -473,10 +473,10 @@ void CNearBlackHistoView::OnInitialUpdate()
 void CNearBlackHistoView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint) 
 {
 	// Update this view only when we are concerned
-	if ( lHint == UPD_EVERYTHING || lHint == UPD_GRAYSCALEANDCOLORS || lHint == UPD_GRAYSCALE || lHint == UPD_NEARBLACK || lHint == UPD_NEARWHITE || lHint == UPD_DATAREFDOC || lHint == UPD_REFERENCEDATA || lHint == UPD_ARRAYSIZES || lHint >= UPD_REALTIME)
+	if ( lHint == UPD_EVERYTHING || lHint == UPD_GRAYSCALEANDCOLORS || lHint == UPD_GRAYSCALE || lHint == UPD_NEARBLACK || lHint == UPD_NEARWHITE || lHint == UPD_DATAREFDOC || lHint == UPD_REFERENCEDATA || lHint == UPD_ARRAYSIZES || lHint == UPD_FREEMEASUREAPPENDED || lHint >= UPD_REALTIME)
 	{
 		m_Grapher.UpdateGraph ( GetDocument () );
-		Invalidate(TRUE);
+		RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW | RDW_ALLCHILDREN);
 	}
 }
 

--- a/Views/NearWhiteHistoView.cpp
+++ b/Views/NearWhiteHistoView.cpp
@@ -451,10 +451,10 @@ void CNearWhiteHistoView::OnInitialUpdate()
 void CNearWhiteHistoView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint) 
 {
 	// Update this view only when we are concerned
-	if ( lHint == UPD_EVERYTHING || lHint == UPD_GRAYSCALEANDCOLORS || lHint == UPD_GRAYSCALE || lHint == UPD_NEARBLACK || lHint == UPD_NEARWHITE || lHint == UPD_DATAREFDOC || lHint == UPD_REFERENCEDATA || lHint == UPD_ARRAYSIZES || lHint >= UPD_REALTIME)
+	if ( lHint == UPD_EVERYTHING || lHint == UPD_GRAYSCALEANDCOLORS || lHint == UPD_GRAYSCALE || lHint == UPD_NEARBLACK || lHint == UPD_NEARWHITE || lHint == UPD_DATAREFDOC || lHint == UPD_REFERENCEDATA || lHint == UPD_ARRAYSIZES || lHint == UPD_FREEMEASUREAPPENDED || lHint >= UPD_REALTIME)
 	{
 		m_Grapher.UpdateGraph ( GetDocument () );
-		Invalidate(TRUE);
+		RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW | RDW_ALLCHILDREN);
 	}
 }
 

--- a/Views/SatLumHistoView.cpp
+++ b/Views/SatLumHistoView.cpp
@@ -396,7 +396,6 @@ void CSatLumHistoView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 		case UPD_NEARWHITE:
 		case UPD_CONTRAST:
 		case UPD_FREEMEASURES:
-		case UPD_FREEMEASUREAPPENDED:
 		case UPD_GENERATORCONFIG:
 		case UPD_SELECTEDCOLOR:
 			 return;
@@ -404,7 +403,7 @@ void CSatLumHistoView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 
 	m_Grapher.UpdateGraph ( GetDocument () );
 
-	Invalidate(TRUE);
+	RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW | RDW_ALLCHILDREN);
 }
 
 DWORD CSatLumHistoView::GetUserInfo ()

--- a/Views/SatLumShiftView.cpp
+++ b/Views/SatLumShiftView.cpp
@@ -736,7 +736,6 @@ void CSatLumShiftView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 		case UPD_NEARWHITE:
 		case UPD_CONTRAST:
 		case UPD_FREEMEASURES:
-		case UPD_FREEMEASUREAPPENDED:
 		case UPD_GENERATORCONFIG:
 		case UPD_SELECTEDCOLOR:
 			 return;
@@ -744,7 +743,7 @@ void CSatLumShiftView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 
 	m_Grapher.UpdateGraph ( GetDocument () );
 
-	Invalidate(TRUE);
+	RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW | RDW_ALLCHILDREN);
 }
 
 DWORD CSatLumShiftView::GetUserInfo ()

--- a/Views/colortemphistoview.cpp
+++ b/Views/colortemphistoview.cpp
@@ -185,7 +185,7 @@ void CColorTempHistoView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 	if ( lHint == UPD_EVERYTHING || lHint == UPD_GRAYSCALEANDCOLORS || lHint == UPD_GRAYSCALE || lHint == UPD_DATAREFDOC || lHint == UPD_REFERENCEDATA || lHint == UPD_FREEMEASUREAPPENDED || lHint >= UPD_REALTIME)
 	{
 		m_Grapher.UpdateGraph ( GetDocument () );
-		Invalidate(TRUE);
+		RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW | RDW_ALLCHILDREN);
 	}
 }
 

--- a/Views/luminancehistoview.cpp
+++ b/Views/luminancehistoview.cpp
@@ -504,7 +504,7 @@ void CLuminanceHistoView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 	if ( lHint == UPD_EVERYTHING || lHint == UPD_GRAYSCALEANDCOLORS || lHint == UPD_GRAYSCALE || lHint == UPD_DATAREFDOC || lHint == UPD_REFERENCEDATA || lHint == UPD_ARRAYSIZES || lHint == UPD_FREEMEASUREAPPENDED || lHint >= UPD_REALTIME)
 	{
 		m_Grapher.UpdateGraph ( GetDocument () );
-		Invalidate(TRUE);
+		RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW | RDW_ALLCHILDREN);
 	}
 }
 

--- a/Views/measureshistoview.cpp
+++ b/Views/measureshistoview.cpp
@@ -370,7 +370,7 @@ void CMeasuresHistoView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 		
 		m_graphCtrl.SetYAxisProps("", pow ( 10.0, (double) ( nFactor < 3 ? nTensScale - 1 : nTensScale ) ), 0, m_LumaMaxY * 2.0);
 	}
-	Invalidate(TRUE);
+	RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW | RDW_ALLCHILDREN);
 }
 
 DWORD CMeasuresHistoView::GetUserInfo ()

--- a/Views/rgbhistoview.cpp
+++ b/Views/rgbhistoview.cpp
@@ -402,7 +402,7 @@ void CRGBHistoView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 	if ( lHint == UPD_EVERYTHING || lHint == UPD_GRAYSCALEANDCOLORS || lHint == UPD_GRAYSCALE || lHint == UPD_DATAREFDOC || lHint == UPD_REFERENCEDATA || lHint == UPD_ARRAYSIZES || lHint == UPD_GENERALREFERENCES || lHint == UPD_SENSORCONFIG || lHint == UPD_FREEMEASUREAPPENDED || lHint >= UPD_REALTIME)
 	{
 		m_Grapher.UpdateGraph ( GetDocument () );
-		Invalidate(TRUE);
+		RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW | RDW_ALLCHILDREN);
 	}
 }
 


### PR DESCRIPTION
## What
Every measurement chart now updates **live and flicker-free** during continuous measures, and the currently-measuring grid column stays highlighted.

## Root cause
During continuous measures the background thread streams "measure ready" messages to the UI thread. The chart views *were* receiving their update hint, refreshing their graph data, and calling `Invalidate(TRUE)` — but the actual `WM_PAINT` was **starved** by the message flood, so the graphs only repainted once the run stopped (instrumented paint counts showed ~4 repaints for ~24 measures). Separately, four chart views ignored the continuous hint entirely, and the graph control flashed on each repaint.

## Changes
- **Flash:** `CGraphControl::OnEraseBkgnd → TRUE` so the double-buffered graph repaints with no erase flash (one place, covers all histo charts).
- **Live repaint:** every chart view's `OnUpdate` now uses `RedrawWindow(RDW_INVALIDATE | RDW_UPDATENOW | RDW_ALLCHILDREN)` instead of `Invalidate(TRUE)`, so the graph and its child control repaint synchronously per measure instead of being deferred.
- **Hint coverage:** NearBlack/NearWhite now handle `UPD_FREEMEASUREAPPENDED` (they gated on `>= UPD_REALTIME`, which excluded value 24); SatLum/SatLumShift stop `return`-ing early on it.
- **Column highlight:** `MainView` keeps the measuring column selected (blue) during continuous measures instead of clearing the grid selection each measure (was flashing blue→white).

## Provenance
The chart-update gaps and the chart flash are **long-standing upstream behaviour (2012–2018)**, not fork regressions (verified via `git blame`).

## Verified
Live on grayscale (gamma / luminance / RGB / color-temp), near-black / near-white, saturation sweeps, CIE, the measures grid, and the target window — all update live and flicker-free; the measuring column stays blue.

## Known follow-up (deferred — not in this PR)
Clicking a column **during** measurement can be missed because the UI thread is busy servicing the measure-ready stream (and these forced synchronous repaints add to that load). The real fix is decoupling the measurement loop from the UI thread — the documented "UI freeze" / threading work — and is intentionally deferred to that effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)