### PR TITLE
Fix CIE diagram making measurement sweeps 5-10x slower (CIE-028)

### DIFF
--- a/Views/CIEChartView.cpp
+++ b/Views/CIEChartView.cpp
@@ -2691,6 +2691,7 @@ CCIEChartView::CCIEChartView()
 	: CSavingView()
 {
 	m_bDelayedUpdate = FALSE;
+	m_bRealtimeIncrement = FALSE;
 }
 
 CCIEChartView::~CCIEChartView()
@@ -2791,7 +2792,16 @@ void CCIEChartView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 		GetReferenceRect ( & Rect );
 		if (lHint != UPD_FREEMEASURES && lHint != UPD_REALTIME && lHint != UPD_FREEMEASUREAPPENDED && !GetDocument()->GetMeasure()->m_binMeasure)
 			m_Grapher.MakeBgBitmap(Rect,GetConfig()->m_bWhiteBkgndOnScreen);
+		// A realtime hint during a sweep adds exactly one measurement: paint it
+		// incrementally. The sweep-end update comes as a non-realtime hint with
+		// m_binMeasure off, which repaints everything (targets, tooltips, dE).
+		if ( lHint >= UPD_REALTIME && GetDocument()->GetMeasure()->m_binMeasure )
+			m_bRealtimeIncrement = TRUE;
 		RedrawWindow( NULL, NULL, RDW_INVALIDATE | RDW_ALLCHILDREN | RDW_UPDATENOW );
+		// The flag must not outlive the synchronous repaint above: if the paint
+		// was skipped (window clipped to nothing), a later unrelated WM_PAINT
+		// would otherwise take the incremental path instead of a full redraw.
+		m_bRealtimeIncrement = FALSE;
 	}
 	else
 	{
@@ -2851,7 +2861,29 @@ void CCIEChartView::OnDraw(CDC* pDC)
 	CDC dcDraw;
 	dcDraw.CreateCompatibleDC(pDC);
 	CBitmap *pOldBitmap=dcDraw.SelectObject(&m_Grapher.m_drawBitmap);
-	m_Grapher.DrawChart ( GetDocument (), & dcDraw, refrect, & m_tooltip, this );
+	if ( m_bRealtimeIncrement )
+	{
+		// Mid-sweep: the retained bitmap already shows the chart as of the
+		// previous patch; add the just-measured point as a plain dot. Marker
+		// styling, dE colouring and tooltips are restored by the full repaint
+		// at sweep end.
+		CDataSetDoc * pDoc = GetDocument ();
+		if ( pDoc->m_SelectedColor.isValid() )
+		{
+			double YWhite = 1.0;
+			if ( pDoc->GetMeasure()->GetPrimeWhite().isValid() )
+				YWhite = pDoc->GetMeasure()->GetPrimeWhite() [ 1 ];
+			else if ( pDoc->GetMeasure()->GetOnOffWhite().isValid() )
+				YWhite = pDoc->GetMeasure()->GetOnOffWhite() [ 1 ];
+
+			CCIEGraphPoint newPoint ( pDoc->m_SelectedColor.GetXYZValue(), YWhite, "", m_Grapher.m_bCIEuv, m_Grapher.m_bCIEab );
+			m_Grapher.DrawGdiPlusMarker ( & dcDraw, & m_Grapher.m_measurePlotBitmap,
+				newPoint.GetGraphX(refrect), newPoint.GetGraphY(refrect), newPoint, false );
+		}
+	}
+	else
+		m_Grapher.DrawChart ( GetDocument (), & dcDraw, refrect, & m_tooltip, this );
+	m_bRealtimeIncrement = FALSE;
 	pDC->BitBlt(0,0,rect.Width(),rect.Height(),&dcDraw,-m_Grapher.m_DeltaX,-m_Grapher.m_DeltaY,SRCCOPY);
 	dcDraw.SelectObject(pOldBitmap);
 }

--- a/Views/ciechartview.h
+++ b/Views/ciechartview.h
@@ -169,6 +169,12 @@ protected:
 // Attributes
 	BOOL	m_bDelayedUpdate;
 
+	// Set when a realtime hint arrives mid-sweep: the next OnDraw paints just
+	// the new measurement over the retained chart bitmap instead of running a
+	// full DrawChart pass (which re-derives every reference point and tooltip,
+	// and made sweeps several times slower while this chart was visible).
+	BOOL	m_bRealtimeIncrement;
+
 	CCIEChartGrapher m_Grapher;
 
 	double	m_refDeltaE;

--- a/datasetdoc.cpp
+++ b/datasetdoc.cpp
@@ -1159,11 +1159,12 @@ void CDataSetDoc::MeasureGrayScale()
 	StopBackgroundMeasures ();
 	MeasureButtonStopScope _btn(this);
 
+	// Views resync even when the sweep is cancelled or fails: a cancelled
+	// sweep keeps the patches measured so far, and the CIE chart relies on
+	// this update to leave its incremental realtime rendering mode.
 	if(m_measure.MeasureGrayScale(m_pSensor,m_pGenerator, this))
