### PR TITLE
Fix custom white point selection on the References page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ UnitTests/tests.xml
 /.claude
 *proj.user
 /flash_diag.log
+CORRECTION-IMPORT-PLAN.md
+REFERENCES-SIGNAL-SYNC-PLAN.md

--- a/ReferencesPropPage.cpp
+++ b/ReferencesPropPage.cpp
@@ -1083,7 +1083,14 @@ void CReferencesPropPage::UpdateControlStates()
     ShowIds(this, whiteIds, 2, TRUE);
     m_manualWhitexedit.EnableWindow(customW);
     m_manualWhiteyedit.EnableWindow(customW);
-    if (m_whiteTargetCombo.GetSafeHwnd()) m_whiteTargetCombo.EnableWindow(!whiteLocked);
+    if (m_whiteTargetCombo.GetSafeHwnd())
+    {
+        m_whiteTargetCombo.EnableWindow(!whiteLocked);
+        // Force the dropdown to reflect m_whiteTarget so the (possibly greyed)
+        // selection can never lag behind the white actually applied to the reference.
+        if (m_whiteTarget >= 0)
+            m_whiteTargetCombo.SetCurSel(m_whiteTarget);
+    }
 
     BOOL customP = (m_colorStandard == CUSTOM);
     m_manualRedxedit.EnableWindow(customP);

--- a/ReferencesPropPage.cpp
+++ b/ReferencesPropPage.cpp
@@ -140,8 +140,6 @@ void CReferencesPropPage::DoDataExchange(CDataExchange* pDX)
 	DDV_MinMaxDouble(pDX, m_GammaRel, 0., 5.);
 	DDV_MinMaxDouble(pDX, m_Split, 0., 100.);
 	DDV_MinMaxDouble(pDX, m_ManualBlack, 0., 1.);
-	DDX_Check(pDX, IDC_CHANGEWHITE_CHECK, m_changeWhiteCheck);
-	DDX_Control(pDX, IDC_CHANGEWHITE_CHECK, m_changeWhiteCheckCtrl);
 	DDX_Check(pDX, IDC_USE_MEASURED_GAMMA, m_useMeasuredGamma);
 	DDX_Check(pDX, IDC_USER_BLACK, m_userBlack);
 	DDX_Control(pDX, IDC_USER_OVERRIDE_TARGS, m_bOverRideTargsCtrl);
@@ -208,7 +206,6 @@ BEGIN_MESSAGE_MAP(CReferencesPropPage, CPropertyPageWithHelp)
 	ON_EN_CHANGE(IDC_EDIT_TARGET_MAXL3, OnChangeEditGammaAvg)
 	ON_EN_CHANGE(IDC_EDIT_TARGET_MAXL4, OnChangeEditGammaAvg)
 	ON_EN_CHANGE(IDC_EDIT_TARGET_MAXL5, OnChangeEditGammaAvg)
-	ON_BN_CLICKED(IDC_CHANGEWHITE_CHECK, OnChangeWhiteCheck)
 	ON_BN_CLICKED(IDC_USE_MEASURED_GAMMA, OnUseMeasuredGammaCheck)
 	ON_BN_CLICKED(IDC_USER_BLACK, OnUserBlackCheck)
 	ON_BN_CLICKED(IDC_USER_OVERRIDE_TARGS, OnUserOverRideTargsCheck)
@@ -252,15 +249,12 @@ BOOL CReferencesPropPage::OnApply()
 	GetConfig()->	WriteProfileDouble("References","TargetSysGammaUser",m_TargetSysGammaUser);
 	if (m_colorStandard == HDTVa || m_colorStandard == HDTVb || m_colorStandard == CC6) 
 	{
-		m_changeWhiteCheckCtrl.EnableWindow(FALSE);
 		m_changeWhiteCheck = FALSE;
         m_whiteTargetCombo.EnableWindow (FALSE);
         m_manualWhitexedit.EnableWindow (FALSE);
         m_manualWhiteyedit.EnableWindow (FALSE);        
 		m_whiteTarget=(int)(GetStandardColorReference((ColorStandard)(m_colorStandard)).m_white);	
 	} 
