### PR TITLE
References: retitle HDR10 metadata group + scoped note

### DIFF
--- a/CHCFR21_DEUTSCH.rc
+++ b/CHCFR21_DEUTSCH.rc
@@ -653,7 +653,7 @@ BEGIN
     CTEXT           "Verbinde...",IDC_STATIC1,7,18,172,8
 END
 
-IDD_REFERENCE_PROP_PAGE DIALOGEX 0, 0, 280, 320
+IDD_REFERENCE_PROP_PAGE DIALOGEX 0, 0, 280, 350
 STYLE DS_SETFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
 CAPTION "Referenzen"
 FONT 8, "MS Sans Serif", 0, 0, 0x1
@@ -2909,7 +2909,7 @@ BEGIN
     IDS_REF_GRP_CCPATTERNS  "ColorChecker-Muster"
     IDS_REF_GRP_TARGETDISPLAY  "Ziel (Ihr Display)"
     IDS_REF_GRP_TONEMAP  "Tone-Mapping (BT.2390)"
-    IDS_REF_GRP_SIGNALMETA  "HDR10-Signalmetadaten (nur madVR-/Windows-HDR-Ausgabe)"
+    IDS_REF_GRP_SIGNALMETA  "HDR10-Signalmetadaten"
     IDS_REF_STANDARD  "Standard"
     IDS_REF_WHITEPOINT  "Weiﬂpunkt"
     IDS_REF_PRIMARIES  "Prim‰rfarben (xy)"
@@ -2938,7 +2938,7 @@ BEGIN
     IDS_REF_MASTERINGMAX  "Mastering max"
     IDS_REF_MAXCLL  "MaxCLL"
     IDS_REF_MAXFALL  "MaxFALL"
-    IDS_REF_METANOTE  "Sent to the HDR signal; no effect on Pi, manual, Ki or non-HDR10 output."
+    IDS_REF_METANOTE  "MaxCLL / MaxFALL are output metadata for madVR / Windows HDR only; Mastering min/max also affect the tone-mapped target on every output."
     IDS_TF_GAMMA_POWER  "Gamma (Potenzgesetz)"
     IDS_TF_GAMMA_BLACKCOMP  "Gamma (Schwarzkompensation)"
     IDS_TF_BT1886  "BT.1886"

--- a/CHCFR21_ENGLISH.rc
+++ b/CHCFR21_ENGLISH.rc
@@ -183,7 +183,7 @@ BEGIN
     PUSHBUTTON      "Help",IDHELP,140,154,49,14,WS_GROUP
 END
 
-IDD_REFERENCE_PROP_PAGE DIALOGEX 0, 0, 280, 320
+IDD_REFERENCE_PROP_PAGE DIALOGEX 0, 0, 280, 350
 STYLE DS_SETFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
 CAPTION "References"
 FONT 8, "MS Sans Serif", 0, 0, 0x1
@@ -2918,7 +2918,7 @@ BEGIN
     IDS_REF_GRP_CCPATTERNS  "ColorChecker patterns"
     IDS_REF_GRP_TARGETDISPLAY  "Target (your display)"
     IDS_REF_GRP_TONEMAP  "Tone mapping (BT.2390)"
-    IDS_REF_GRP_SIGNALMETA  "HDR10 signal metadata (madVR / Windows HDR output only)"
+    IDS_REF_GRP_SIGNALMETA  "HDR10 signal metadata"
     IDS_REF_STANDARD  "Standard"
     IDS_REF_WHITEPOINT  "White point"
     IDS_REF_PRIMARIES  "Primaries (xy)"
@@ -2947,7 +2947,7 @@ BEGIN
     IDS_REF_MASTERINGMAX  "Mastering max"
     IDS_REF_MAXCLL  "MaxCLL"
     IDS_REF_MAXFALL  "MaxFALL"
-    IDS_REF_METANOTE  "Sent to the HDR signal; no effect on Pi, manual, Ki or non-HDR10 output."
+    IDS_REF_METANOTE  "MaxCLL / MaxFALL are output metadata for madVR / Windows HDR only; Mastering min/max also affect the tone-mapped target on every output."
     IDS_TF_GAMMA_POWER  "Gamma (power law)"
     IDS_TF_GAMMA_BLACKCOMP  "Gamma (black compensation)"
     IDS_TF_BT1886  "BT.1886"

--- a/CHCFR21_ESPANOL.rc
+++ b/CHCFR21_ESPANOL.rc
@@ -263,7 +263,7 @@ BEGIN
     PUSHBUTTON      "Help",IDHELP,140,154,49,14,WS_GROUP
 END
 
-IDD_REFERENCE_PROP_PAGE DIALOGEX 0, 0, 280, 320
+IDD_REFERENCE_PROP_PAGE DIALOGEX 0, 0, 280, 350
 STYLE DS_SETFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
 CAPTION "References"
 FONT 8, "MS Sans Serif", 0, 0, 0x1
