### PR TITLE
High-DPI stats band fixes + coalesce live-chart repaints (4.0.3 review)

### DIFF
--- a/Controls/StatsBarWnd.cpp
+++ b/Controls/StatsBarWnd.cpp
@@ -15,6 +15,7 @@ static char THIS_FILE[] = __FILE__;
 #define STATSBAR_GAP		8	// horizontal gap between chips
 #define STATSBAR_TEXTPAD	12	// text padding inside a chip (each side)
 #define STATSBAR_VMARGIN	5	// top/bottom margin of a chip within the band
+#define STATSBAR_CHIPVPAD	6	// vertical slack between the text and the chip edge
 #define STATSBAR_FONTPT		10	// chip text size, points
 
 /////////////////////////////////////////////////////////////////////////////
@@ -172,6 +173,39 @@ BOOL CStatsBarWnd::OnEraseBkgnd(CDC* /*pDC*/)
 	return TRUE;	// fully painted in OnPaint (double-buffered)
 }
 
+// Build the larger bold chip font once (its height depends on screen DPI).
+void CStatsBarWnd::EnsureFont(CDC* pDC)
+{
+	if (m_font.m_hObject != NULL)
+		return;
+	LOGFONT lf;
+	ZeroMemory(&lf, sizeof(lf));
+	// GetFont() asserts on a not-yet-created window, and PreferredHeight() can be
+	// called before the band is created -- guard it (the band has no custom font,
+	// so this falls back to the default GUI font either way).
+	CFont* pBase = ::IsWindow(GetSafeHwnd()) ? GetFont() : NULL;
+	if (pBase == NULL || pBase->GetLogFont(&lf) == 0)
+		::GetObject(::GetStockObject(DEFAULT_GUI_FONT), sizeof(lf), &lf);
+	lf.lfHeight = -MulDiv(STATSBAR_FONTPT, pDC->GetDeviceCaps(LOGPIXELSY), 72);
+	lf.lfWidth = 0;
+	lf.lfWeight = FW_BOLD;
+	m_font.CreateFontIndirect(&lf);
+}
+
+// Band height needed so the DPI-scaled chip text clears the chip edges: the
+// scaled text height plus fixed chip + band padding. Only the text term scales
+// with DPI, so the band grows with the font but less than proportionally --
+// the chips get taller to fit the text without the padding ballooning.
+int CStatsBarWnd::PreferredHeight(CDC* pDC)
+{
+	EnsureFont(pDC);
+	CFont* pOld = pDC->SelectObject(&m_font);
+	TEXTMETRIC tm;
+	pDC->GetTextMetrics(&tm);
+	pDC->SelectObject(pOld);
+	return tm.tmHeight + 2 * (STATSBAR_VMARGIN + STATSBAR_CHIPVPAD);
+}
+
 void CStatsBarWnd::OnPaint()
 {
 	CPaintDC dc(this);
@@ -181,19 +215,7 @@ void CStatsBarWnd::OnPaint()
 	if (rc.Width() <= 0 || rc.Height() <= 0)
 		return;
 
-	// Build the larger bold chip font once (depends on screen DPI).
-	if (m_font.m_hObject == NULL)
-	{
-		LOGFONT lf;
-		ZeroMemory(&lf, sizeof(lf));
-		CFont* pBase = GetFont();
-		if (pBase == NULL || pBase->GetLogFont(&lf) == 0)
-			::GetObject(::GetStockObject(DEFAULT_GUI_FONT), sizeof(lf), &lf);
-		lf.lfHeight = -MulDiv(STATSBAR_FONTPT, dc.GetDeviceCaps(LOGPIXELSY), 72);
-		lf.lfWidth = 0;
-		lf.lfWeight = FW_BOLD;
-		m_font.CreateFontIndirect(&lf);
-	}
+	EnsureFont(&dc);
 
 	// Double-buffer to keep the header flicker-free during measurement updates.
 	CDC memDC;

--- a/Controls/StatsBarWnd.h
+++ b/Controls/StatsBarWnd.h
@@ -35,6 +35,11 @@ public:
 	// Feed the verbose summary string; it is split into display segments.
 	void SetSegmentedText(LPCTSTR lpszText);
 
+	// Height (px) the band needs so the DPI-scaled chip text is not clipped:
+	// the scaled text height plus fixed, modest padding -- so the band tracks
+	// the font but its padding does not balloon at high DPI.
+	int PreferredHeight(CDC* pDC);
+
 // Implementation
 public:
 	virtual ~CStatsBarWnd();
@@ -42,6 +47,7 @@ public:
 protected:
 	void Parse(LPCTSTR lpszText);
 	void AddGroup(const CString& strGroup, BOOL bSplitCommas);
+	void EnsureFont(CDC* pDC);	// build the bold chip font once (DPI-scaled)
 
 	CString			m_strText;	// last text received (to skip redundant repaints)
 	CStringArray	m_segments;	// parsed display segments

--- a/Views/CIEChartView.cpp
+++ b/Views/CIEChartView.cpp
@@ -2485,7 +2485,7 @@ void CCIEChartView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 		GetReferenceRect ( & Rect );
 		if (lHint != UPD_FREEMEASURES && lHint != UPD_REALTIME && lHint != UPD_FREEMEASUREAPPENDED && !GetDocument()->GetMeasure()->m_binMeasure)
 			m_Grapher.MakeBgBitmap(Rect,GetConfig()->m_bWhiteBkgndOnScreen);
-		RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW | RDW_ALLCHILDREN);
+		{ static DWORD s_liveTick = 0; UINT redrawFlags = RDW_INVALIDATE | RDW_ALLCHILDREN; DWORD nowTick = ::GetTickCount(); if ( nowTick - s_liveTick >= 33 ) { redrawFlags |= RDW_UPDATENOW; s_liveTick = nowTick; } RedrawWindow( NULL, NULL, redrawFlags ); }
 	}
 	else
 	{

--- a/Views/GammaHistoView.cpp
+++ b/Views/GammaHistoView.cpp
@@ -444,7 +444,7 @@ void CGammaHistoView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 	if ( lHint == UPD_EVERYTHING || lHint == UPD_GRAYSCALEANDCOLORS || lHint == UPD_GRAYSCALE || lHint == UPD_DATAREFDOC || lHint == UPD_REFERENCEDATA  || lHint == UPD_FREEMEASUREAPPENDED || lHint >= UPD_REALTIME)
 	{
 		m_Grapher.UpdateGraph ( GetDocument () );
-		RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW | RDW_ALLCHILDREN);
+		{ static DWORD s_liveTick = 0; UINT redrawFlags = RDW_INVALIDATE | RDW_ALLCHILDREN; DWORD nowTick = ::GetTickCount(); if ( nowTick - s_liveTick >= 33 ) { redrawFlags |= RDW_UPDATENOW; s_liveTick = nowTick; } RedrawWindow( NULL, NULL, redrawFlags ); }
 	}
 }
 

