### PR TITLE
Add gamut coverage chips to the CIE chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ Tools/libusb1/libusb/os/libusb-X.X.def
 Tools/libusb1/libusb/os/makefile
 Tools/libusb1/libusb/os/objfre_wlh_amd64/
 Tools/libusb1/libusb/os/objfre_wxp_x86/
-UnitTests/tests.xml
+tests.xml
 
 
 /.vs

--- a/Controls/TargetWnd.cpp
+++ b/Controls/TargetWnd.cpp
@@ -34,6 +34,7 @@
 #include <algorithm>
 #include <gdiplus.h>
 #pragma comment(lib, "gdiplus.lib")
+#include "GdiPlusAA.h"
 
 #ifdef _DEBUG
 #define new DEBUG_NEW
@@ -832,33 +833,7 @@ static const WCHAR * DeltaEFormulaName()
 	return L"";
 }
 
-// Draws a pill chip anchored by its bottom-right corner and returns its width
-// (so a row of chips can grow leftward from the corner).
-static Gdiplus::REAL DrawChip(Gdiplus::Graphics & g, const Gdiplus::Font & font, const WCHAR * text,
-					 Gdiplus::REAL right, Gdiplus::REAL bottom,
-					 const Gdiplus::Color & fill, const Gdiplus::Color & border, const Gdiplus::Color & textClr)
-{
-	Gdiplus::RectF bounds;
-	g.MeasureString(text, -1, &font, Gdiplus::PointF(0.0f, 0.0f), &bounds);
-	Gdiplus::REAL padX = font.GetSize() * 0.55f;
-	Gdiplus::REAL padY = font.GetSize() * 0.24f;
-	Gdiplus::REAL w = bounds.Width + 2.0f * padX;
-	Gdiplus::REAL h = bounds.Height + 2.0f * padY;
-	Gdiplus::REAL x = right - w;
-	Gdiplus::REAL y = bottom - h;
-	Gdiplus::REAL r = h / 2.0f;	// pill
-	Gdiplus::GraphicsPath path;
-	path.AddArc(x, y, 2.0f * r, 2.0f * r, 90.0f, 180.0f);
-	path.AddArc(x + w - 2.0f * r, y, 2.0f * r, 2.0f * r, 270.0f, 180.0f);
-	path.CloseFigure();
-	Gdiplus::SolidBrush fillBrush(fill);
-	g.FillPath(&fillBrush, &path);
-	Gdiplus::Pen borderPen(border, 1.0f);
-	g.DrawPath(&borderPen, &path);
-	Gdiplus::SolidBrush textBrush(textClr);
-	g.DrawString(text, -1, &font, Gdiplus::PointF(x + padX, y + padY), &textBrush);
-	return w;
-}
+// Pill stat chips are drawn with the shared DrawStatChip helper (GdiPlusAA.h).
 
 void CTargetWnd::OnPaint()
 {
@@ -954,7 +929,7 @@ void CTargetWnd::OnPaint()
 	if ( !compact )
 	{
 		g.SetTextRenderingHint(Gdiplus::TextRenderingHintAntiAlias);
-		Gdiplus::REAL chipFontPx = (Gdiplus::REAL)max(12.0, 0.052 * R + 1.0);
+		Gdiplus::REAL chipFontPx = (Gdiplus::REAL)max(14.0, 0.058 * R + 1.0);
 		Gdiplus::Font chipFont(L"Segoe UI", chipFontPx, Gdiplus::FontStyleRegular, Gdiplus::UnitPixel);
 		const Gdiplus::REAL pad = 8.0f;
 
@@ -973,13 +948,13 @@ void CTargetWnd::OnPaint()
 		Gdiplus::REAL xRight = (Gdiplus::REAL)rect.Width() - pad;
 		Gdiplus::REAL yBottom = (Gdiplus::REAL)rect.Height() - pad;
 		swprintf_s(buf, 64, L"dE %.1f", m_deltaE);
-		Gdiplus::REAL wChip = DrawChip(g, chipFont, buf, xRight, yBottom, chipFill, chipBorder, chipText);
+		Gdiplus::REAL wChip = DrawStatChip(g, chipFont, buf, xRight, yBottom, chipFill, chipBorder, chipText);
 
 		Gdiplus::Color nFill   = bDark ? Gdiplus::Color(255, 42, 42, 42)    : Gdiplus::Color(255, 255, 255, 255);
 		Gdiplus::Color nBorder = bDark ? Gdiplus::Color(255, 72, 72, 72)    : Gdiplus::Color(255, 205, 207, 213);
 		Gdiplus::Color nText   = bDark ? Gdiplus::Color(255, 215, 215, 215) : Gdiplus::Color(255, 70, 74, 80);
 		swprintf_s(buf, 64, L"dx %+.1f%%   dy %+.1f%%", m_deltax * 100.0, m_deltay * 100.0);
-		DrawChip(g, chipFont, buf, xRight - wChip - 6.0f, yBottom, nFill, nBorder, nText);
+		DrawStatChip(g, chipFont, buf, xRight - wChip - 6.0f, yBottom, nFill, nBorder, nText);
 
 		// ring formula note, plain muted text (localized prefix)
 		Gdiplus::REAL noteFontPx = (Gdiplus::REAL)max(11.0, 0.055 * R);

--- a/UnitTests/GamutCoverage_unittests.cpp
+++ b/UnitTests/GamutCoverage_unittests.cpp
@@ -1,0 +1,101 @@
+#include "GamutCoverage.h"
+#include <math.h>
+#include <cppunit/config/SourcePrefix.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+#define THIS_TEST_CASE GamutCoverageTestCase
+
+namespace
+{
+    // Reference primaries (xy), matching libHCFR/Color.cpp
+    const ColorxyY rec709[3]  = { ColorxyY(0.6400, 0.3300), ColorxyY(0.3000, 0.6000), ColorxyY(0.1500, 0.0600) };
+    const ColorxyY p3[3]      = { ColorxyY(0.6800, 0.3200), ColorxyY(0.2650, 0.6900), ColorxyY(0.1500, 0.0600) };
+    const ColorxyY rec2020[3] = { ColorxyY(0.7080, 0.2920), ColorxyY(0.1700, 0.7970), ColorxyY(0.1310, 0.0460) };
+}
+
+class THIS_TEST_CASE : public CPPUNIT_NS::TestFixture
+{
+    CPPUNIT_TEST_SUITE(THIS_TEST_CASE);
+    CPPUNIT_TEST( SelfCoverageTest );
+    CPPUNIT_TEST( ContainmentTest );
+    CPPUNIT_TEST( PartialOverlapTest );
+    CPPUNIT_TEST( DegenerateTest );
+    CPPUNIT_TEST( WindingInvarianceTest );
+    CPPUNIT_TEST( UvPlaneTest );
+    CPPUNIT_TEST( xyToUvTest );
+    CPPUNIT_TEST_SUITE_END();
+
+protected:
+
+    void SelfCoverageTest()
+    {
+        // a gamut covers itself exactly, in both planes
+        CPPUNIT_ASSERT_DOUBLES_EQUAL( 1.0, GamutCoverage(rec709, rec709, GAMUT_PLANE_XY), 1e-12 );
+        CPPUNIT_ASSERT_DOUBLES_EQUAL( 1.0, GamutCoverage(p3, p3, GAMUT_PLANE_XY), 1e-12 );
+        CPPUNIT_ASSERT_DOUBLES_EQUAL( 1.0, GamutCoverage(rec2020, rec2020, GAMUT_PLANE_UV), 1e-12 );
+    }
+
+    void ContainmentTest()
+    {
+        // Rec.709 is entirely inside Rec.2020: 2020 fully covers 709...
+        CPPUNIT_ASSERT_DOUBLES_EQUAL( 1.0, GamutCoverage(rec2020, rec709, GAMUT_PLANE_XY), 1e-9 );
+        CPPUNIT_ASSERT_DOUBLES_EQUAL( 1.0, GamutCoverage(rec2020, rec709, GAMUT_PLANE_UV), 1e-9 );
+        // ...but 709 covers well under 100% of 2020, and P3 sits in between
+        double c709 = GamutCoverage(rec709, rec2020, GAMUT_PLANE_XY);
+        double cP3  = GamutCoverage(p3, rec2020, GAMUT_PLANE_XY);
+        CPPUNIT_ASSERT( c709 > 0.30 && c709 < 0.60 );
+        CPPUNIT_ASSERT( cP3 > c709 && cP3 < 1.0 );
+    }
+
+    void PartialOverlapTest()
+    {
+        // right triangle with legs 1, clipped by its own mirror shifted so the
+        // intersection is analytic: clip square-ish case via known triangles
+        const ColorxyY tri[3]     = { ColorxyY(0.0, 0.0), ColorxyY(1.0, 0.0), ColorxyY(0.0, 1.0) };
+        const ColorxyY shifted[3] = { ColorxyY(0.5, 0.0), ColorxyY(1.5, 0.0), ColorxyY(0.5, 1.0) };
+        // intersection of tri and shifted: triangle (0.5,0),(1,0),(0.5,0.5) with area 0.125
+        // reference area = 0.5, so coverage = 0.25
+        CPPUNIT_ASSERT_DOUBLES_EQUAL( 0.25, GamutCoverage(shifted, tri, GAMUT_PLANE_XY), 1e-12 );
+        // and disjoint triangles give zero
+        const ColorxyY disjoint[3] = { ColorxyY(5.0, 5.0), ColorxyY(6.0, 5.0), ColorxyY(5.0, 6.0) };
+        CPPUNIT_ASSERT_DOUBLES_EQUAL( 0.0, GamutCoverage(disjoint, tri, GAMUT_PLANE_XY), 1e-12 );
+    }
+
+    void DegenerateTest()
+    {
+        // collinear measured primaries -> zero coverage, no crash
+        const ColorxyY line[3] = { ColorxyY(0.1, 0.1), ColorxyY(0.2, 0.2), ColorxyY(0.3, 0.3) };
+        CPPUNIT_ASSERT_DOUBLES_EQUAL( 0.0, GamutCoverage(line, rec709, GAMUT_PLANE_XY), 1e-12 );
+        CPPUNIT_ASSERT_DOUBLES_EQUAL( 0.0, GamutCoverage(rec709, line, GAMUT_PLANE_XY), 1e-12 );
+    }
+
+    void WindingInvarianceTest()
+    {
+        // vertex order must not matter
+        const ColorxyY swapped[3] = { ColorxyY(0.1500, 0.0600), ColorxyY(0.3000, 0.6000), ColorxyY(0.6400, 0.3300) };
+        CPPUNIT_ASSERT_DOUBLES_EQUAL( GamutCoverage(rec709, rec2020, GAMUT_PLANE_XY),
+                                      GamutCoverage(swapped, rec2020, GAMUT_PLANE_XY), 1e-12 );
+        CPPUNIT_ASSERT_DOUBLES_EQUAL( 1.0, GamutCoverage(swapped, rec709, GAMUT_PLANE_XY), 1e-12 );
+    }
+
+    void UvPlaneTest()
+    {
+        // xy and u'v' coverages differ for non-trivial pairs (sanity that the
+        // plane parameter actually changes the projection)
+        double xy = GamutCoverage(rec709, rec2020, GAMUT_PLANE_XY);
+        double uv = GamutCoverage(rec709, rec2020, GAMUT_PLANE_UV);
+        CPPUNIT_ASSERT( uv > 0.0 && uv < 1.0 );
+        CPPUNIT_ASSERT( fabs(xy - uv) > 0.01 );
+    }
+
+    void xyToUvTest()
+    {
+        // D65 white: x=0.3127, y=0.3290 -> u'=0.1978, v'=0.4683
+        double u, v;
+        xyToUv(0.3127, 0.3290, u, v);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL( 0.1978, u, 5e-5 );
+        CPPUNIT_ASSERT_DOUBLES_EQUAL( 0.4683, v, 5e-5 );
+    }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(THIS_TEST_CASE);

--- a/UnitTests/UnitTests.vcxproj
+++ b/UnitTests/UnitTests.vcxproj
@@ -104,6 +104,7 @@
   <ItemGroup>
     <ClCompile Include="ArgyllMeterWrapper_unittests.cpp" />
     <ClCompile Include="Color_unittests.cpp" />
+    <ClCompile Include="GamutCoverage_unittests.cpp" />
     <ClCompile Include="MatrixAdjustment_unittests.cpp" />
     <ClCompile Include="spectro_unittests.cpp" />
     <ClCompile Include="UnitTests.cpp" />

--- a/UnitTests/UnitTests.vcxproj.filters
+++ b/UnitTests/UnitTests.vcxproj.filters
@@ -21,6 +21,9 @@
     <ClCompile Include="Color_unittests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="GamutCoverage_unittests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="MatrixAdjustment_unittests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/Views/CIEChartView.cpp
+++ b/Views/CIEChartView.cpp
@@ -32,6 +32,7 @@
 #include "savegraphdialog.h"
 #include "graphcontrol.h"
 #include "GdiPlusAA.h"
+#include "GamutCoverage.h"
 #include "Views\MainView.h"
 
 #ifdef _DEBUG
@@ -158,6 +159,8 @@ CCIEChartGrapher::CCIEChartGrapher()
 	m_DeltaY = 0;
 	dE10 = 0.;
 	isSat = FALSE;
+
+	m_covValid = FALSE;
 
 	m_pMarkerGraphics = NULL;
 	m_markerScale = 1.0f;
@@ -1707,6 +1710,113 @@ void CCIEChartGrapher::DrawChart(CDataSetDoc * pDoc, CDC* pDC, CRect rect, CPPTo
 			pDC->TextOut(colorTempPoint2700.GetGraphX(rect)-2,colorTempPoint2700.GetGraphY(rect)-2,"2700");
 
 			pDC->SelectObject(pOldFont);
+		}
+
+		// Gamut coverage chips (top right): [gamut] [xy: n%] [u'v': n%]. The
+		// gamut-name chip always shows; the coverage percentages are the measured
+		// primaries triangle vs the displayed reference triangle (area
+		// intersection / reference area) in xy and u'v'. Not shown in CIE a*b*
+		// mode (the metric is a chromaticity-plane one). The percentages hide
+		// when the gamut is changed until the primaries are re-measured, since
+		// old primaries don't belong to the new reference.
+		if (!m_bCIEab && min(rect.Width(),rect.Height()) > FX_MINSIZETOSHOW_REFDETAILS)
+		{
+			// Short names for the mainstream gamuts; everything else (incl. the
+			// reduced-primary HDTVa/HDTVb pseudo-gamuts) uses its own reference
+			// name so the label always matches the triangle actually drawn.
+			WCHAR gamutName[64];
+			switch (GetColorReference().m_standard)
+			{
+				case HDTV: case UHDTV4: wcscpy_s(gamutName, L"Rec.709");  break;
+				case UHDTV: case UHDTV3: wcscpy_s(gamutName, L"DCI-P3");   break;
+				case UHDTV2:            wcscpy_s(gamutName, L"Rec.2020");  break;
+				default:
+					swprintf_s(gamutName, 64, L"%S", GetColorReference().GetName().c_str());
+					break;
+			}
+
+			// Decide whether the coverage percentages are current. They are stale
+			// (and hidden) if the reference standard changed while the measured
+			// primaries stayed put -- i.e. the gamut was switched without a fresh
+			// measurement. Re-measuring changes the primaries and re-shows them.
+			ColorStandard curStd = GetColorReference().m_standard;
+			BOOL showPct = FALSE;
+			double covXY = 0.0, covUV = 0.0;
+			if (hasPrimaries)
+			{
+				BOOL primsSame = m_covValid
+					&& redPrimaryColor[0]   == m_covPrimaries[0][0] && redPrimaryColor[1]   == m_covPrimaries[0][1] && redPrimaryColor[2]   == m_covPrimaries[0][2]
+					&& greenPrimaryColor[0] == m_covPrimaries[1][0] && greenPrimaryColor[1] == m_covPrimaries[1][1] && greenPrimaryColor[2] == m_covPrimaries[1][2]
+					&& bluePrimaryColor[0]  == m_covPrimaries[2][0] && bluePrimaryColor[1]  == m_covPrimaries[2][1] && bluePrimaryColor[2]  == m_covPrimaries[2][2];
+				BOOL stdSame = m_covValid && (m_covStandard == curStd);
+
+				if (m_covValid && !stdSame && primsSame)
+				{
+					showPct = FALSE;	// gamut changed, primaries not re-measured
+				}
+				else
+				{
+					showPct = TRUE;
+					ColorxyY measured[3] = { ColorxyY(redPrimaryColor),
+											 ColorxyY(greenPrimaryColor),
+											 ColorxyY(bluePrimaryColor) };
+					// the triangle drawn on the chart is the active reference's primaries
+					// (for P3/709 inside a 2020 container these are already the inner gamut)
+					ColorxyY refTri[3] = { ColorxyY(GetColorReference().GetRed()),
+										   ColorxyY(GetColorReference().GetGreen()),
+										   ColorxyY(GetColorReference().GetBlue()) };
+					covXY = GamutCoverage(measured, refTri, GAMUT_PLANE_XY) * 100.0;
+					covUV = GamutCoverage(measured, refTri, GAMUT_PLANE_UV) * 100.0;
+					m_covStandard = curStd;
+					m_covPrimaries[0] = redPrimaryColor;
+					m_covPrimaries[1] = greenPrimaryColor;
+					m_covPrimaries[2] = bluePrimaryColor;
+					m_covValid = TRUE;
+				}
+			}
+
+			// Pill stat chips like the target widget's, anchored top right,
+			// growing leftward from the corner.
+			EnsureGdiplus();
+			Gdiplus::Graphics g(pDC->GetSafeHdc());
+			GpApplyDCOrigin(g, pDC);
+			g.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
+			g.SetTextRenderingHint(Gdiplus::TextRenderingHintAntiAlias);
+			Gdiplus::Font chipFont(L"Segoe UI", 15.0f, Gdiplus::FontStyleRegular, Gdiplus::UnitPixel);
+
+			// neutral chip palette shared with the target widget's dx/dy chip
+			BOOL bDark = !m_bgWhite;
+			Gdiplus::Color nFill   = bDark ? Gdiplus::Color(255, 42, 42, 42)    : Gdiplus::Color(255, 255, 255, 255);
+			Gdiplus::Color nBorder = bDark ? Gdiplus::Color(255, 72, 72, 72)    : Gdiplus::Color(255, 205, 207, 213);
+			Gdiplus::Color nText   = bDark ? Gdiplus::Color(255, 215, 215, 215) : Gdiplus::Color(255, 70, 74, 80);
+
+			// Visual order left-to-right is [gamut] [xy] [u'v']; priority is the
+			// reverse, so if the row can't fit the chart width drop u'v' first,
+			// then xy, always keeping the gamut name.
+			WCHAR uvBuf[64], xyBuf[64];
+			const WCHAR * ordered[3];
+			int nChips = 0;
+			ordered[nChips++] = gamutName;
+			if (showPct)
+			{
+				swprintf_s(xyBuf, 64, L"xy: %.1f%%", covXY);
+				swprintf_s(uvBuf, 64, L"u'v': %.1f%%", covUV);
+				ordered[nChips++] = xyBuf;
+				ordered[nChips++] = uvBuf;
+			}
+
+			const Gdiplus::REAL pad = 8.0f, gap = 6.0f;
+			Gdiplus::REAL avail = (Gdiplus::REAL)rect.Width() - 2.0f * pad;
+			Gdiplus::REAL total = 0.0f;
+			for (int i = 0; i < nChips; i++)
+				total += MeasureStatChip(g, chipFont, ordered[i]).Width + (i ? gap : 0.0f);
+			while (nChips > 1 && total > avail)	// drop lowest-priority (rightmost) chips
+				total -= MeasureStatChip(g, chipFont, ordered[--nChips]).Width + gap;
+
+			Gdiplus::REAL bottom = (Gdiplus::REAL)rect.top + pad + MeasureStatChip(g, chipFont, gamutName).Height;
+			Gdiplus::REAL xRight = (Gdiplus::REAL)rect.right - pad;
+			for (int i = nChips - 1; i >= 0; i--)	// draw right to left
+				xRight -= DrawStatChip(g, chipFont, ordered[i], xRight, bottom, nFill, nBorder, nText) + gap;
 		}
 
 		if(hasPrimaries && hasSecondaries && !m_bCIEab)

--- a/Views/GdiPlusAA.h
+++ b/Views/GdiPlusAA.h
@@ -47,6 +47,48 @@ inline void GpApplyDCOrigin(Gdiplus::Graphics & g, CDC *pDC)
 		g.TranslateTransform((float)(vo.x - wo.x), (float)(vo.y - wo.y));
 }
 
+// Chip padding as a fraction of the font size (horizontal, vertical).
+static const float STATCHIP_PADX_FRAC = 0.55f;
+static const float STATCHIP_PADY_FRAC = 0.24f;
+
+// Size of a stat chip (pill) for the given text, padding included.
+inline Gdiplus::SizeF MeasureStatChip(Gdiplus::Graphics & g, const Gdiplus::Font & font, const WCHAR * text)
+{
+	Gdiplus::RectF bounds;
+	g.MeasureString(text, -1, &font, Gdiplus::PointF(0.0f, 0.0f), &bounds);
+	return Gdiplus::SizeF(bounds.Width + 2.0f * font.GetSize() * STATCHIP_PADX_FRAC,
+						  bounds.Height + 2.0f * font.GetSize() * STATCHIP_PADY_FRAC);
+}
+
+// Draws a pill stat chip anchored by its bottom-right corner and returns its
+// width (so a row of chips can grow leftward from the corner). Shared by the
+// target widget and the CIE chart coverage readout.
+inline Gdiplus::REAL DrawStatChip(Gdiplus::Graphics & g, const Gdiplus::Font & font, const WCHAR * text,
+					 Gdiplus::REAL right, Gdiplus::REAL bottom,
+					 const Gdiplus::Color & fill, const Gdiplus::Color & border, const Gdiplus::Color & textClr)
+{
+	Gdiplus::RectF bounds;
+	g.MeasureString(text, -1, &font, Gdiplus::PointF(0.0f, 0.0f), &bounds);
+	Gdiplus::REAL padX = font.GetSize() * STATCHIP_PADX_FRAC;
+	Gdiplus::REAL padY = font.GetSize() * STATCHIP_PADY_FRAC;
+	Gdiplus::REAL w = bounds.Width + 2.0f * padX;
+	Gdiplus::REAL h = bounds.Height + 2.0f * padY;
+	Gdiplus::REAL x = right - w;
+	Gdiplus::REAL y = bottom - h;
+	Gdiplus::REAL r = h / 2.0f;	// pill
+	Gdiplus::GraphicsPath path;
+	path.AddArc(x, y, 2.0f * r, 2.0f * r, 90.0f, 180.0f);
+	path.AddArc(x + w - 2.0f * r, y, 2.0f * r, 2.0f * r, 270.0f, 180.0f);
+	path.CloseFigure();
+	Gdiplus::SolidBrush fillBrush(fill);
+	g.FillPath(&fillBrush, &path);
+	Gdiplus::Pen borderPen(border, 1.0f);
+	g.DrawPath(&borderPen, &path);
+	Gdiplus::SolidBrush textBrush(textClr);
+	g.DrawString(text, -1, &font, Gdiplus::PointF(x + padX, y + padY), &textBrush);
+	return w;
+}
+
 // Anti-aliased drop-in for the CDC MoveTo/LineTo pattern used by the charts.
 // Wraps a Graphics + Pen over the target DC and keeps the current position.
 class CAAPolyline

--- a/Views/ciechartview.h
+++ b/Views/ciechartview.h
@@ -132,6 +132,14 @@ class CCIEChartGrapher
 	BOOL	m_bgWhite, m_bgUv, m_bgAb, m_bgShowBg, m_bgShowDE;
 	double	m_bgWhitex, m_bgWhitey;
 
+	// Gamut-coverage chip staleness tracking: the standard and measured
+	// primaries the last shown coverage % was computed for. When the gamut is
+	// changed but the primaries have not been re-measured, the percentages are
+	// hidden (the gamut-name chip still shows).
+	BOOL			m_covValid;
+	ColorStandard	m_covStandard;
+	ColorXYZ		m_covPrimaries[3];
+
 	// Zoom handling, for window mode
 	UINT	m_ZoomFactor;	// Zoom factor = 1000 for 1:1 scale, 2000 for 2x zoom, and so on
 	int		m_DeltaX;		// When zoom active, delta values for picture scrolling in pixels

--- a/libHCFR/GamutCoverage.cpp
+++ b/libHCFR/GamutCoverage.cpp
@@ -1,0 +1,137 @@
+///////////////////////////////////////////////////////////////////////////////
+// GamutCoverage.cpp: gamut coverage computation (see GamutCoverage.h).
+///////////////////////////////////////////////////////////////////////////////
+
+#include "GamutCoverage.h"
+
+#include <math.h>
+#include <vector>
+
+void xyToUv(double x, double y, double & u, double & v)
+{
+    double d = -2.0 * x + 12.0 * y + 3.0;
+    if (d == 0.0)
+    {
+        u = 0.0;
+        v = 0.0;
+        return;
+    }
+    u = (4.0 * x) / d;
+    v = (9.0 * y) / d;
+}
+
+namespace
+{
+    struct Pt
+    {
+        double x;
+        double y;
+    };
+
+    // Twice the signed area of the polygon (shoelace).  Positive when the
+    // vertices are counter-clockwise.
+    double signedArea2(const std::vector<Pt> & poly)
+    {
+        double a = 0.0;
+        size_t n = poly.size();
+        for (size_t i = 0; i < n; i++)
+        {
+            const Pt & p = poly[i];
+            const Pt & q = poly[(i + 1) % n];
+            a += p.x * q.y - q.x * p.y;
+        }
+        return a;
+    }
+
+    // Cross product (b-a) x (p-a): positive when p is left of a->b.
+    double cross(const Pt & a, const Pt & b, const Pt & p)
+    {
+        return (b.x - a.x) * (p.y - a.y) - (b.y - a.y) * (p.x - a.x);
+    }
+
+    Pt intersect(const Pt & p, const Pt & q, const Pt & a, const Pt & b)
+    {
+        double d1 = cross(a, b, p);
+        double d2 = cross(a, b, q);
+        double t = d1 / (d1 - d2);
+        Pt r = { p.x + t * (q.x - p.x), p.y + t * (q.y - p.y) };
+        return r;
+    }
+
+    // Sutherland-Hodgman: clip a polygon against a convex, CCW-wound clip
+    // triangle.
+    std::vector<Pt> clipPolygon(std::vector<Pt> poly, const Pt clip[3])
+    {
+        for (int e = 0; e < 3 && !poly.empty(); e++)
+        {
+            const Pt & a = clip[e];
+            const Pt & b = clip[(e + 1) % 3];
+            std::vector<Pt> out;
+            size_t n = poly.size();
+            for (size_t i = 0; i < n; i++)
+            {
+                const Pt & p = poly[i];
+                const Pt & q = poly[(i + 1) % n];
+                bool pIn = cross(a, b, p) >= 0.0;
+                bool qIn = cross(a, b, q) >= 0.0;
+                if (pIn)
+                {
+                    out.push_back(p);
+                    if (!qIn)
+                        out.push_back(intersect(p, q, a, b));
+                }
+                else if (qIn)
+                {
+                    out.push_back(intersect(p, q, a, b));
+                }
+            }
+            poly.swap(out);
+        }
+        return poly;
+    }
+
+    Pt project(const ColorxyY & c, GamutPlane plane)
+    {
+        Pt p = { c[0], c[1] };
+        if (plane == GAMUT_PLANE_UV)
+            xyToUv(c[0], c[1], p.x, p.y);
+        return p;
+    }
+
+    // Ensure counter-clockwise winding.
+    void makeCCW(std::vector<Pt> & tri)
+    {
+        if (signedArea2(tri) < 0.0)
+        {
+            Pt tmp = tri[1];
+            tri[1] = tri[2];
+            tri[2] = tmp;
+        }
+    }
+}
+
+double GamutCoverage(const ColorxyY measured[3], const ColorxyY reference[3], GamutPlane plane)
+{
+    std::vector<Pt> meas(3), ref(3);
+    for (int i = 0; i < 3; i++)
+    {
+        meas[i] = project(measured[i], plane);
+        ref[i] = project(reference[i], plane);
+    }
+    makeCCW(meas);
+    makeCCW(ref);
+
+    // Chromaticity coordinates are O(1), so their doubled triangle areas are
+    // well above this floor unless the triangle is genuinely degenerate.
+    const double kAreaEpsilon = 1e-12;
+    double refArea2 = signedArea2(ref);
+    if (refArea2 <= kAreaEpsilon || fabs(signedArea2(meas)) <= kAreaEpsilon)
+        return 0.0;
+
+    Pt clip[3] = { ref[0], ref[1], ref[2] };
+    std::vector<Pt> inter = clipPolygon(meas, clip);
+    if (inter.size() < 3)
+        return 0.0;
+
+    return fabs(signedArea2(inter)) / refArea2;
+}

--- a/libHCFR/GamutCoverage.h
+++ b/libHCFR/GamutCoverage.h
@@ -1,0 +1,30 @@
+///////////////////////////////////////////////////////////////////////////////
+// GamutCoverage.h: gamut coverage computation (pure geometry, no UI).
+//
+// Coverage = area(measured triangle intersect reference triangle) / area(reference
+// triangle), computed in a 2D chromaticity plane (CIE 1931 xy or CIE 1976
+// u'v').  This is the industry "P3 coverage 96%" style metric: it saturates
+// at 1.0 and penalizes misaligned primaries even when the measured gamut is
+// larger than the reference.
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef GAMUTCOVERAGE_H_INCLUDED
+#define GAMUTCOVERAGE_H_INCLUDED
+
+#include "Color.h"
+
+enum GamutPlane
+{
+    GAMUT_PLANE_XY,     // CIE 1931 xy
+    GAMUT_PLANE_UV      // CIE 1976 u'v'
+};
+
+// CIE 1931 xy -> CIE 1976 u'v'
+void xyToUv(double x, double y, double & u, double & v);
+
+// Coverage of the reference triangle by the measured triangle in the given
+// plane.  Both arrays are the R, G, B primaries as xyY (Y is ignored).
+// Returns a value in [0, 1].  Returns 0 if either triangle is degenerate.
+double GamutCoverage(const ColorxyY measured[3], const ColorxyY reference[3], GamutPlane plane);
+
+#endif // GAMUTCOVERAGE_H_INCLUDED

--- a/libHCFR/Makefile
+++ b/libHCFR/Makefile
@@ -3,7 +3,7 @@ all:
 	rm ProfilesRepositoryIndexFileReader.cpp
 	flex -t ProfilesRepositoryIndexFileReader.ll > ProfilesRepositoryIndexFileReader.cpp
 
-	gcc -c Color.cpp matrix.cpp calibrationFile.cpp Exceptions.cpp ProfilesRepositoryIndexFileReader.cpp
+	gcc -c Color.cpp GamutCoverage.cpp matrix.cpp calibrationFile.cpp Exceptions.cpp ProfilesRepositoryIndexFileReader.cpp
 
 	libtool -static -o libHCFR.a *.o
 

--- a/libHCFR/winFiles/libHCFR.vcxproj
+++ b/libHCFR/winFiles/libHCFR.vcxproj
@@ -97,6 +97,7 @@
     <ClCompile Include="..\CriticalSection.cpp" />
     <ClCompile Include="..\Endianness.cpp" />
     <ClCompile Include="..\Exceptions.cpp" />
+    <ClCompile Include="..\GamutCoverage.cpp" />
     <ClCompile Include="..\IHCFile.cpp" />
     <ClCompile Include="..\matrix.cpp" />
     <ClCompile Include="..\PCFilesReaderUtilities.cpp" />
@@ -108,6 +109,7 @@
     <ClInclude Include="..\CriticalSection.h" />
     <ClInclude Include="..\Endianness.h" />
     <ClInclude Include="..\Exceptions.h" />
+    <ClInclude Include="..\GamutCoverage.h" />
     <ClInclude Include="..\IHCFile.h" />
     <ClInclude Include="..\libHCFR_Config.h" />
     <ClInclude Include="..\LockWhileInScope.h" />

--- a/libHCFR/winFiles/libHCFR.vcxproj.filters
+++ b/libHCFR/winFiles/libHCFR.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClCompile Include="..\Exceptions.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\GamutCoverage.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\IHCFile.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -60,6 +63,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\Exceptions.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GamutCoverage.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\IHCFile.h">


### PR DESCRIPTION
## Summary

Adds **display gamut coverage** to the CIE chart — the "P3 coverage 96%" style metric — for Rec.709, DCI-P3, Rec.2020, and the P3/709-in-2020 container modes, in both CIE 1931 **xy** and CIE 1976 **u'v'**.

Coverage = area(measured-primaries triangle ∩ reference triangle) / area(reference triangle). It saturates at 100% and penalizes misaligned primaries (distinct from gamut *volume*, which is 3D/luminance-inclusive and out of scope here).

## What's shown

Stat-bar-style pill chips, top right of the CIE chart:

`[DCI-P3]  [xy: 96.4%]  [u'v': 95.8%]`

- The **gamut-name chip always shows**, even before any measurement.
- The **percentages hide when the gamut is changed** until the primaries are re-measured — old primaries don't belong to the new reference. Switching back to a previously-measured gamut re-shows its numbers.
- Chips clamp to the chart width, dropping `u'v'` then `xy`, always keeping the gamut name.
- Not shown in CIE a\*b\* mode (the metric is a chromaticity-plane one).

## Implementation

- **`libHCFR/GamutCoverage.{h,cpp}`** — pure, UI-free geometry: Sutherland–Hodgman clip of the measured triangle against the reference triangle, then shoelace area. `xyToUv` helper shared out of the view.
- **`UnitTests/GamutCoverage_unittests.cpp`** — 7 cases: self-coverage = 100%, Rec.709 ⊂ Rec.2020 containment, an analytic 25% partial-overlap, winding invariance, degenerate-triangle guards, xy≠u'v' sanity, and the D65 u'v' conversion. All pass.
- **CIE chart readout** compares the measured primaries against the *displayed* reference triangle (`GetColorReference().GetRed/Green/Blue()`), so P3-in-2020 correctly evaluates against the inner P3 gamut. Staleness is tracked on the persistent grapher via the standard + primary values the last shown coverage was computed for.
- **Shared chip drawing** — the pill helper is factored out of `TargetWnd` into `DrawStatChip`/`MeasureStatChip` in `GdiPlusAA.h` (no duplication); target-widget chip font bumped slightly to match.

## Testing

- `UnitTests` (Debug/Win32): `GamutCoverageTestCase` — OK (7).
- `ColorHCFR` (Debug/Win32) builds clean; verified on-screen across gamut/plane switches and the change-then-remeasure hide/show behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)