### PR TITLE
Fix edit-grid checkbox regression, control-ID collision, ColorTemp preference

### DIFF
--- a/Tools/fxcolor.cpp
+++ b/Tools/fxcolor.cpp
@@ -14,7 +14,7 @@
 //  GNU General Public License for more details
 /////////////////////////////////////////////////////////////////////////////
 //  Author(s):
-//	François-Xavier CHABOUD
+//	Franï¿½ois-Xavier CHABOUD
 /////////////////////////////////////////////////////////////////////////////
 
 #include "stdafx.h"        // Standard windows header file
@@ -667,10 +667,14 @@ void FxApplyDarkModeTree(HWND hRoot, BOOL bDark)
 // that draw anti-aliased (RGB level bars, target widget).
 void FxEnsureGdiplus()
 {
-    static ULONG_PTR s_token = 0;
-    if (s_token == 0)
+    // C++11 magic-static: the initializer runs exactly once even if two
+    // threads race the first call, so no double-startup / leaked token.
+    static ULONG_PTR s_token = []() -> ULONG_PTR
     {
+        ULONG_PTR token = 0;
         Gdiplus::GdiplusStartupInput gdipInput;
-        Gdiplus::GdiplusStartup(&s_token, &gdipInput, NULL);
-    }
+        Gdiplus::GdiplusStartup(&token, &gdipInput, NULL);
+        return token;
+    }();
+    (void)s_token;
 }

--- a/Views/MainView.cpp
+++ b/Views/MainView.cpp
@@ -144,7 +144,6 @@ static const SCtrlLayout g_DisplayComboLayout =
 { IDC_DISPLAYTYPE_COMBO, LAYOUT_RIGHT, LAYOUT_RIGHT, LAYOUT_TOP, LAYOUT_TOP };
 
 
-static COLORREF ButtonPanelColor();   // defined near OnEraseBkgnd
 static COLORREF ButtonFaceColor();
 static COLORREF ButtonHoverColor();
 static COLORREF ButtonBorderColor();
@@ -577,7 +576,6 @@ CMainView::CMainView()
 	m_pSelectedColorGrid = NULL;
 	m_nSelColorGridReadingType = -1;
 	m_pBgBrush= new CBrush(FxGetMenuBgColor());
-	m_pHdrBrush = NULL;
 	m_rcButtonPanel.SetRectEmpty();
 
 	m_pInfoWnd = NULL;
@@ -651,7 +649,6 @@ CMainView::~CMainView()
 			delete m_pInfoWnd;
 
 	delete m_pBgBrush;
-	if (m_pHdrBrush) delete m_pHdrBrush;
 
 	GetConfig()->WriteProfileInt("MainView","Display type",m_displayType);
 
@@ -1193,7 +1190,7 @@ void CMainView::HighlightMeasuringColumn(int gridCol)
 		return;
 	if ( gridCol < 1 || gridCol >= m_pGrayScaleGrid->GetColumnCount() )
 		return;
-	if ( IsDlgButtonChecked(IDC_EDITGRID_CHECK) == BST_CHECKED )
+	if ( m_editCheckButton.GetCheck() == BST_CHECKED )
 		return;
 
 	int maxRow = m_pGrayScaleGrid->GetRowCount() - 1;	// select the x/y/Y data rows of the column
@@ -5424,7 +5421,7 @@ void CMainView::OnGrayScaleGridEndSelChange(NMHDR *pNotifyStruct,LRESULT* pResul
 				 break;
 		}
 
-		if (IsDlgButtonChecked(IDC_EDITGRID_CHECK)!=BST_CHECKED)
+		if (m_editCheckButton.GetCheck()!=BST_CHECKED)
 			m_pGrayScaleGrid->SetSelectedRange(1,minCol,3,minCol,FALSE);	// Select entire column
 	}
 	GetDocument()->UpdateAllViews(this, UPD_SELECTEDCOLOR);