-	{
 		SetModifiedFlag(m_measure.IsModified());
-		UpdateAllViews(NULL, UPD_GRAYSCALE);
-	}
+	UpdateAllViews(NULL, UPD_GRAYSCALE);
 }
 
 void CDataSetDoc::MeasureGrayScaleAndColors() 
@@ -1172,10 +1173,8 @@ void CDataSetDoc::MeasureGrayScaleAndColors()
 	MeasureButtonStopScope _btn(this);
 
 	if(m_measure.MeasureGrayScaleAndColors(m_pSensor,m_pGenerator,this))
-	{
 		SetModifiedFlag(m_measure.IsModified());
-		UpdateAllViews(NULL, UPD_GRAYSCALEANDCOLORS);
-	}
+	UpdateAllViews(NULL, UPD_GRAYSCALEANDCOLORS);
 }
 
 void CDataSetDoc::MeasureNearBlackScale() 
@@ -1184,10 +1183,8 @@ void CDataSetDoc::MeasureNearBlackScale()
 	MeasureButtonStopScope _btn(this);
 
 	if(m_measure.MeasureNearBlackScale(m_pSensor,m_pGenerator,this))
-	{
 		SetModifiedFlag(m_measure.IsModified());
-		UpdateAllViews(NULL, UPD_NEARBLACK);
-	}
+	UpdateAllViews(NULL, UPD_NEARBLACK);
 }
 
 void CDataSetDoc::MeasureNearWhiteScale() 
@@ -1196,10 +1193,8 @@ void CDataSetDoc::MeasureNearWhiteScale()
 	MeasureButtonStopScope _btn(this);
 
 	if(m_measure.MeasureNearWhiteScale(m_pSensor,m_pGenerator,this))
-	{
 		SetModifiedFlag(m_measure.IsModified());
-		UpdateAllViews(NULL, UPD_NEARWHITE);
-	}
+	UpdateAllViews(NULL, UPD_NEARWHITE);
 }
 
 void CDataSetDoc::MeasureRedSatScale() 
@@ -1208,10 +1203,8 @@ void CDataSetDoc::MeasureRedSatScale()
 	MeasureButtonStopScope _btn(this);
 
 	if(m_measure.MeasureRedSatScale(m_pSensor,m_pGenerator,this))
-	{
 		SetModifiedFlag(m_measure.IsModified());
-		UpdateAllViews(NULL, UPD_REDSAT);
-	}
+	UpdateAllViews(NULL, UPD_REDSAT);
 }
 
 void CDataSetDoc::MeasureGreenSatScale() 
@@ -1220,10 +1213,8 @@ void CDataSetDoc::MeasureGreenSatScale()
 	MeasureButtonStopScope _btn(this);
 
 	if(m_measure.MeasureGreenSatScale(m_pSensor,m_pGenerator,this))
-	{
 		SetModifiedFlag(m_measure.IsModified());
-		UpdateAllViews(NULL, UPD_GREENSAT);
-	}
+	UpdateAllViews(NULL, UPD_GREENSAT);
 }
 
 void CDataSetDoc::MeasureBlueSatScale() 
@@ -1232,10 +1223,8 @@ void CDataSetDoc::MeasureBlueSatScale()
 	MeasureButtonStopScope _btn(this);
 
 	if(m_measure.MeasureBlueSatScale(m_pSensor,m_pGenerator,this))
-	{
 		SetModifiedFlag(m_measure.IsModified());
-		UpdateAllViews(NULL, UPD_BLUESAT);
-	}
+	UpdateAllViews(NULL, UPD_BLUESAT);
 }
 
 void CDataSetDoc::MeasureYellowSatScale() 
@@ -1244,10 +1233,8 @@ void CDataSetDoc::MeasureYellowSatScale()
 	MeasureButtonStopScope _btn(this);
 
 	if(m_measure.MeasureYellowSatScale(m_pSensor,m_pGenerator,this))
-	{
 		SetModifiedFlag(m_measure.IsModified());
-		UpdateAllViews(NULL, UPD_YELLOWSAT);
-	}
+	UpdateAllViews(NULL, UPD_YELLOWSAT);
 }
 
 void CDataSetDoc::MeasureCyanSatScale() 
@@ -1256,10 +1243,8 @@ void CDataSetDoc::MeasureCyanSatScale()
 	MeasureButtonStopScope _btn(this);
 
 	if(m_measure.MeasureCyanSatScale(m_pSensor,m_pGenerator,this))
-	{
 		SetModifiedFlag(m_measure.IsModified());
-		UpdateAllViews(NULL, UPD_CYANSAT);
-	}
+	UpdateAllViews(NULL, UPD_CYANSAT);
 }
 
 void CDataSetDoc::MeasureMagentaSatScale() 
@@ -1268,20 +1253,16 @@ void CDataSetDoc::MeasureMagentaSatScale()
 	MeasureButtonStopScope _btn(this);
 
 	if(m_measure.MeasureMagentaSatScale(m_pSensor,m_pGenerator,this))