--- a/Views/MainView.cpp
+++ b/Views/MainView.cpp
@@ -833,12 +833,12 @@ void CMainView::OnInitialUpdate()
 				}
 			}
 
-			// Pull the whole lower half up to meet the (snug) top row, closing the
-			// gap the shorter panes would otherwise leave above the measures grid.
-			// Fixed-height controls move rigidly; bottom-anchored ones grow upward.
+			// Shift the whole lower half to align with the top row: UP to close a gap
+			// a shorter pane leaves, or DOWN to clear an overlap when the computed band
+			// is taller than the template (high DPI/font). Bottom-anchored ones grow/shrink.
 			int measTop = pGGrid->m_Rect.top;
 			int delta = (top + rowH + cfg->Scale(3)) - measTop;
-			if (delta < 0)
+			if (delta != 0)
 			{
 				POSITION rp2 = m_CtrlInitPos.GetHeadPosition();
 				while (rp2)
@@ -857,7 +857,8 @@ void CMainView::OnInitialUpdate()
 
 
 	{
-		const int HEADER_H = 38;
+		CClientDC sbHdrDC( this );
+		int HEADER_H = m_statsBar.PreferredHeight( &sbHdrDC );
 		CRect rcGroup( 0, 0, 0, 0 );
 		CRect rcGrid( 0, 0, 0, 0 );
 		POSITION sbPos = m_CtrlInitPos.GetHeadPosition();

--- a/Views/NearBlackHistoView.cpp
+++ b/Views/NearBlackHistoView.cpp
@@ -476,7 +476,7 @@ void CNearBlackHistoView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 	if ( lHint == UPD_EVERYTHING || lHint == UPD_GRAYSCALEANDCOLORS || lHint == UPD_GRAYSCALE || lHint == UPD_NEARBLACK || lHint == UPD_NEARWHITE || lHint == UPD_DATAREFDOC || lHint == UPD_REFERENCEDATA || lHint == UPD_ARRAYSIZES || lHint == UPD_FREEMEASUREAPPENDED || lHint >= UPD_REALTIME)
 	{
 		m_Grapher.UpdateGraph ( GetDocument () );
-		RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW | RDW_ALLCHILDREN);
+		{ static DWORD s_liveTick = 0; UINT redrawFlags = RDW_INVALIDATE | RDW_ALLCHILDREN; DWORD nowTick = ::GetTickCount(); if ( nowTick - s_liveTick >= 33 ) { redrawFlags |= RDW_UPDATENOW; s_liveTick = nowTick; } RedrawWindow( NULL, NULL, redrawFlags ); }
 	}
 }
 

