### PR TITLE
Fix crash & data-integrity issues (sensors, unsafe getenv/format strings, OOB)

### DIFF
--- a/Export.cpp
+++ b/Export.cpp
@@ -14,7 +14,7 @@
 //  GNU General Public License for more details
 /////////////////////////////////////////////////////////////////////////////
 //  Author(s):
-//	François-Xavier CHABOUD
+//	Franï¿½ois-Xavier CHABOUD
 //	Georges GALLERAND
 /////////////////////////////////////////////////////////////////////////////
 
@@ -81,9 +81,9 @@ draw_image (HPDF_Doc     pdf,
     HPDF_Image image;
 	char * path;
 	path = getenv("APPDATA");
-    strcpy(filename1, path);
-    strcat(filename1, FILE_SEPARATOR);
-    strcat(filename1, filename);
+	if (!path) path = "";
+    _snprintf(filename1, sizeof(filename1), "%s%s%s", path, FILE_SEPARATOR, filename);
+    filename1[sizeof(filename1)-1] = 0;
 
     image = HPDF_LoadPngImageFromFile (pdf, filename1);
 
@@ -117,10 +117,9 @@ draw_image2 (HPDF_Doc     pdf,
     HPDF_Image image;
 	char * path;
 	path = getenv("APPDATA");
-
-	strcpy(filename1, path);
-    strcat(filename1, FILE_SEPARATOR);
-    strcat(filename1, filename);
+	if (!path) path = "";
+	_snprintf(filename1, sizeof(filename1), "%s%s%s", path, FILE_SEPARATOR, filename);
+    filename1[sizeof(filename1)-1] = 0;
 
     image = HPDF_LoadPngImageFromFile (pdf, filename1);
 
@@ -515,7 +514,7 @@ bool CExport::SavePDF()
 	if (nCount > 0 && !isHDR )
 	{
 		m_pDoc->ComputeGammaAndOffset(&Gamma, &Offset, 1, 1, nCount, false);
-		sprintf(str,"Average measured gamma: %.2f, Color dE formula: "+dEform2,Gamma);
+		sprintf(str,"Average measured gamma: %.2f, Color dE formula: %s",Gamma,(LPCTSTR)dEform2);
 	}
 	else
 	{
@@ -756,9 +755,9 @@ bool CExport::SavePDF()
 	char * path;
 	char filename1[255];
 	path = getenv("APPDATA");
-    strcpy(filename1, path);
-    strcat(filename1, "\\");
-    strcat(filename1, "color\\temp.png");
+	if (!path) path = "";
+    _snprintf(filename1, sizeof(filename1), "%s\\color\\temp.png", path);
+    filename1[sizeof(filename1)-1] = 0;
 
 //CIE Chart
 	CCIEChartGrapher pCIE;
@@ -1089,7 +1088,7 @@ bool CExport::SavePDF()
 		if (nCount > 0)
 		{
 			m_pDoc->ComputeGammaAndOffset(&Gamma, &Offset, 1, 1, nCount, false);
-			sprintf(str,"Average measured gamma: %.2f, Color dE formula: "+dEform2,Gamma);
+			sprintf(str,"Average measured gamma: %.2f, Color dE formula: %s",Gamma,(LPCTSTR)dEform2);
 		}
 		else
 		{
@@ -1327,9 +1326,9 @@ bool CExport::SavePDF()
 		char * path;
 		char filename1[255];
 		path = getenv("APPDATA");
-		strcpy(filename1, path);
-		strcat(filename1, "\\");
-		strcat(filename1, "color\\temp.png");
+		if (!path) path = "";
+		_snprintf(filename1, sizeof(filename1), "%s\\color\\temp.png", path);
+		filename1[sizeof(filename1)-1] = 0;
 		CCIEChartGrapher pCIE;
 		pCIE.SaveGraphFile(pDataRef,CSize(dX,dY),filename1,2,95,TRUE);
 

--- a/Generators/GDIGenerator.cpp
+++ b/Generators/GDIGenerator.cpp
@@ -14,7 +14,7 @@
 //  GNU General Public License for more details
 /////////////////////////////////////////////////////////////////////////////
 //  Author(s):
-//	François-Xavier CHABOUD
+//	Franï¿½ois-Xavier CHABOUD
 //	Georges GALLERAND
 /////////////////////////////////////////////////////////////////////////////
 
@@ -540,7 +540,8 @@ BOOL CGDIGenerator::Init(UINT nbMeasure, bool isSpecial)
 		CString str1 = GetConfig () -> m_ApplicationPath;
 		str += "\\tools\\dispwin.exe";
 		str1 += "\\tools\\current.cal";
-		sprintf(arg," -d%d -s " + str1, m_activeMonitorNum+1);
+		_snprintf(arg, sizeof(arg), " -d%d -s %s", m_activeMonitorNum+1, (LPCTSTR)str1);
+		arg[sizeof(arg)-1] = 0;
 		ShellExecute(NULL, "open", str, arg, NULL, SW_HIDE);
 		Sleep(100);
 		sprintf(arg," -d%d -c", m_activeMonitorNum+1);
@@ -1419,7 +1420,8 @@ BOOL CGDIGenerator::Release(INT nbNext)
 		CString str1 = GetConfig () -> m_ApplicationPath;
 		str += "\\tools\\dispwin.exe";
 		str1 += "\\tools\\current.cal";
-		sprintf(arg," -d%d " + str1, m_activeMonitorNum+1);
+		_snprintf(arg, sizeof(arg), " -d%d %s", m_activeMonitorNum+1, (LPCTSTR)str1);
+		arg[sizeof(arg)-1] = 0;
 		ShellExecute(NULL, "open", str, arg, NULL, SW_HIDE);
 		m_bConnect = FALSE;
 	}

--- a/Sensors/EyeOneSensor.cpp
+++ b/Sensors/EyeOneSensor.cpp
@@ -520,11 +520,13 @@ CColor CEyeOneSensor::MeasureColorInternal(const ColorRGBDisplay& aRGBValue)
 						sscanf ( lpStr, "%lf,%lf,%lf,%d", & x, & y, & z, & bSpectrumOk );
 						if ( bSpectrumOk )
 						{
-							lpStr = strchr ( lpStr, (int) '|' ) + 1;
+							char * pBar = strchr ( lpStr, (int) '|' );
+							lpStr = pBar ? pBar + 1 : NULL;
 							for (int i = 0; lpStr && lpStr [ 0 ] && i < SPECTRUM_BANDS ; i ++ )
 							{
 								Spectrum [ i ] = atof ( lpStr );
-								lpStr = strchr ( lpStr, (int) ',' ) + 1;
+								char * pComma = strchr ( lpStr, (int) ',' );
+								lpStr = pComma ? pComma + 1 : NULL;
 							}
 						}
 					}

--- a/Sensors/MTCSSensor.cpp
+++ b/Sensors/MTCSSensor.cpp
@@ -347,17 +347,21 @@ CColor CMTCSSensor::MeasureColorInternal(const ColorRGBDisplay& aRGBValue)
 		if (m_debugMode) 
 		{
 			EnterCriticalSection ( & GetConfig () -> LogFileCritSec );
-			CTime theTime = CTime::GetCurrentTime(); 
-			CString s = theTime.Format( "%d/%m/%y %H:%M:%S" );		
+			CTime theTime = CTime::GetCurrentTime();
+			CString s = theTime.Format( "%d/%m/%y %H:%M:%S" );
 			FILE *f = fopen ( GetConfig () -> m_logFileName, "a" );
-			fprintf(f, "MTCS-C2 - %s : R:%3f G:%3f B:%3f : amp:%d Ticks:%6d RVal:%6d GVal:%6d BVal:%6d\n", s, aRGBValue[0], aRGBValue[1], aRGBValue[2], amp, nTicks, r, g, b );
-			fclose(f);
+			if ( f )
+			{
+				fprintf(f, "MTCS-C2 - %s : R:%3f G:%3f B:%3f : amp:%d Ticks:%6d RVal:%6d GVal:%6d BVal:%6d\n", s, aRGBValue[0], aRGBValue[1], aRGBValue[2], amp, nTicks, r, g, b );
+				fclose(f);
+			}
 			LeaveCriticalSection ( & GetConfig () -> LogFileCritSec );
 		}
 	}
-	else 
+	else
 	{
 		MessageBox(0, "No data from Sensor","Error",MB_OK+MB_ICONINFORMATION);
+		return noDataColor;
 	}
 
 	return colMeasure;

--- a/Tools/ArgyllMeterWrapper/ArgyllMeterWrapper.cpp
+++ b/Tools/ArgyllMeterWrapper/ArgyllMeterWrapper.cpp
@@ -651,15 +651,20 @@ ArgyllMeterWrapper::eMeterState ArgyllMeterWrapper::takeReading(CString Spectral
 
         if (cnt > 0)
         {
+            int nGood = 0;
             for(int i(0); i < cnt; ++i)
             {
                 instCode = m_meter->read_sample(m_meter, "SPOT", &argyllReading, instNoClamp);
+                if (instCode != inst_ok)
+                    continue;
                 if (!isColorimeter() && sp2cie != NULL)
                     sp2cie->convert(sp2cie, argyllReading.XYZ, &argyllReading.sp);
-                    X+=argyllReading.XYZ[0];
-                    Y+=argyllReading.XYZ[1];
-                    Z+=argyllReading.XYZ[2];
+                X+=argyllReading.XYZ[0];
+                Y+=argyllReading.XYZ[1];
+                Z+=argyllReading.XYZ[2];
+                ++nGood;
             }
+            cnt = nGood; // average only over samples that actually succeeded
         }
     }
     X = X / (cnt+1);

--- a/Views/GammaHistoView.cpp
+++ b/Views/GammaHistoView.cpp
@@ -14,7 +14,7 @@
 //  GNU General Public License for more details
 /////////////////////////////////////////////////////////////////////////////
 //  Author(s):
-//	François-Xavier CHABOUD
+//	Franï¿½ois-Xavier CHABOUD
 //	Georges GALLERAND
 //	Benoit SEGUIN
 /////////////////////////////////////////////////////////////////////////////
@@ -36,7 +36,6 @@ static char THIS_FILE[] = __FILE__;
 #endif
 
 double Y_to_L( double val );
-std::vector<double> m_yref_abs;
 
 /////////////////////////////////////////////////////////////////////////////
 // CGammaGrapher
@@ -183,8 +182,8 @@ void CGammaGrapher::UpdateGraph ( CDataSetDoc * pDoc )
 
 	if (m_showAverage && m_avgLogGraphID != -1 && size > 0 && bDataPresent && !(GetConfig()->m_GammaOffsetType == 5 || GetConfig()->m_GammaOffsetType == 7 ))
 	{	
-		// Le calcul de la moyenne des gamma et la représentation en échelle log 
-		// ne se fait plus avec l'échelle des x = % de blanc mais avec la formule : 
+		// Le calcul de la moyenne des gamma et la reprï¿½sentation en ï¿½chelle log 
+		// ne se fait plus avec l'ï¿½chelle des x = % de blanc mais avec la formule : 
 		// (x + offset) / (1+offset) 
 		for (int i=1; i<size-1; i++)
 			m_graphCtrl.AddPoint(m_avgLogGraphID, pDoc->GetMeasure()->GetGrayPercent ( i, GetConfig () -> m_bUseRoundDown, GetConfig()->GetUse10bitLevels() ), GammaOpt);
@@ -194,8 +193,8 @@ void CGammaGrapher::UpdateGraph ( CDataSetDoc * pDoc )
 	{
 		if (m_showAverage && m_luxmeterAvgLogGraphID != -1 && size > 0 && bDataPresent && pDoc->GetMeasure()->GetGray(0).HasLuxValue() )
 		{	
-			// Le calcul de la moyenne des gamma et la représentation en échelle log 
-			// ne se fait plus avec l'échelle des x = % de blanc mais avec la formule : 
+			// Le calcul de la moyenne des gamma et la reprï¿½sentation en ï¿½chelle log 
+			// ne se fait plus avec l'ï¿½chelle des x = % de blanc mais avec la formule : 
 			// (x + offset) / (1+offset) 
 			for (int i=1; i<size-1; i++)
 				m_graphCtrl.AddPoint(m_luxmeterAvgLogGraphID, pDoc->GetMeasure()->GetGrayPercent ( i, GetConfig () -> m_bUseRoundDown, GetConfig()->GetUse10bitLevels() ), LuxGammaOpt);
@@ -338,8 +337,8 @@ void CGammaGrapher::AddPointtoLumGraph(int ColorSpace,int ColorIndex,int Size,in
 		lpMsg = szBuf;
 	}
 	
-	// Le calcul de la moyenne des gamma et la représentation en échelle log 
-	// ne se fait plus avec l'échelle des x = % de blanc mais avec la formule : 
+	// Le calcul de la moyenne des gamma et la reprï¿½sentation en ï¿½chelle log 
+	// ne se fait plus avec l'ï¿½chelle des x = % de blanc mais avec la formule : 
 	// (x + offset) / (1+offset) 
 
 	if((GraphID != -1)&&((PointIndex != 0 && PointIndex != (Size-1)) && colorlevel > 0.0001) || (GraphID != -1&&(GetConfig()->m_GammaOffsetType == 5 || GetConfig()->m_GammaOffsetType == 7 )))	// log scale is not valid for first and last value nor for negative values
@@ -349,7 +348,7 @@ void CGammaGrapher::AddPointtoLumGraph(int ColorSpace,int ColorIndex,int Size,in
 		double valxprime=(GrayLevelToGrayProp(x, GetConfig () -> m_bUseRoundDown, GetConfig()->GetUse10bitLevels())+GammaOffset)/(1.0+GammaOffset);
 
 		if (GetConfig()->m_GammaOffsetType == 5 || GetConfig()->m_GammaOffsetType == 7) 
-			m_graphCtrl.AddPoint(GraphID, x, colorlevel - whitelvl * m_yref_abs[PointIndex], lpMsg);
+			m_graphCtrl.AddPoint(GraphID, x, colorlevel - whitelvl * (PointIndex >= 0 && PointIndex < (int)m_yref_abs.size() ? m_yref_abs[PointIndex] : 0.0), lpMsg);
 		else
 			m_graphCtrl.AddPoint(GraphID, x, log((colorlevel)/whitelvl)/log(valxprime), lpMsg);
 

--- a/Views/GammaHistoView.h
+++ b/Views/GammaHistoView.h
@@ -14,7 +14,7 @@
 //  GNU General Public License for more details
 /////////////////////////////////////////////////////////////////////////////
 //  Author(s):
-//	François-Xavier CHABOUD
+//	Franï¿½ois-Xavier CHABOUD
 //	Benoit SEGUIN
 /////////////////////////////////////////////////////////////////////////////
 
@@ -28,6 +28,7 @@
 //
 
 #include "GraphControl.h"
+#include <vector>
 
 /////////////////////////////////////////////////////////////////////////////
 // CGammaHistoView form view
@@ -58,6 +59,8 @@ class CGammaGrapher
 	long m_redLumDataRefLogGraphID;		//Ki
 	long m_greenLumDataRefLogGraphID;	//Ki
 	long m_blueLumDataRefLogGraphID;	//Ki
+
+	std::vector<double> m_yref_abs;	// per-view reference luminance (was a file-scope global -> cross-doc corruption)
 
 	// Updatable flags. Initialized with default values in constructor, can be changed before calling UpdateGraph
 	BOOL m_showReference;

--- a/Views/GraphControl.cpp
+++ b/Views/GraphControl.cpp
@@ -666,9 +666,9 @@ static double spectral_chromaticities[][2] = {
 				nWaveIndex = 0;
 				WaveIndex = 0.0;
 			}
-			else if ( nWaveIndex > sizeof ( spectral_chromaticities ) / sizeof ( spectral_chromaticities [ 0 ] ) - 1 )
+			else if ( nWaveIndex > sizeof ( spectral_chromaticities ) / sizeof ( spectral_chromaticities [ 0 ] ) - 2 )
 			{
-				nWaveIndex = sizeof ( spectral_chromaticities ) / sizeof ( spectral_chromaticities [ 0 ] ) - 1;
+				nWaveIndex = sizeof ( spectral_chromaticities ) / sizeof ( spectral_chromaticities [ 0 ] ) - 2;
 				WaveIndex = 1.0;
 			}
 
@@ -701,6 +701,9 @@ static double spectral_chromaticities[][2] = {
 			m_pSpectrumColors [ x ] = RGB(nR,nG,nB);
 		}
 	}
+
+	if ( m_graphArray.GetSize() == 0 )
+		return;
 
 	ptOrg = pDC ->GetWindowOrg ();
 	pts = new POINT [ m_graphArray[0].m_pointArray.GetSize() + 2 ];
@@ -1011,7 +1014,7 @@ void CGraphControl::OnPaint()
 	CString		GTxt = m_graphArray[0].p_Title;
 	BOOL		bWhiteBkgnd = GetConfig () -> m_bWhiteBkgndOnScreen;
 	TCHAR		GLabel[100] = _T("");
-	StringCchCat(GLabel, 260, GTxt); 
+	StringCchCat(GLabel, _countof(GLabel), GTxt);
 	// CIE-005: dropped uninitialised-font SelectObject + red-bg SetBkColor;
 	// real select + bg-color assignment happens below, after CreateFont.
 	font.CreateFont( GetConfig()->ScaleFloor(18,22), 0, 0, 0, FW_BOLD, FALSE, FALSE, FALSE, ANSI_CHARSET, OUT_DEFAULT_PRECIS, CLIP_CHARACTER_PRECIS, DEFAULT_QUALITY, VARIABLE_PITCH | FF_DONTCARE, "Segoe UI" );

--- a/Views/NearWhiteHistoView.cpp
+++ b/Views/NearWhiteHistoView.cpp
@@ -14,7 +14,7 @@
 //  GNU General Public License for more details
 /////////////////////////////////////////////////////////////////////////////
 //  Author(s):
-//	François-Xavier CHABOUD
+//	Franï¿½ois-Xavier CHABOUD
 //	Georges GALLERAND
 //	Benoit SEGUIN
 /////////////////////////////////////////////////////////////////////////////
@@ -354,9 +354,9 @@ void CNearWhiteGrapher::AddPointtoLumGraph(int ColorSpace,int ColorIndex,int Siz
 	{
 		max = whitelvl;
 		if (ColorSpace == 1 && ColorIndex == 1)
-	        m_graphCtrl.AddPoint(GraphID, GrayLevelToGrayProp( (double)(PointIndex+pDataSet->GetMeasure()->m_NearWhiteClipCol-Size), GetConfig () -> m_bUseRoundDown, GetConfig()->GetUse10bitLevels()) * 100., (colorlevel/max)*100.0, lpMsg, whitelvl);
+	        m_graphCtrl.AddPoint(GraphID, GrayLevelToGrayProp( (double)(PointIndex+pDataSet->GetMeasure()->m_NearWhiteClipCol-Size), GetConfig () -> m_bUseRoundDown, GetConfig()->GetUse10bitLevels()) * 100., (max>0?(colorlevel/max)*100.0:0.0), lpMsg, whitelvl);
 		else
-	        m_graphCtrl.AddPoint(GraphID, GrayLevelToGrayProp( (double)(PointIndex+pDataSet->GetMeasure()->m_NearWhiteClipCol-Size), GetConfig () -> m_bUseRoundDown, GetConfig()->GetUse10bitLevels()) * 100., (colorlevel/max)*100.0, lpMsg, NULL);
+	        m_graphCtrl.AddPoint(GraphID, GrayLevelToGrayProp( (double)(PointIndex+pDataSet->GetMeasure()->m_NearWhiteClipCol-Size), GetConfig () -> m_bUseRoundDown, GetConfig()->GetUse10bitLevels()) * 100., (max>0?(colorlevel/max)*100.0:0.0), lpMsg, NULL);
 	}
 	else 
 	{

--- a/Views/measureshistoview.cpp
+++ b/Views/measureshistoview.cpp
@@ -461,7 +461,7 @@ void CMeasuresHistoView::OnDraw(CDC* pDC)
 	char		szBuf[10];
 	TCHAR		trkPerc[100] = _T("");
 
-	StringCchCat(trkPerc, 260, trkTxt); 
+	StringCchCat(trkPerc, _countof(trkPerc), trkTxt); 
 
 	GetClientRect(&rect);	// fill entire window with three graphs
 	
@@ -479,21 +479,21 @@ void CMeasuresHistoView::OnDraw(CDC* pDC)
 	_ltoa(l_nCol * stepSize, szBuf, 10);
 
 	if (l_Display == 0 || l_Display == 3 || l_Display == 4)
-		StringCchCat(trkPerc, 260, szBuf);
+		StringCchCat(trkPerc, _countof(trkPerc), szBuf);
 
 	switch (l_Display)
 	{
 	case (0):
-		StringCchCat(trkPerc, 260, _T("% (Gray scale)"));
+		StringCchCat(trkPerc, _countof(trkPerc), _T("% (Gray scale)"));
 		break;
 	case (3):
-		StringCchCat(trkPerc, 260, _T("% (Near black scale)"));
+		StringCchCat(trkPerc, _countof(trkPerc), _T("% (Near black scale)"));
 		break;
 	case (4):
-		StringCchCat(trkPerc, 260, _T("% (Near white scale)"));
+		StringCchCat(trkPerc, _countof(trkPerc), _T("% (Near white scale)"));
 		break;
 	default:
-	StringCchCat(trkPerc, 260, _T("Tracking off..."));
+	StringCchCat(trkPerc, _countof(trkPerc), _T("Tracking off..."));
 	}
 						
 	if ( m_showLuminance )

--- a/datasetdoc.cpp
+++ b/datasetdoc.cpp
@@ -14,7 +14,7 @@
 //  GNU General Public License for more details
 /////////////////////////////////////////////////////////////////////////////
 //  Author(s):
-//	François-Xavier CHABOUD
+//	Franï¿½ois-Xavier CHABOUD
 //	Georges GALLERAND
 /////////////////////////////////////////////////////////////////////////////
 
@@ -2233,7 +2233,8 @@ void CDataSetDoc::OnCalibrationSpectralSample()
 
 		const char* FILE_SEPARATOR = "\\";			
 		const char* FILE_PREPEND = "\\color\\";			
-		std::string savePath = getenv("APPDATA");
+		const char* appdataEnv = getenv("APPDATA");
+		std::string savePath = appdataEnv ? appdataEnv : "";
 		savePath += FILE_PREPEND;
 		CFileDialog fileSaveDialog( FALSE, "ccss", NULL, OFN_HIDEREADONLY, "Colorimeter Calibration Spectral Sample (*.ccss)|*.ccss||" );
 		fileSaveDialog.m_ofn.lpstrInitialDir = savePath.c_str();

--- a/libHCFR/Color.cpp
+++ b/libHCFR/Color.cpp
@@ -2816,8 +2816,9 @@ bool GenerateCC24Colors (const CColorReference& colorReference, ColorRGBDisplay*
 	char * path;
 	char appPath[255];
 	path = getenv("APPDATA");
-	strcpy(appPath, path);
-	strcat(appPath, "\\color");
+	if (!path) path = "";
+	_snprintf(appPath, sizeof(appPath), "%s\\color", path);
+	appPath[sizeof(appPath)-1] = 0;
 	bool bOk = true, constant_XYZ = FALSE, m_bRecalc = FALSE;
 	int n_elements=24;
 	switch (aCCMode)
@@ -3646,10 +3647,15 @@ int PiBackground8ToCode ( double v255, bool is16_235, int bits )
     if ( bits == 10 )
     {
         if ( is16_235 )
+        {
             code = (int) floor ( v255 / 255.0 * 876.0 + 64.5 );
+            code = ( code < 0 ) ? 0 : ( ( code > 940 ) ? 940 : code );
+        }
         else
+        {
             code = (int) floor ( v255 / 255.0 * 1023.0 + 0.5 );
-        code = ( code < 0 ) ? 0 : ( ( code > 1023 ) ? 1023 : code );
+            code = ( code < 0 ) ? 0 : ( ( code > 1023 ) ? 1023 : code );
+        }
         return code;
     }
     if ( is16_235 )


### PR DESCRIPTION
Crash / data-integrity fixes surfaced in the 4.1.0 pre-release review. This is the risk-bearing set — worth careful review. Two companion PRs cover functional/UI fixes and dead-code cleanup.

### Sensors
- **Argyll** low-light averager (`ArgyllMeterWrapper.cpp`): skip reads where `instCode != inst_ok` and divide by the count of accepted samples (previously averaged garbage from failed reads into a "valid" reading, and divided by a fixed count).
- **MTCS** (`MTCSSensor.cpp`): return `noDataColor` on read failure instead of an unassigned value; null-check the debug-log `fopen` before `fprintf`/`fclose`.
- **EyeOne** (`EyeOneSensor.cpp`): guard both `strchr(...)+1` sites so a malformed daemon spectrum line no longer dereferences `(char*)1`.

### Filesystem / string safety
- Unchecked `getenv("APPDATA")` + unbounded `strcpy`/`strcat` → null-guarded, bounded `_snprintf`: `Color.cpp` (`GenerateCC24Colors`), `Export.cpp` (×4), `datasetdoc.cpp`.
- Runtime-built format strings (`"lit" + cstring` passed as the format) → literal `%s` args: `Export.cpp` (×2), `GDIGenerator.cpp` (×2, dispwin) — a `%` in an install path can no longer corrupt/crash.

### Numeric / OOB
- `GraphControl.cpp`: spectrum interpolation clamp `size-2` (no `[nWaveIndex+1]` overrun), `DrawSpectrumColors` empty-array guard, `StringCchCat` buffer sizes (`_countof`).
- `NearWhiteHistoView.cpp`: divide-by-zero guard when the white level clamps to 0.
- `GammaHistoView.cpp/.h`: `m_yref_abs` moved from a file-scope global to a per-view `CGammaGrapher` member (no cross-document corruption) + bounds-guarded read.

### Validation
Clean full rebuild (Debug|Win32, 0 errors, warning-neutral vs baseline). `ColorMathTest` passes against **baseline goldens** (grey-level/pattern/COLORREF output byte-identical; T5 covers the 10-bit quantizer). Argyll low-light averaging spot-checked on hardware (near-black readings sane). Sensor failure branches (MTCS/EyeOne) reasoned + code-verified but need the specific meters / fault injection to exercise live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
