### PR TITLE
Remove dead code (unused member, dead guards, duplicate includes)

### DIFF
--- a/Controls/RGBLevelWnd.cpp
+++ b/Controls/RGBLevelWnd.cpp
@@ -28,8 +28,6 @@
 #include "RGBLevelWnd.h"
 #include "Color.h"
 #include "fxcolor.h"
-#include "../Views/GdiPlusAA.h"
-#include "../Tools/fxcolor.h"
 
 #ifdef _DEBUG
 #define new DEBUG_NEW

--- a/Controls/StatsBarWnd.h
+++ b/Controls/StatsBarWnd.h
@@ -61,7 +61,6 @@ protected:
 	CString			m_strText;	// last text received (to skip redundant repaints)
 	CStringArray	m_segments;	// parsed display segments
 	CFont			m_font;		// larger bold font for the header chips
-	int				m_rightReserve;	// px reserved on the right for overlaid controls
 
 	// Bar-drawn header controls
 	CButton*		m_pEditBtn;		// hidden control holding the edit-grid state

--- a/Measure.cpp
+++ b/Measure.cpp
@@ -3345,9 +3345,8 @@ BOOL CMeasure::MeasureCC24SatScale(CSensor *pSensor, CGenerator *pGenerator, CDa
 	str.LoadString(IDS_MANUALDVDGENERATOR_NAME);
 
     if(pGenerator->GetName() == str&&( (GetConfig()->m_CCMode==USER && size > 100) ) )
-	{		
+	{
 		Title.LoadString ( IDS_ERROR );
-		if (pGenerator->m_initShowedError) return FALSE;
 		strMsg.LoadString ( IDS_ERRINITGENERATOR );
 		strMsg.Append(" not a supported DVD sequence.");
 		GetColorApp()->InMeasureMessageBox(strMsg,Title,MB_ICONERROR | MB_OK);
@@ -3356,9 +3355,8 @@ BOOL CMeasure::MeasureCC24SatScale(CSensor *pSensor, CGenerator *pGenerator, CDa
 	}
 
     if (!GenerateCC24Colors (GetColorReference(), GenColors, GetConfig()->m_CCMode, GetConfig()->m_GammaOffsetType))
-	{		
+	{
 		Title.LoadString ( IDS_ERROR );
-		if (pGenerator->m_initShowedError) return FALSE;
 		strMsg.LoadString ( IDS_ERRINITGENERATOR );
 		GetColorApp()->InMeasureMessageBox(strMsg,Title,MB_ICONERROR | MB_OK);
 		pGenerator->Release();


### PR DESCRIPTION
Low-risk dead-code cleanup from the 4.1.0 pre-release review. No behavioral change. Companion to the crash/data-integrity PR (#134) and functional/UI PR (#135).

- **`StatsBarWnd.h`** — drop `m_rightReserve` (declared, never initialized, never read).
- **`Measure.cpp`** — remove two unreachable `if (m_initShowedError) return FALSE;` guards in the CC24 post-Init error blocks. The flag is provably `FALSE` after a successful `Init()`, and the guards sat *before* the block's own `Release()`, so if they ever fired they'd leak the generator session — but they can't fire.
- **`RGBLevelWnd.cpp`** — de-duplicate includes (`fxcolor.h` was included twice; `GdiPlusAA.h` both directly and via the header).

Builds clean; the two live `m_initShowedError` guards inside the `Init() != TRUE` blocks are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