-	{
 		SetModifiedFlag(m_measure.IsModified());
-		UpdateAllViews(NULL, UPD_MAGENTASAT);
-	}
+	UpdateAllViews(NULL, UPD_MAGENTASAT);
 }
 
 void CDataSetDoc::MeasureCC24SatScale() 
 {
 	StopBackgroundMeasures ();
 	if(m_measure.MeasureCC24SatScale(m_pSensor,m_pGenerator,this))
-	{
 		SetModifiedFlag(m_measure.IsModified());
-		UpdateAllViews(NULL, UPD_CC24SAT);
-	}
+	UpdateAllViews(NULL, UPD_CC24SAT);
 }
 
 void CDataSetDoc::MeasureAllSaturationScales() 
@@ -1290,10 +1271,8 @@ void CDataSetDoc::MeasureAllSaturationScales()
 	MeasureButtonStopScope _btn(this);
 
 	if(m_measure.MeasureAllSaturationScales(m_pSensor,m_pGenerator,FALSE,this))
-	{
 		SetModifiedFlag(m_measure.IsModified());
-		UpdateAllViews(NULL, UPD_ALLSATURATIONS);
-	}
+	UpdateAllViews(NULL, UPD_ALLSATURATIONS);
 }
 
 void CDataSetDoc::MeasurePrimarySaturationScales() 
@@ -1302,10 +1281,8 @@ void CDataSetDoc::MeasurePrimarySaturationScales()
 	MeasureButtonStopScope _btn(this);
 
 	if(m_measure.MeasurePrimarySecondarySaturationScales(m_pSensor,m_pGenerator,TRUE,this))
-	{
 		SetModifiedFlag(m_measure.IsModified());
-		UpdateAllViews(NULL, UPD_ALLSATURATIONS);
-	}
+	UpdateAllViews(NULL, UPD_ALLSATURATIONS);
 }
 
 void CDataSetDoc::MeasurePrimarySecondarySaturationScales() 
@@ -1314,10 +1291,8 @@ void CDataSetDoc::MeasurePrimarySecondarySaturationScales()
 	MeasureButtonStopScope _btn(this);
 
 	if(m_measure.MeasurePrimarySecondarySaturationScales(m_pSensor,m_pGenerator,FALSE,this))
-	{
 		SetModifiedFlag(m_measure.IsModified());
-		UpdateAllViews(NULL, UPD_ALLSATURATIONS);
-	}
+	UpdateAllViews(NULL, UPD_ALLSATURATIONS);
 }
 
 void CDataSetDoc::MeasurePrimaries() 
@@ -1326,10 +1301,8 @@ void CDataSetDoc::MeasurePrimaries()
 	MeasureButtonStopScope _btn(this);
 
 	if(m_measure.MeasurePrimaries(m_pSensor,m_pGenerator,this))
-	{
 		SetModifiedFlag(m_measure.IsModified());
-		UpdateAllViews(NULL, UPD_PRIMARIES);
-	}
+	UpdateAllViews(NULL, UPD_PRIMARIES);
 }
 
 void CDataSetDoc::MeasureSecondaries() 
@@ -1338,10 +1311,8 @@ void CDataSetDoc::MeasureSecondaries()
 	MeasureButtonStopScope _btn(this);
 
 	if(m_measure.MeasureSecondaries(m_pSensor,m_pGenerator,this))
-	{
 		SetModifiedFlag(m_measure.IsModified());
-		UpdateAllViews(NULL, UPD_SECONDARIES);
-	}
+	UpdateAllViews(NULL, UPD_SECONDARIES);
 }
 
 void CDataSetDoc::MeasureContrast()


### PR DESCRIPTION
## Problem

With the CIE diagram visible, every sweep patch spent 0.8–2.2s inside the synchronous all-views refresh (>80% of each patch), scaling with the number of stored measures. Instrumentation pinned it: each realtime update ran a full `DrawChart`, re-deriving all ~388 reference points per paint (`GetRefSat`/`GetRefCC24Sat` each do registry reads, `CColorReference` matrix constructions and EOTF/tone-map math per call) and rebuilding all HTML tooltips (~155ms alone).

## Fix

- A realtime hint during a sweep adds exactly one measurement, so the chart now paints just that dot over the retained chart bitmap. Any non-realtime update (sweep end, resize, setting change) still runs the full `DrawChart` with proper marker styling, dE colouring, targets and tooltips.
- Sweep command handlers resync views even when the sweep is cancelled (ESC) or fails — partial measures are retained, and the chart needs that update to leave incremental mode.
- The increment flag is cleared immediately after the synchronous redraw so a skipped paint can't leak it into a later unrelated `WM_PAINT`.

## Measured

Debug build, simulated sensor, CM5SAT set, CIE chart visible: per-patch view update dropped from ~700ms (growing to ~1.6s) to ~95ms; the CIE view's share went from ~625ms to ~1ms plus blit. Live dots still appear per patch; verified visually including ESC mid-sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