--- a/Views/NearWhiteHistoView.cpp
+++ b/Views/NearWhiteHistoView.cpp
@@ -454,7 +454,7 @@ void CNearWhiteHistoView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 	if ( lHint == UPD_EVERYTHING || lHint == UPD_GRAYSCALEANDCOLORS || lHint == UPD_GRAYSCALE || lHint == UPD_NEARBLACK || lHint == UPD_NEARWHITE || lHint == UPD_DATAREFDOC || lHint == UPD_REFERENCEDATA || lHint == UPD_ARRAYSIZES || lHint == UPD_FREEMEASUREAPPENDED || lHint >= UPD_REALTIME)
 	{
 		m_Grapher.UpdateGraph ( GetDocument () );
-		RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW | RDW_ALLCHILDREN);
+		{ static DWORD s_liveTick = 0; UINT redrawFlags = RDW_INVALIDATE | RDW_ALLCHILDREN; DWORD nowTick = ::GetTickCount(); if ( nowTick - s_liveTick >= 33 ) { redrawFlags |= RDW_UPDATENOW; s_liveTick = nowTick; } RedrawWindow( NULL, NULL, redrawFlags ); }
 	}
 }
 

--- a/Views/SatLumHistoView.cpp
+++ b/Views/SatLumHistoView.cpp
@@ -403,7 +403,7 @@ void CSatLumHistoView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 
 	m_Grapher.UpdateGraph ( GetDocument () );
 
-	RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW | RDW_ALLCHILDREN);
+	{ static DWORD s_liveTick = 0; UINT redrawFlags = RDW_INVALIDATE | RDW_ALLCHILDREN; DWORD nowTick = ::GetTickCount(); if ( nowTick - s_liveTick >= 33 ) { redrawFlags |= RDW_UPDATENOW; s_liveTick = nowTick; } RedrawWindow( NULL, NULL, redrawFlags ); }
 }
 
 DWORD CSatLumHistoView::GetUserInfo ()

--- a/Views/SatLumShiftView.cpp
+++ b/Views/SatLumShiftView.cpp
@@ -743,7 +743,7 @@ void CSatLumShiftView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 
 	m_Grapher.UpdateGraph ( GetDocument () );
 
-	RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW | RDW_ALLCHILDREN);
+	{ static DWORD s_liveTick = 0; UINT redrawFlags = RDW_INVALIDATE | RDW_ALLCHILDREN; DWORD nowTick = ::GetTickCount(); if ( nowTick - s_liveTick >= 33 ) { redrawFlags |= RDW_UPDATENOW; s_liveTick = nowTick; } RedrawWindow( NULL, NULL, redrawFlags ); }
 }
 
 DWORD CSatLumShiftView::GetUserInfo ()

--- a/Views/colortemphistoview.cpp
+++ b/Views/colortemphistoview.cpp
@@ -185,7 +185,7 @@ void CColorTempHistoView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 	if ( lHint == UPD_EVERYTHING || lHint == UPD_GRAYSCALEANDCOLORS || lHint == UPD_GRAYSCALE || lHint == UPD_DATAREFDOC || lHint == UPD_REFERENCEDATA || lHint == UPD_FREEMEASUREAPPENDED || lHint >= UPD_REALTIME)
 	{
 		m_Grapher.UpdateGraph ( GetDocument () );
-		RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW | RDW_ALLCHILDREN);
+		{ static DWORD s_liveTick = 0; UINT redrawFlags = RDW_INVALIDATE | RDW_ALLCHILDREN; DWORD nowTick = ::GetTickCount(); if ( nowTick - s_liveTick >= 33 ) { redrawFlags |= RDW_UPDATENOW; s_liveTick = nowTick; } RedrawWindow( NULL, NULL, redrawFlags ); }
 	}
 }
 