@@ -3040,7 +3040,7 @@ BEGIN
     IDS_REF_GRP_CCPATTERNS  "Patrones ColorChecker"
     IDS_REF_GRP_TARGETDISPLAY  "Objetivo (tu pantalla)"
     IDS_REF_GRP_TONEMAP  "Mapeo tonal (BT.2390)"
-    IDS_REF_GRP_SIGNALMETA  "Metadatos de señal HDR10 (solo salida madVR / Windows HDR)"
+    IDS_REF_GRP_SIGNALMETA  "Metadatos de señal HDR10"
     IDS_REF_STANDARD  "Estándar"
     IDS_REF_WHITEPOINT  "Punto blanco"
     IDS_REF_PRIMARIES  "Primarios (xy)"
@@ -3069,7 +3069,7 @@ BEGIN
     IDS_REF_MASTERINGMAX  "Masterización máx"
     IDS_REF_MAXCLL  "MaxCLL"
     IDS_REF_MAXFALL  "MaxFALL"
-    IDS_REF_METANOTE  "Sent to the HDR signal; no effect on Pi, manual, Ki or non-HDR10 output."
+    IDS_REF_METANOTE  "MaxCLL / MaxFALL are output metadata for madVR / Windows HDR only; Mastering min/max also affect the tone-mapped target on every output."
     IDS_TF_GAMMA_POWER  "Gamma (ley de potencia)"
     IDS_TF_GAMMA_BLACKCOMP  "Gamma (compensación de negro)"
     IDS_TF_BT1886  "BT.1886"

--- a/CHCFR21_FRANCAIS.rc
+++ b/CHCFR21_FRANCAIS.rc
@@ -598,7 +598,7 @@ BEGIN
     PUSHBUTTON      "Aide",IDHELP,140,154,49,14,WS_GROUP
 END
 
-IDD_REFERENCE_PROP_PAGE DIALOGEX 0, 0, 280, 320
+IDD_REFERENCE_PROP_PAGE DIALOGEX 0, 0, 280, 350
 STYLE DS_SETFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
 CAPTION "Références"
 FONT 8, "MS Sans Serif", 0, 0, 0x1
@@ -3132,7 +3132,7 @@ BEGIN
     IDS_REF_GRP_CCPATTERNS  "Mires ColorChecker"
     IDS_REF_GRP_TARGETDISPLAY  "Cible (votre écran)"
     IDS_REF_GRP_TONEMAP  "Mappage tonal (BT.2390)"
-    IDS_REF_GRP_SIGNALMETA  "Métadonnées du signal HDR10 (sortie madVR / Windows HDR uniquement)"
+    IDS_REF_GRP_SIGNALMETA  "Métadonnées du signal HDR10"
     IDS_REF_STANDARD  "Standard"
     IDS_REF_WHITEPOINT  "Point blanc"
     IDS_REF_PRIMARIES  "Primaires (xy)"
@@ -3161,7 +3161,7 @@ BEGIN
     IDS_REF_MASTERINGMAX  "Mastering max"
     IDS_REF_MAXCLL  "MaxCLL"
     IDS_REF_MAXFALL  "MaxFALL"
-    IDS_REF_METANOTE  "Sent to the HDR signal; no effect on Pi, manual, Ki or non-HDR10 output."
+    IDS_REF_METANOTE  "MaxCLL / MaxFALL are output metadata for madVR / Windows HDR only; Mastering min/max also affect the tone-mapped target on every output."
     IDS_TF_GAMMA_POWER  "Gamma (loi de puissance)"
     IDS_TF_GAMMA_BLACKCOMP  "Gamma (compensation du noir)"
     IDS_TF_BT1886  "BT.1886"

--- a/CHCFR21_ITALIAN.rc
+++ b/CHCFR21_ITALIAN.rc
@@ -183,7 +183,7 @@ BEGIN
     PUSHBUTTON      "Aiuto",IDHELP,140,154,49,14,WS_GROUP
 END
 
-IDD_REFERENCE_PROP_PAGE DIALOGEX 0, 0, 280, 320
+IDD_REFERENCE_PROP_PAGE DIALOGEX 0, 0, 280, 350
 STYLE DS_SETFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
 CAPTION "Riferimenti"
 FONT 8, "MS Sans Serif", 0, 0, 0x1
@@ -3118,7 +3118,7 @@ BEGIN
     IDS_REF_GRP_CCPATTERNS  "Pattern ColorChecker"
     IDS_REF_GRP_TARGETDISPLAY  "Target (il tuo display)"
     IDS_REF_GRP_TONEMAP  "Mappatura tonale (BT.2390)"
-    IDS_REF_GRP_SIGNALMETA  "Metadati segnale HDR10 (solo uscita madVR / Windows HDR)"
+    IDS_REF_GRP_SIGNALMETA  "Metadati segnale HDR10"
     IDS_REF_STANDARD  "Standard"
     IDS_REF_WHITEPOINT  "Punto bianco"
     IDS_REF_PRIMARIES  "Primari (xy)"