@@ -5457,8 +5454,9 @@ void CMainView::OnRgbRadio()
 
 void CMainView::OnXyz2Radio() 
 {
-	CheckDlgButton ( IDC_EDITGRID_CHECK, FALSE );
+	m_editCheckButton.SetCheck ( BST_UNCHECKED );
 	m_editCheckButton.EnableWindow ( FALSE );
+	if (::IsWindow(m_statsBar.GetSafeHwnd())) m_statsBar.Invalidate(FALSE);   // refresh the bar-drawn Edit checkbox
 	m_displayType=HCFR_xyz2_VIEW;
 	InitGrid();	// to update row labels
 	UpdateGrid();
@@ -5496,11 +5494,12 @@ void CMainView::OnSelchangeDisplayType()
 	// Mirror the per-radio enable rule for the Edit checkbox (see OnXyz2Radio etc.).
 	if (newType == HCFR_xyz2_VIEW)
 	{
-		CheckDlgButton(IDC_EDITGRID_CHECK, FALSE);
+		m_editCheckButton.SetCheck(BST_UNCHECKED);
 		m_editCheckButton.EnableWindow(FALSE);
 	}
 	else
 		m_editCheckButton.EnableWindow(!m_AdjustXYZCheckButton.GetCheck());
+	if (::IsWindow(m_statsBar.GetSafeHwnd())) m_statsBar.Invalidate(FALSE);   // refresh the bar-drawn Edit checkbox
 
 	InitGrid();   // update row labels
 	UpdateGrid();
@@ -6478,9 +6477,6 @@ void CMainView::InitButtons()
 	// (the Edit checkbox is reparented into the stats bar by SetHeaderModel below)
 	// (The Go button's border is tinted green/red by SetMeasureButtonForMode/Stop.)
 
-	// Header band brush (matches the stats bar) for the Edit checkbox background.
-	if (m_pHdrBrush) { delete m_pHdrBrush; m_pHdrBrush = NULL; }
-	m_pHdrBrush = new CBrush(FxGetSysColor(COLOR_BTNFACE));
 
 	// (The Display dropdown keeps its own group-box frame; the buttons get their
 	// own rounded panel painted in OnEraseBkgnd.)
@@ -6663,7 +6659,6 @@ void CMainView::InitGroups()
 // lighter than the app (menu) background so the group reads as a raised pane and
 // the rounded buttons' corners blend into it.
 // Action-button palette. Light theme uses the design values; dark theme uses muted equivalents.
-static COLORREF ButtonPanelColor() { return (fxUseCustomColor != FALSE) ? RGB(45,45,47) : RGB(217,217,217); }  // container D9D9D9
 static COLORREF ButtonFaceColor()  { return (fxUseCustomColor != FALSE) ? RGB(60,60,62) : RGB(255,255,255); }  // face FFFFFF
 static COLORREF ButtonHoverColor() { return (fxUseCustomColor != FALSE) ? RGB(82,82,85) : RGB(242,242,242); }  // hover F2F2F2
 static COLORREF ButtonBorderColor(){ return (fxUseCustomColor != FALSE) ? RGB(95,95,98) : RGB(210, 210, 210); }  // D2D2D2 (light) / subtle dark, matches the +/- buttons

--- a/Views/MainView.h
+++ b/Views/MainView.h
@@ -115,8 +115,6 @@ public:
 	CButtonST	m_testAnsiPatternButton;
 	CButtonST	m_refs;
 	CComboBox	m_comboDisplayType;	// Display-type dropdown (runtime-created, replaces the 5 radios)
-	CButton		m_btnSizePlus;	// header [+] size button (runtime-created, replaces the spinner)
-	CButton		m_btnSizeMinus;	// header [-] size button
 	CFont		m_fluentFont;	// Segoe Fluent Icons font for the +/- glyphs
 	//}}AFX_DATA
 
@@ -204,7 +202,6 @@ public:
 	std::vector<double> dEvector, dLvector, dCvector, dHvector;
 
 	CBrush *m_pBgBrush;
-	CBrush *m_pHdrBrush;		// header band brush for the Edit checkbox (matches the stats bar)
 	CRect  m_rcButtonPanel;	// solid panel behind the Display dropdown + action buttons
 
 	CDataSetDoc* GetDocument();

--- a/Views/colortemphistoview.cpp
+++ b/Views/colortemphistoview.cpp
@@ -14,7 +14,7 @@
 //  GNU General Public License for more details
 /////////////////////////////////////////////////////////////////////////////
 //  Author(s):
-//	François-Xavier CHABOUD
+//	Franï¿½ois-Xavier CHABOUD
 //	Georges GALLERAND
 //	Benoit SEGUIN
 /////////////////////////////////////////////////////////////////////////////
@@ -54,7 +54,7 @@ CColorTempGrapher::CColorTempGrapher()
 	m_graphCtrl.SetYAxisProps("K", 500, 1500, 15000);
 
 	m_showReference=GetConfig()->GetProfileInt("ColorTemp Histo","Show Reference",TRUE);
-	m_showDataRef=GetConfig()->GetProfileInt("ColorTemp Hist","Show Reference Data",TRUE);	//Ki
+	m_showDataRef=GetConfig()->GetProfileInt("ColorTemp Histo","Show Reference Data",TRUE);	//Ki
 
 	m_graphCtrl.ReadSettings("ColorTemp Histo");
 	m_graphCtrl.m_graphArray[0].p_Title="Color Temperature";

--- a/resource.h
+++ b/resource.h
@@ -1840,7 +1840,7 @@
 #define IDS_DEPRESET_PROFESSIONAL      59526
 #define IDS_DEPRESET_CONSUMER          59527
 #define IDS_DEPRESET_RELAXED           59528
-#define IDC_COMBO_DE_TOLERANCE          1548
+#define IDC_COMBO_DE_TOLERANCE          1549
 #define ID_TARGET_TOL_FIRST             33108
 
 // Next default values for new objects
@@ -1850,7 +1850,7 @@
 #define _APS_3D_CONTROLS                     1
 #define _APS_NEXT_RESOURCE_VALUE        385
 #define _APS_NEXT_COMMAND_VALUE         33113
-#define _APS_NEXT_CONTROL_VALUE         1549
+#define _APS_NEXT_CONTROL_VALUE         1550
 #define _APS_NEXT_SYMED_VALUE           143
 #endif
 #endif


### PR DESCRIPTION
Functional / UI fixes from the 4.1.0 pre-release review. Companion to the crash/data-integrity PR (#134) and a dead-code cleanup PR.

### Fixes
- **C4 — edit-grid checkbox regression (new this release).** The checkbox was reparented into the stats bar, so `IsDlgButtonChecked`/`CheckDlgButton(IDC_EDITGRID_CHECK)` in `MainView.cpp` silently no-op'd — column highlighting during measurement, whole-column selection, and the auto-uncheck when switching to the "xyz" view all broke. The four sites now use the `m_editCheckButton` member; a `m_statsBar.Invalidate(FALSE)` after the programmatic uncheck refreshes the bar-drawn checkmark (matches the existing `OnUpdate` idiom).
- **C15 — control-ID collision.** `IDC_COMBO_DE_TOLERANCE` and `IDC_MADVR_10BIT_CHECK` were both `#define`d to `1548`; moved the tolerance combo to `1549` (and bumped `_APS_NEXT_CONTROL_VALUE`).
- **M4 — ColorTemp preference.** `colortemphistoview.cpp` read "Show Reference Data" under `"ColorTemp Hist"` but wrote it under `"ColorTemp Histo"`, so the setting never persisted; fixed the read key.
- **fxcolor** — `FxEnsureGdiplus()` GDI+ init made race-safe via a C++11 magic-static.

### Also (dead code in the same file)
`MainView` `m_pHdrBrush` (a header brush never drawn), `m_btnSizePlus`/`m_btnSizeMinus` (never created — the +/- are bar-drawn zones), and the unused `ButtonPanelColor()` — kept here rather than split from the C4 change to the same file.

### Validation
Clean full rebuild. Live-tested end to end: edit-checkbox click/highlight/xyz behaviors all correct (checkmark now clears + greys on "xyz"); dE-tolerance combo and madVR 10-bit checkbox confirmed independent; ColorTemp "Show Reference Data" persists across restart; theme toggle repaints the button panel cleanly after the dead-code removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