--- a/Views/luminancehistoview.cpp
+++ b/Views/luminancehistoview.cpp
@@ -504,7 +504,7 @@ void CLuminanceHistoView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 	if ( lHint == UPD_EVERYTHING || lHint == UPD_GRAYSCALEANDCOLORS || lHint == UPD_GRAYSCALE || lHint == UPD_DATAREFDOC || lHint == UPD_REFERENCEDATA || lHint == UPD_ARRAYSIZES || lHint == UPD_FREEMEASUREAPPENDED || lHint >= UPD_REALTIME)
 	{
 		m_Grapher.UpdateGraph ( GetDocument () );
-		RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW | RDW_ALLCHILDREN);
+		{ static DWORD s_liveTick = 0; UINT redrawFlags = RDW_INVALIDATE | RDW_ALLCHILDREN; DWORD nowTick = ::GetTickCount(); if ( nowTick - s_liveTick >= 33 ) { redrawFlags |= RDW_UPDATENOW; s_liveTick = nowTick; } RedrawWindow( NULL, NULL, redrawFlags ); }
 	}
 }
 

--- a/Views/measureshistoview.cpp
+++ b/Views/measureshistoview.cpp
@@ -370,7 +370,7 @@ void CMeasuresHistoView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 		
 		m_graphCtrl.SetYAxisProps("", pow ( 10.0, (double) ( nFactor < 3 ? nTensScale - 1 : nTensScale ) ), 0, m_LumaMaxY * 2.0);
 	}
-	RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW | RDW_ALLCHILDREN);
+	{ static DWORD s_liveTick = 0; UINT redrawFlags = RDW_INVALIDATE | RDW_ALLCHILDREN; DWORD nowTick = ::GetTickCount(); if ( nowTick - s_liveTick >= 33 ) { redrawFlags |= RDW_UPDATENOW; s_liveTick = nowTick; } RedrawWindow( NULL, NULL, redrawFlags ); }
 }
 
 DWORD CMeasuresHistoView::GetUserInfo ()

--- a/Views/rgbhistoview.cpp
+++ b/Views/rgbhistoview.cpp
@@ -402,7 +402,7 @@ void CRGBHistoView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 	if ( lHint == UPD_EVERYTHING || lHint == UPD_GRAYSCALEANDCOLORS || lHint == UPD_GRAYSCALE || lHint == UPD_DATAREFDOC || lHint == UPD_REFERENCEDATA || lHint == UPD_ARRAYSIZES || lHint == UPD_GENERALREFERENCES || lHint == UPD_SENSORCONFIG || lHint == UPD_FREEMEASUREAPPENDED || lHint >= UPD_REALTIME)
 	{
 		m_Grapher.UpdateGraph ( GetDocument () );
-		RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW | RDW_ALLCHILDREN);
+		{ static DWORD s_liveTick = 0; UINT redrawFlags = RDW_INVALIDATE | RDW_ALLCHILDREN; DWORD nowTick = ::GetTickCount(); if ( nowTick - s_liveTick >= 33 ) { redrawFlags |= RDW_UPDATENOW; s_liveTick = nowTick; } RedrawWindow( NULL, NULL, redrawFlags ); }
 	}
 }
 


### PR DESCRIPTION
Fixes from the **4.0.3 ultra-review** of the work since 4.0.2.

## Changes
1. **MainView top-band overlaps the measures grid at high DPI.** The lower-half shift only ran when the computed band was *shorter* than the template (`delta < 0`); when it was *taller* (high DPI / large font / long captions) it painted over the grid. Now shifts on `delta != 0`, moving the grid down to clear the band. Normal-DPI English is unchanged (`delta < 0` path).

2. **Per-sample synchronous chart repaints.** The 10 histo/CIE `OnUpdate` handlers forced a synchronous full repaint (`RDW_UPDATENOW`) on every measurement sample. Now the forced repaint is throttled to ~30 fps (`RDW_INVALIDATE | RDW_ALLCHILDREN` still issued every time, so it stays flicker-free and live). Coalesces paints under fast continuous measures.
   - ⚠️ Note: a blanket removal of `RDW_UPDATENOW` was tried first but **broke live updates during continuous measures** (the worker-thread message queue never idles, so `WM_PAINT` starved). The throttle keeps live updates while capping the forced-paint rate.

3. **Stats chips clipped at high DPI.** The band height was a fixed 38px while the chip font scales with DPI, so text clipped at 200%. Band height is now derived from the font's text height + fixed padding (`CStatsBarWnd::PreferredHeight`) — scales with the font but the padding doesn't balloon. Also guarded `EnsureFont`'s `GetFont()` against a not-yet-created window (fixed a Debug-only assert on launch).

## Testing
Built Debug + Release clean (Win32). User-verified on-screen at 100 / 150 / 200% DPI: no band/grid overlap, chips size correctly with no text clipping, continuous measures + sweeps update live and flicker-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)