### PR TITLE
Fix empty dE/ref + xy/ref rows when reference doc has different grayscale step count

### DIFF
--- a/Views/MainView.cpp
+++ b/Views/MainView.cpp
@@ -3332,8 +3332,6 @@ void CMainView::UpdateGrid()
 				if ( pDataRef -> GetMeasure () -> GetGray ( nCount - 1 ).isValid() )
 					YWhiteGrayRefDoc = pDataRef -> GetMeasure () -> GetGray ( nCount - 1 ) [ 1 ];
 			}
-			else
-				pDataRef = NULL;
 
 		}
 


### PR DESCRIPTION
## Summary
- `UpdateGrid` was nullifying the local `pDataRef` whenever the reference doc's grayscale step count differed from the current doc's — even when the active view (Primaries/Secondaries, Saturations, Color Checker, Measurements, NearBlack, NearWhite) did not touch grayscale data.
- `InitGrid` did **not** apply that early guard, so the row labels "dE / ref" and "xy / ref" still appeared. Result: visible label, empty cells.
- Removed the over-broad `else pDataRef = NULL;` so UpdateGrid mirrors InitGrid. The remaining `if (refCount == nCount)` still safely guards the one access that indexes `pDataRef` by the current doc's grayscale size, and each per-mode branch already nullifies `pDataRef` on its own size mismatch when needed.

## Background
Regression originally introduced in 2015 by [ce53b749](https://github.com/pixelpusher15/hcfr-code/commit/ce53b749), which "fixed" a typo (`pDataRef == NULL;` no-op comparison) into a real assignment without noticing the guard was over-broad.

## Test plan
- [x] Debug|Win32 build clean (no new warnings).
- [x] Manually reproduced original bug: two docs with mismatched grayscale presets, mark one as Reference, switch to Primaries/Secondaries → before fix, "dE / ref" and "xy / ref" rows show labels but empty cells.
- [x] After fix: rows populate with expected values (e.g. when chromaticities match, xy/ref = 0.0000; when they differ, the value tracks the delta).
- [x] Grayscale view (mode 0) behavior unchanged — case-0's own size check at MainView.cpp:3358 still nullifies pDataRef on mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)