@@ -3147,7 +3147,7 @@ BEGIN
     IDS_REF_MASTERINGMAX  "Mastering max"
     IDS_REF_MAXCLL  "MaxCLL"
     IDS_REF_MAXFALL  "MaxFALL"
-    IDS_REF_METANOTE  "Sent to the HDR signal; no effect on Pi, manual, Ki or non-HDR10 output."
+    IDS_REF_METANOTE  "MaxCLL / MaxFALL are output metadata for madVR / Windows HDR only; Mastering min/max also affect the tone-mapped target on every output."
     IDS_TF_GAMMA_POWER  "Gamma (legge di potenza)"
     IDS_TF_GAMMA_BLACKCOMP  "Gamma (compensazione del nero)"
     IDS_TF_BT1886  "BT.1886"

--- a/ReferencesPropPage.cpp
+++ b/ReferencesPropPage.cpp
@@ -989,7 +989,7 @@ void CReferencesPropPage::BuildRuntimeLayout()
     MoveDlg(this, IDC_EDIT_TARGET_MAXL4, M, 140, 188, 22, 12);
 
     // --- HDR10 signal metadata (PQ only) ---
-    AddGroup(this, m_dynAll, &m_bPQ, font, M, IDS_REF_GRP_SIGNALMETA, 10, 234, 260, 42);
+    AddGroup(this, m_dynAll, &m_bPQ, font, M, IDS_REF_GRP_SIGNALMETA, 10, 234, 260, 66);
     AddText(this, m_dynAll, &m_bPQ, font, M, LS(IDS_REF_MASTERINGMIN), 16, 244, 62, 9);
     MoveDlg(this, IDC_EDIT_MASTER_MINL, M, 16, 254, 44, 12);
     AddText(this, m_dynAll, &m_bPQ, font, M, LS(IDS_REF_MASTERINGMAX), 82, 244, 62, 9);
@@ -998,6 +998,7 @@ void CReferencesPropPage::BuildRuntimeLayout()
     MoveDlg(this, IDC_EDIT_CONTENT_MAXL, M, 148, 254, 44, 12);
     AddText(this, m_dynAll, &m_bPQ, font, M, LS(IDS_REF_MAXFALL), 214, 244, 54, 9);
     MoveDlg(this, IDC_EDIT_FRAME_AVG_MAXL, M, 214, 254, 44, 12);
+    AddText(this, m_dynAll, &m_bPQ, font, M, LS(IDS_REF_METANOTE), 16, 268, 248, 26);
 
     // ===== Section 3: ColorChecker patterns =====
     m_pCCGroup = AddGroup(this, m_dynAll, NULL, font, M, IDS_REF_GRP_CCPATTERNS, 5, 232, 270, 30);
@@ -1106,7 +1107,7 @@ void CReferencesPropPage::UpdateControlStates()
     else if (isBT1886)  tfBottom = 146;
     else if (isLstar)   tfBottom = 128;
     else if (isHLG)     tfBottom = 168;
-    else                tfBottom = 282;
+    else                tfBottom = 306;
     MoveWnd(m_pTFGroup, M, 5, 80, 270, tfBottom - 80);
     MoveWnd(m_pCCGroup, M, 5, tfBottom + 6, 270, 30);
     MoveDlg(this, IDC_CCMODE_COMBO, M, 12, tfBottom + 18, 200, 100);


### PR DESCRIPTION
## What
Fixes the misleading **"HDR10 signal metadata (madVR / Windows HDR output only)"** group label on the References page.

## Why
The parenthetical is wrong for **Mastering min/max**: those feed the tone-mapped PQ target curve (`getL_EOTF`, mode 10 / BT.2390) on **every** output — including a Pi / PGenerator measurement — not just the madVR / Windows-HDR signal. Only **MaxCLL / MaxFALL** are pure output metadata (reach only madVR + the Windows-HDR DXGI path, `GDIGenerator.cpp:576-579` / `:648`).

## Changes
- **Title** → just "HDR10 signal metadata" (parenthetical dropped, all 5 languages).
- **Note under the fields** (`IDS_REF_METANOTE`, previously defined but never rendered):
  > MaxCLL / MaxFALL are output metadata for madVR / Windows HDR only; Mastering min/max also affect the tone-mapped target on every output.
- `ReferencesPropPage.cpp`: draw the note (PQ-only bucket), grow the metadata group (42->66 dlu) and PQ `tfBottom` (282->306).
- `CHCFR21_*.rc`: References template height 320->350 dlu so the note fits.

## Notes / verification
- Builds clean Debug|Win32 (0 errors). Verified on-screen in English: title + note render, no clipping, ColorChecker group below still has room.
- The note is **byte-identical across all 5 languages** in a language-independent layout box, so it renders the same everywhere — English fitting means all fit.
- `IDS_REF_METANOTE` is English in all 5 (it was already English-only pre-redesign). Proper ES/FR/DE/IT translation is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