-	else
-		m_changeWhiteCheckCtrl.EnableWindow(TRUE);
 
     if (m_whiteTarget == DCUST)
     {
@@ -362,23 +356,11 @@ BOOL CReferencesPropPage::OnInitDialog()
 	m_GammaAvgEdit.EnableWindow(FALSE);
 	if (m_colorStandard == HDTVa || m_colorStandard == HDTVb || m_colorStandard == CC6) 
 	{
-		m_changeWhiteCheckCtrl.EnableWindow(FALSE);
 		m_changeWhiteCheck = FALSE;
 		m_whiteTarget=(int)(GetStandardColorReference((ColorStandard)(m_colorStandard)).m_white);	}
 	else
 		m_changeWhiteCheck = (m_whiteTarget!=(int)(GetStandardColorReference((ColorStandard)(m_colorStandard)).m_white));
 
-	if(m_changeWhiteCheck)
-	{
-		CheckRadioButton ( IDC_CHANGEWHITE_CHECK, IDC_CHANGEWHITE_CHECK, IDC_CHANGEWHITE_CHECK );
-		m_whiteTargetCombo.EnableWindow (TRUE);
-	}
-    else
-    {
-        m_whiteTargetCombo.EnableWindow (FALSE);
-        m_manualWhitexedit.EnableWindow (FALSE);
-        m_manualWhiteyedit.EnableWindow (FALSE);        
-    }
     if (m_colorStandard == CUSTOM)
     {
         m_manualRedxedit.EnableWindow (TRUE);
@@ -524,21 +506,6 @@ UINT CReferencesPropPage::GetHelpId ( LPSTR lpszTopic )
 	return HID_PREF_REFERENCES;
 }
 
-void CReferencesPropPage::OnChangeWhiteCheck() 
-{
-	UpdateData(TRUE);
-	m_bSave = TRUE;
-	if(!m_changeWhiteCheck)	// Restore default white
-	{
-		m_whiteTarget=(int)(GetStandardColorReference((ColorStandard)(m_colorStandard)).m_white);
-		m_isModified=TRUE;
-		SetModified(TRUE);
-		UpdateData(FALSE);	
-		OnSelchangeWhiteCombo();
-	}
-	m_whiteTargetCombo.EnableWindow (m_changeWhiteCheck);
-}
-
 void CReferencesPropPage::OnUseMeasuredGammaCheck() 
 {
 	m_isModified=TRUE;
@@ -611,6 +578,10 @@ void CReferencesPropPage::OnSelchangeWhiteCombo()
 	SetModified(TRUE);
 	m_bSave = TRUE;
 	UpdateData(TRUE);
+	// Keep the internal "white overridden" flag honest now that the dropdown is the
+	// only control: TRUE when the chosen white differs from the standard default, so a
+	// later color-space change preserves the user's white instead of resetting it.
+	m_changeWhiteCheck = (m_whiteTarget != (int)(GetStandardColorReference((ColorStandard)(m_colorStandard)).m_white));
 	BOOL enableEditControls = m_whiteTarget == DCUST ? TRUE : FALSE;
 	m_manualWhitexedit.EnableWindow (enableEditControls);
 	m_manualWhiteyedit.EnableWindow (enableEditControls);
@@ -679,7 +650,9 @@ void CReferencesPropPage::OnSelchangeColorrefCombo()
 	}
 	if (m_colorStandard == CC6)
 		m_CCMode = GCD;
-	if(!m_changeWhiteCheck) // Restore default white
+	// Restore the standard's default white when the user hasn't overridden it,
+	// and ALWAYS for the fixed-matrix standards (HDTVa/HDTVb/CC6), locked to D65.
+	if(!m_changeWhiteCheck || m_colorStandard == HDTVa || m_colorStandard == HDTVb || m_colorStandard == CC6)
 		m_whiteTarget=(int)(GetStandardColorReference((ColorStandard)(m_colorStandard)).m_white);
     if (m_colorStandard == CUSTOM)
     {
@@ -1099,12 +1072,18 @@ void CReferencesPropPage::UpdateControlStates()
     static const UINT manualChkId[] = { IDC_USER_OVERRIDE_TARGS };
     EnableIds(this, manualChkId, 1, isHDR);
 
-    BOOL customW = (m_whiteTarget == DCUST);
+    // White-point dropdown is enabled directly (the old enabling checkbox is gone).
+    // HDTVa/HDTVb/CC6 are fixed-matrix calibration standards locked to D65: grey out
+    // the dropdown AND the x/y fields so the UI can't present an editable custom white
+    // for a standard that ignores it.
+    BOOL whiteLocked = (m_colorStandard == HDTVa || m_colorStandard == HDTVb || m_colorStandard == CC6);
+    BOOL customW = (m_whiteTarget == DCUST) && !whiteLocked;
     ShowBucket(m_bWhiteXY, TRUE);
     static const UINT whiteIds[] = { IDC_WHITE_X, IDC_WHITE_Y };
     ShowIds(this, whiteIds, 2, TRUE);
     m_manualWhitexedit.EnableWindow(customW);
     m_manualWhiteyedit.EnableWindow(customW);
+    if (m_whiteTargetCombo.GetSafeHwnd()) m_whiteTargetCombo.EnableWindow(!whiteLocked);
 
     BOOL customP = (m_colorStandard == CUSTOM);
     m_manualRedxedit.EnableWindow(customP);

--- a/ReferencesPropPage.h
+++ b/ReferencesPropPage.h
@@ -87,7 +87,6 @@ public:
 	CEdit	m_TargetMinLCtrl, m_TargetMaxLCtrl, m_DiffuseLCtrl, m_MasterMinLCtrl, m_MasterMaxLCtrl, m_ContentMaxLCtrl, m_FrameAvgMaxLCtrl, m_bOverRideTargsCtrl, m_useToneMapCtrl;
 	CEdit	m_TargetSysGammaCtrl, m_BT2390_BSCtrl, m_BT2390_WSCtrl, m_BT2390_WS1Ctrl;
 	BOOL	m_changeWhiteCheck;
-	CEdit	m_changeWhiteCheckCtrl;
 	BOOL	m_useMeasuredGamma;
 	BOOL	m_bSave;
 	BOOL	m_userBlack, m_useToneMap, m_bOverRideTargs;
@@ -135,7 +134,6 @@ protected:
 	afx_msg void OnChangeEditGammaRel();
 	afx_msg void OnChangeEditManualBlack();
 	afx_msg void OnChangeEditGammaAvg();
-	afx_msg void OnChangeWhiteCheck();
 	afx_msg void OnUseMeasuredGammaCheck();
 	afx_msg void OnUserBlackCheck();
 	afx_msg void OnUserOverRideTargsCheck();


### PR DESCRIPTION
Targeted for the **4.0.3.0** release.

## What
Restores the ability to choose a custom white point on Preferences → References, and tidies up the surrounding logic.

## Regression fixed
The References-page redesign hid the old "Change White" checkbox but left the white-point dropdown's enabled state gated on that (now-hidden) checkbox. For any standard whose default white equals its standard white (e.g. **Rec.709 = D65**), the dropdown stayed permanently greyed out, so a custom white was unreachable. The dropdown is now enabled directly.

## Changes
- **Enable the white-point dropdown** in `UpdateControlStates`; it stays locked only for the fixed-matrix calibration standards (HDTVa "75%", HDTVb "Plasma", CC6) which are anchored to D65.
- **Consistent locking** for those standards: force D65 and disable the x/y fields together, so the dropdown shows D65 (greyed) rather than a stale value, and x/y can't stay editable while the combo is greyed.
- Keep the internal "white overridden" flag honest when a white is picked, so a non-default white survives a later color-space switch.
- **Remove the now-dead** Change-White checkbox machinery (control member, click handler, message-map entry, DDX bindings); the hidden template control stays hidden.

## Verified
Confirmed on-screen: Rec.709 dropdown live and Custom enabling the x/y fields; 75%/Plasma showing D65 greyed with x/y disabled; a custom white persisting across a gamut change. Builds clean (Debug|Win32) on current `main`.

(Also includes a small `.gitignore` chore to ignore local-only planning docs.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)