### PR TITLE
CIE chart: pinch-to-zoom, cursor-anchored zoom, pinned coverage chips

### DIFF
--- a/MultiFrm.cpp
+++ b/MultiFrm.cpp
@@ -512,7 +512,13 @@ CView * CMultiFrame::CreateTabbedView ( CCreateContext * pContext, int nIDName, 
 		}
 		else if (!m_bHasStarted && (m_nTabbedViewIndex[0] == IDS_DATASETVIEW_NAME))
 		{
+			// A torn ini write can persist an out-of-range view index; treat
+			// it as "no tab" instead of indexing past g_ViewType, which made
+			// startup die in CFrameWnd::CreateView with a NULL view class
+			int nViewTypes = sizeof(g_ViewType)/sizeof(g_ViewType[0]);
 			int a = GetConfig()->GetProfileInt ( "Tabbed Views", "Tab1", 0 );
+			if ( a < 0 || a >= nViewTypes )
+				a = 0;
 
 			if (a)
 			{
@@ -537,6 +543,8 @@ CView * CMultiFrame::CreateTabbedView ( CCreateContext * pContext, int nIDName, 
 				m_NbTabbedViews ++;
 			}
 			a = GetConfig()->GetProfileInt ( "Tabbed Views", "Tab2", 0 );
+			if ( a < 0 || a >= nViewTypes )
+				a = 0;
 
 			if (a)
 			{
@@ -561,6 +569,8 @@ CView * CMultiFrame::CreateTabbedView ( CCreateContext * pContext, int nIDName, 
 				m_NbTabbedViews ++;
 			}
 			a = GetConfig()->GetProfileInt ( "Tabbed Views", "Tab3", 0 );
+			if ( a < 0 || a >= nViewTypes )
+				a = 0;
 
 			if (a)
 			{

--- a/Views/CIEChartView.cpp
+++ b/Views/CIEChartView.cpp
@@ -3014,29 +3014,36 @@ void CCIEChartView::OnDraw(CDC* pDC)
 		if ( m_composeBitmap.m_hObject )
 			m_composeBitmap.DeleteObject ();
 		m_composeBitmap.CreateCompatibleBitmap ( pDC, rect.Width (), rect.Height () );
-		m_composeSize = rect.Size ();
+		// On GDI resource exhaustion keep the size null so creation retries
+		m_composeSize = m_composeBitmap.m_hObject ? rect.Size () : CSize ( 0, 0 );
 	}
 	CDC dcOut;
 	dcOut.CreateCompatibleDC ( pDC );
-	CBitmap * pOldOut = dcOut.SelectObject ( & m_composeBitmap );
+	CBitmap * pOldOut = m_composeBitmap.m_hObject ? dcOut.SelectObject ( & m_composeBitmap ) : NULL;
+	// If the compose bitmap couldn't be created, paint the window directly
+	// (the chips may flicker) rather than blitting from an empty DC
+	CDC * pOut = pOldOut ? & dcOut : pDC;
 
 	if ( bScalePreview )
 	{
-		dcOut.SetStretchBltMode(HALFTONE);
-		SetBrushOrgEx(dcOut.GetSafeHdc(), 0, 0, NULL);
-		dcOut.StretchBlt(m_Grapher.m_DeltaX, m_Grapher.m_DeltaY, refrect.Width(), refrect.Height(),
+		pOut->SetStretchBltMode(HALFTONE);
+		SetBrushOrgEx(pOut->GetSafeHdc(), 0, 0, NULL);
+		pOut->StretchBlt(m_Grapher.m_DeltaX, m_Grapher.m_DeltaY, refrect.Width(), refrect.Height(),
 			&dcDraw, 0, 0, m_chartW, m_chartH, SRCCOPY);
 	}
 	else
-		dcOut.BitBlt(0,0,rect.Width(),rect.Height(),&dcDraw,-m_Grapher.m_DeltaX,-m_Grapher.m_DeltaY,SRCCOPY);
+		pOut->BitBlt(0,0,rect.Width(),rect.Height(),&dcDraw,-m_Grapher.m_DeltaX,-m_Grapher.m_DeltaY,SRCCOPY);
 	dcDraw.SelectObject(pOldBitmap);
 
 	// The coverage chips are not part of the retained chart, so they stay
 	// pinned to the window's top-right whatever the zoom/pan state
-	m_Grapher.DrawCoverageChips ( & dcOut, rect, pDoc );
+	m_Grapher.DrawCoverageChips ( pOut, rect, pDoc );
 
-	pDC->BitBlt(0,0,rect.Width(),rect.Height(),&dcOut,0,0,SRCCOPY);
-	dcOut.SelectObject(pOldOut);
+	if ( pOldOut )
+	{
+		pDC->BitBlt(0,0,rect.Width(),rect.Height(),&dcOut,0,0,SRCCOPY);
+		dcOut.SelectObject(pOldOut);
+	}
 }
 
 void CCIEChartView::SaveChart() 

--- a/Views/CIEChartView.cpp
+++ b/Views/CIEChartView.cpp
@@ -48,6 +48,12 @@ extern void DrawDeltaECurve(CDC* pDC, int cxMax, int cyMax, double DeltaE, BOOL 
 #define FX_MINSIZETOSHOW_TRIANGLEDETAILS 100
 #define FX_MINSIZETOSHOW_REFDETAILS 300
 
+// Zoom limits. The retained chart bitmaps are canvas-sized, so the canvas
+// cap bounds their memory (~64MB per bitmap at 4096px, which a 32-bit
+// process can afford); it is what actually limits zoom on large panes.
+#define FX_MAXZOOMFACTOR   8000
+#define FX_MAXZOOMCANVASPX 4096
+
 // The HDTV reference used to derive display colours for plot dots and
 // tooltips is built from fixed constants only (verified: the constructor and
 // the reference luma getters read nothing mutable), so build it once instead
@@ -717,6 +723,125 @@ void CCIEChartGrapher::DrawAlphaBitmap(CDC *pDC, const CCIEGraphPoint& aGraphPoi
 		}
 	}
 
+}
+
+// Gamut coverage chips (top right): [gamut] [xy: n%] [u'v': n%]. The
+// gamut-name chip always shows; the coverage percentages are the measured
+// primaries triangle vs the displayed reference triangle (area intersection
+// / reference area) in xy and u'v'. Not shown in CIE a*b* mode (the metric
+// is a chromaticity-plane one). The percentages hide when the gamut is
+// changed until the primaries are re-measured, since old primaries don't
+// belong to the new reference.
+// The row anchors to rcAnchor's top-right: the client rect when overlaid on
+// screen paints (OnDraw calls this after every blit so the chips stay pinned
+// under zoom/pan), the image rect when baked into exports.
+void CCIEChartGrapher::DrawCoverageChips ( CDC * pDC, CRect rcAnchor, CDataSetDoc * pDoc )
+{
+	if ( m_bCIEab || min(rcAnchor.Width(),rcAnchor.Height()) <= FX_MINSIZETOSHOW_REFDETAILS )
+		return;
+
+	ColorXYZ redPrimaryColor=pDoc->GetMeasure()->GetRedPrimary().GetXYZValue();
+	ColorXYZ greenPrimaryColor=pDoc->GetMeasure()->GetGreenPrimary().GetXYZValue();
+	ColorXYZ bluePrimaryColor=pDoc->GetMeasure()->GetBluePrimary().GetXYZValue();
+	BOOL hasPrimaries = redPrimaryColor.isValid() && greenPrimaryColor.isValid() &&
+						bluePrimaryColor.isValid();
+
+	// Short names for the mainstream gamuts; everything else (incl. the
+	// reduced-primary HDTVa/HDTVb pseudo-gamuts) uses its own reference
+	// name so the label always matches the triangle actually drawn.
+	WCHAR gamutName[64];
+	switch (GetColorReference().m_standard)
+	{
+		case HDTV: case UHDTV4: wcscpy_s(gamutName, L"Rec.709");  break;
+		case UHDTV: case UHDTV3: wcscpy_s(gamutName, L"DCI-P3");   break;
+		case UHDTV2:            wcscpy_s(gamutName, L"Rec.2020");  break;
+		default:
+			swprintf_s(gamutName, 64, L"%S", GetColorReference().GetName().c_str());
+			break;
+	}
+
+	// Decide whether the coverage percentages are current. They are stale
+	// (and hidden) if the reference standard changed while the measured
+	// primaries stayed put -- i.e. the gamut was switched without a fresh
+	// measurement. Re-measuring changes the primaries and re-shows them.
+	ColorStandard curStd = GetColorReference().m_standard;
+	BOOL showPct = FALSE;
+	double covXY = 0.0, covUV = 0.0;
+	if (hasPrimaries)
+	{
+		BOOL primsSame = m_covValid
+			&& redPrimaryColor[0]   == m_covPrimaries[0][0] && redPrimaryColor[1]   == m_covPrimaries[0][1] && redPrimaryColor[2]   == m_covPrimaries[0][2]
+			&& greenPrimaryColor[0] == m_covPrimaries[1][0] && greenPrimaryColor[1] == m_covPrimaries[1][1] && greenPrimaryColor[2] == m_covPrimaries[1][2]
+			&& bluePrimaryColor[0]  == m_covPrimaries[2][0] && bluePrimaryColor[1]  == m_covPrimaries[2][1] && bluePrimaryColor[2]  == m_covPrimaries[2][2];
+		BOOL stdSame = m_covValid && (m_covStandard == curStd);
+
+		if (m_covValid && !stdSame && primsSame)
+		{
+			showPct = FALSE;	// gamut changed, primaries not re-measured
+		}
+		else
+		{
+			showPct = TRUE;
+			ColorxyY measured[3] = { ColorxyY(redPrimaryColor),
+									 ColorxyY(greenPrimaryColor),
+									 ColorxyY(bluePrimaryColor) };
+			// the triangle drawn on the chart is the active reference's primaries
+			// (for P3/709 inside a 2020 container these are already the inner gamut)
+			ColorxyY refTri[3] = { ColorxyY(GetColorReference().GetRed()),
+								   ColorxyY(GetColorReference().GetGreen()),
+								   ColorxyY(GetColorReference().GetBlue()) };
+			covXY = GamutCoverage(measured, refTri, GAMUT_PLANE_XY) * 100.0;
+			covUV = GamutCoverage(measured, refTri, GAMUT_PLANE_UV) * 100.0;
+			m_covStandard = curStd;
+			m_covPrimaries[0] = redPrimaryColor;
+			m_covPrimaries[1] = greenPrimaryColor;
+			m_covPrimaries[2] = bluePrimaryColor;
+			m_covValid = TRUE;
+		}
+	}
+
+	// Pill stat chips like the target widget's, anchored top right,
+	// growing leftward from the corner.
+	EnsureGdiplus();
+	Gdiplus::Graphics g(pDC->GetSafeHdc());
+	GpApplyDCOrigin(g, pDC);
+	g.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
+	g.SetTextRenderingHint(Gdiplus::TextRenderingHintAntiAlias);
+	Gdiplus::Font chipFont(L"Segoe UI", 15.0f, Gdiplus::FontStyleRegular, Gdiplus::UnitPixel);
+
+	// neutral chip palette shared with the target widget's dx/dy chip
+	BOOL bDark = !m_bgWhite;
+	Gdiplus::Color nFill   = bDark ? Gdiplus::Color(255, 42, 42, 42)    : Gdiplus::Color(255, 255, 255, 255);
+	Gdiplus::Color nBorder = bDark ? Gdiplus::Color(255, 72, 72, 72)    : Gdiplus::Color(255, 205, 207, 213);
+	Gdiplus::Color nText   = bDark ? Gdiplus::Color(255, 215, 215, 215) : Gdiplus::Color(255, 70, 74, 80);
+
+	// Visual order left-to-right is [gamut] [xy] [u'v']; priority is the
+	// reverse, so if the row can't fit the chart width drop u'v' first,
+	// then xy, always keeping the gamut name.
+	WCHAR uvBuf[64], xyBuf[64];
+	const WCHAR * ordered[3];
+	int nChips = 0;
+	ordered[nChips++] = gamutName;
+	if (showPct)
+	{
+		swprintf_s(xyBuf, 64, L"xy: %.1f%%", covXY);
+		swprintf_s(uvBuf, 64, L"u'v': %.1f%%", covUV);
+		ordered[nChips++] = xyBuf;
+		ordered[nChips++] = uvBuf;
+	}
+
+	const Gdiplus::REAL pad = 8.0f, gap = 6.0f;
+	Gdiplus::REAL avail = (Gdiplus::REAL)rcAnchor.Width() - 2.0f * pad;
+	Gdiplus::REAL total = 0.0f;
+	for (int i = 0; i < nChips; i++)
+		total += MeasureStatChip(g, chipFont, ordered[i]).Width + (i ? gap : 0.0f);
+	while (nChips > 1 && total > avail)	// drop lowest-priority (rightmost) chips
+		total -= MeasureStatChip(g, chipFont, ordered[--nChips]).Width + gap;
+
+	Gdiplus::REAL bottom = (Gdiplus::REAL)rcAnchor.top + pad + MeasureStatChip(g, chipFont, gamutName).Height;
+	Gdiplus::REAL xRight = (Gdiplus::REAL)rcAnchor.right - pad;
+	for (int i = nChips - 1; i >= 0; i--)	// draw right to left
+		xRight -= DrawStatChip(g, chipFont, ordered[i], xRight, bottom, nFill, nBorder, nText) + gap;
 }
 
 void CCIEChartGrapher::DrawChart(CDataSetDoc * pDoc, CDC* pDC, CRect rect, CPPToolTip * pTooltip, CWnd * pWnd)
@@ -1737,105 +1862,11 @@ void CCIEChartGrapher::DrawChart(CDataSetDoc * pDoc, CDC* pDC, CRect rect, CPPTo
 		// mode (the metric is a chromaticity-plane one). The percentages hide
 		// when the gamut is changed until the primaries are re-measured, since
 		// old primaries don't belong to the new reference.
-		if (!m_bCIEab && min(rect.Width(),rect.Height()) > FX_MINSIZETOSHOW_REFDETAILS)
-		{
-			// Short names for the mainstream gamuts; everything else (incl. the
-			// reduced-primary HDTVa/HDTVb pseudo-gamuts) uses its own reference
-			// name so the label always matches the triangle actually drawn.
-			WCHAR gamutName[64];
-			switch (GetColorReference().m_standard)
-			{
-				case HDTV: case UHDTV4: wcscpy_s(gamutName, L"Rec.709");  break;
-				case UHDTV: case UHDTV3: wcscpy_s(gamutName, L"DCI-P3");   break;
-				case UHDTV2:            wcscpy_s(gamutName, L"Rec.2020");  break;
-				default:
-					swprintf_s(gamutName, 64, L"%S", GetColorReference().GetName().c_str());
-					break;
-			}
-
-			// Decide whether the coverage percentages are current. They are stale
-			// (and hidden) if the reference standard changed while the measured
-			// primaries stayed put -- i.e. the gamut was switched without a fresh
-			// measurement. Re-measuring changes the primaries and re-shows them.
-			ColorStandard curStd = GetColorReference().m_standard;
-			BOOL showPct = FALSE;
-			double covXY = 0.0, covUV = 0.0;
-			if (hasPrimaries)
-			{
-				BOOL primsSame = m_covValid
-					&& redPrimaryColor[0]   == m_covPrimaries[0][0] && redPrimaryColor[1]   == m_covPrimaries[0][1] && redPrimaryColor[2]   == m_covPrimaries[0][2]
-					&& greenPrimaryColor[0] == m_covPrimaries[1][0] && greenPrimaryColor[1] == m_covPrimaries[1][1] && greenPrimaryColor[2] == m_covPrimaries[1][2]
-					&& bluePrimaryColor[0]  == m_covPrimaries[2][0] && bluePrimaryColor[1]  == m_covPrimaries[2][1] && bluePrimaryColor[2]  == m_covPrimaries[2][2];
-				BOOL stdSame = m_covValid && (m_covStandard == curStd);
-
-				if (m_covValid && !stdSame && primsSame)
-				{
-					showPct = FALSE;	// gamut changed, primaries not re-measured
-				}
-				else
-				{
-					showPct = TRUE;
-					ColorxyY measured[3] = { ColorxyY(redPrimaryColor),
-											 ColorxyY(greenPrimaryColor),
-											 ColorxyY(bluePrimaryColor) };
-					// the triangle drawn on the chart is the active reference's primaries
-					// (for P3/709 inside a 2020 container these are already the inner gamut)
-					ColorxyY refTri[3] = { ColorxyY(GetColorReference().GetRed()),
-										   ColorxyY(GetColorReference().GetGreen()),
-										   ColorxyY(GetColorReference().GetBlue()) };
-					covXY = GamutCoverage(measured, refTri, GAMUT_PLANE_XY) * 100.0;
-					covUV = GamutCoverage(measured, refTri, GAMUT_PLANE_UV) * 100.0;
-					m_covStandard = curStd;
-					m_covPrimaries[0] = redPrimaryColor;
-					m_covPrimaries[1] = greenPrimaryColor;
-					m_covPrimaries[2] = bluePrimaryColor;
-					m_covValid = TRUE;
-				}
-			}
-
-			// Pill stat chips like the target widget's, anchored top right,
-			// growing leftward from the corner.
-			EnsureGdiplus();
-			Gdiplus::Graphics g(pDC->GetSafeHdc());
-			GpApplyDCOrigin(g, pDC);
-			g.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
-			g.SetTextRenderingHint(Gdiplus::TextRenderingHintAntiAlias);
-			Gdiplus::Font chipFont(L"Segoe UI", 15.0f, Gdiplus::FontStyleRegular, Gdiplus::UnitPixel);
-
-			// neutral chip palette shared with the target widget's dx/dy chip
-			BOOL bDark = !m_bgWhite;
-			Gdiplus::Color nFill   = bDark ? Gdiplus::Color(255, 42, 42, 42)    : Gdiplus::Color(255, 255, 255, 255);
-			Gdiplus::Color nBorder = bDark ? Gdiplus::Color(255, 72, 72, 72)    : Gdiplus::Color(255, 205, 207, 213);
-			Gdiplus::Color nText   = bDark ? Gdiplus::Color(255, 215, 215, 215) : Gdiplus::Color(255, 70, 74, 80);
-
-			// Visual order left-to-right is [gamut] [xy] [u'v']; priority is the
-			// reverse, so if the row can't fit the chart width drop u'v' first,
-			// then xy, always keeping the gamut name.
-			WCHAR uvBuf[64], xyBuf[64];
-			const WCHAR * ordered[3];
-			int nChips = 0;
-			ordered[nChips++] = gamutName;
-			if (showPct)
-			{
-				swprintf_s(xyBuf, 64, L"xy: %.1f%%", covXY);
-				swprintf_s(uvBuf, 64, L"u'v': %.1f%%", covUV);
-				ordered[nChips++] = xyBuf;
-				ordered[nChips++] = uvBuf;
-			}
-
-			const Gdiplus::REAL pad = 8.0f, gap = 6.0f;
-			Gdiplus::REAL avail = (Gdiplus::REAL)rect.Width() - 2.0f * pad;
-			Gdiplus::REAL total = 0.0f;
-			for (int i = 0; i < nChips; i++)
-				total += MeasureStatChip(g, chipFont, ordered[i]).Width + (i ? gap : 0.0f);
-			while (nChips > 1 && total > avail)	// drop lowest-priority (rightmost) chips
-				total -= MeasureStatChip(g, chipFont, ordered[--nChips]).Width + gap;
-
-			Gdiplus::REAL bottom = (Gdiplus::REAL)rect.top + pad + MeasureStatChip(g, chipFont, gamutName).Height;
-			Gdiplus::REAL xRight = (Gdiplus::REAL)rect.right - pad;
-			for (int i = nChips - 1; i >= 0; i--)	// draw right to left
-				xRight -= DrawStatChip(g, chipFont, ordered[i], xRight, bottom, nFill, nBorder, nText) + gap;
-		}
+		// Coverage chips are baked into exports here; screen paints overlay
+		// them in OnDraw after the blit instead, so they stay pinned to the
+		// window's top-right corner while the chart is zoomed or panned.
+		if ( ! pWnd )
+			DrawCoverageChips ( pDC, rect, pDoc );
 
 		if(hasPrimaries && hasSecondaries && !m_bCIEab)
 		{
@@ -2719,6 +2750,9 @@ CCIEChartView::CCIEChartView()
 	m_chartEdit = -1;
 	m_chartdE10 = 0.0;
 	m_chartSelValid = FALSE;
+	m_gestureStartDist = 0.0;
+	m_gestureStartZoom = 1000;
+	m_composeSize = CSize ( 0, 0 );
 }
 
 CCIEChartView::~CCIEChartView()
@@ -2767,6 +2801,7 @@ BEGIN_MESSAGE_MAP(CCIEChartView, CSavingView)
 	ON_WM_MOUSEWHEEL()
 	ON_WM_PAINT()
 	ON_WM_KEYDOWN()
+	ON_MESSAGE(WM_GESTURE, OnGestureMsg)
 	ON_NOTIFY (UDM_TOOLTIP_DISPLAY, NULL, NotifyDisplayTooltip)
 	//}}AFX_MSG_MAP
 END_MESSAGE_MAP()
@@ -2795,6 +2830,12 @@ void CCIEChartView::OnInitialUpdate()
 	m_tooltip.SetBehaviour(PPTOOLTIP_MULTIPLE_SHOW);
 	m_tooltip.SetNotify(TRUE);
 	m_tooltip.SetBorder(::CreateSolidBrush(RGB(212,175,55)),1,1);
+
+	// Touch: keep the pinch gesture for zooming, but block the pan gesture so
+	// single-finger drags promote to the mouse messages the existing
+	// drag-pan/selection code already handles.
+	GESTURECONFIG gestureConfig[] = { { GID_ZOOM, GC_ZOOM, 0 }, { GID_PAN, 0, GC_PAN } };
+	::SetGestureConfig ( m_hWnd, 0, 2, gestureConfig, sizeof ( GESTURECONFIG ) );
 }
 
 void CCIEChartView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
@@ -2889,6 +2930,10 @@ void CCIEChartView::OnDraw(CDC* pDC)
 	CRect rect, refrect;
 	GetClientRect(&rect);
 	GetReferenceRect(&refrect);
+	if ( rect.Width () <= 0 || rect.Height () <= 0 )
+		return;
+
+	BOOL bScalePreview = FALSE;
 
 	// State DrawChart reads directly, with no update hint reaching this view
 	// when it changes: MainView mode/edit state, the worst-dE threshold, and
@@ -2939,16 +2984,12 @@ void CCIEChartView::OnDraw(CDC* pDC)
 		// Nothing changed since the last full render: the retained bitmap is
 		// current and the blit below is the whole repaint (hover, uncover)
 	}
-	else if ( m_bResizeSettling && m_chartW > 0 && m_Grapher.m_ZoomFactor <= 1000 )
+	else if ( m_bResizeSettling && m_chartW > 0 )
 	{
-		// Live resize: scale the retained chart to the moving size and skip
-		// the ~0.5s full render; the resize settle timer renders once for
-		// real when the drag stops
-		pDC->SetStretchBltMode(HALFTONE);
-		SetBrushOrgEx(pDC->GetSafeHdc(), 0, 0, NULL);
-		pDC->StretchBlt(0,0,rect.Width(),rect.Height(),&dcDraw,0,0,m_chartW,m_chartH,SRCCOPY);
-		dcDraw.SelectObject(pOldBitmap);
-		return;
+		// Live resize or zoom: scale the retained chart into the current
+		// canvas placement (refrect at the pan deltas) and skip the full
+		// render; the settle timer renders once for real when it pauses
+		bScalePreview = TRUE;
 	}
 	else
 	{
@@ -2964,8 +3005,38 @@ void CCIEChartView::OnDraw(CDC* pDC)
 		m_bChartDirty = FALSE;
 	}
 	m_bRealtimeIncrement = FALSE;
-	pDC->BitBlt(0,0,rect.Width(),rect.Height(),&dcDraw,-m_Grapher.m_DeltaX,-m_Grapher.m_DeltaY,SRCCOPY);
+
+	// Compose the visible chart and the pinned chip overlay off-screen and
+	// flip to the window in a single blit: painting them in two steps
+	// directly on screen made the chip corner flicker on every pan repaint
+	if ( m_composeSize != rect.Size () )
+	{
+		if ( m_composeBitmap.m_hObject )
+			m_composeBitmap.DeleteObject ();
+		m_composeBitmap.CreateCompatibleBitmap ( pDC, rect.Width (), rect.Height () );
+		m_composeSize = rect.Size ();
+	}
+	CDC dcOut;
+	dcOut.CreateCompatibleDC ( pDC );
+	CBitmap * pOldOut = dcOut.SelectObject ( & m_composeBitmap );
+
+	if ( bScalePreview )
+	{
+		dcOut.SetStretchBltMode(HALFTONE);
+		SetBrushOrgEx(dcOut.GetSafeHdc(), 0, 0, NULL);
+		dcOut.StretchBlt(m_Grapher.m_DeltaX, m_Grapher.m_DeltaY, refrect.Width(), refrect.Height(),
+			&dcDraw, 0, 0, m_chartW, m_chartH, SRCCOPY);
+	}
+	else
+		dcOut.BitBlt(0,0,rect.Width(),rect.Height(),&dcDraw,-m_Grapher.m_DeltaX,-m_Grapher.m_DeltaY,SRCCOPY);
 	dcDraw.SelectObject(pOldBitmap);
+
+	// The coverage chips are not part of the retained chart, so they stay
+	// pinned to the window's top-right whatever the zoom/pan state
+	m_Grapher.DrawCoverageChips ( & dcOut, rect, pDoc );
+
+	pDC->BitBlt(0,0,rect.Width(),rect.Height(),&dcOut,0,0,SRCCOPY);
+	dcOut.SelectObject(pOldOut);
 }
 
 void CCIEChartView::SaveChart() 
@@ -3047,16 +3118,13 @@ void CCIEChartView::OnSize(UINT nType, int cx, int cy)
 
 		if ( m_Grapher.m_ZoomFactor > 1000 )
 		{
-			// Zoom is active: adjust deltaX and deltaY
-			CRect RefRect;
-			do
-			{
-				RefRect = CRect(CPoint(0,0),CSize(cx*m_Grapher.m_ZoomFactor/1000,cy*m_Grapher.m_ZoomFactor/1000));
-				if ( m_Grapher.m_ZoomFactor >= 1200 && ( RefRect.Width () > 2000 || RefRect.Height () > 2000 ) )
-					m_Grapher.m_ZoomFactor -= 250;
-				else
-					break;
-			} while ( TRUE );
+			// Zoom is active: keep the zoomed canvas below the size cap
+			// (the factor is continuous now, so clamp instead of stepping)
+			// and adjust deltaX and deltaY
+			int nMaxFactor = min ( FX_MAXZOOMFACTOR, FX_MAXZOOMCANVASPX * 1000 / max ( cx, cy ) );
+			m_Grapher.m_ZoomFactor = max ( 1000, min ( (int) m_Grapher.m_ZoomFactor, nMaxFactor ) );
+
+			CRect RefRect(CPoint(0,0),CSize(cx*m_Grapher.m_ZoomFactor/1000,cy*m_Grapher.m_ZoomFactor/1000));
 
 			if ( RefRect.right + m_Grapher.m_DeltaX < ClientRect.right )
 				m_Grapher.m_DeltaX = ClientRect.right - RefRect.right;
@@ -3065,9 +3133,7 @@ void CCIEChartView::OnSize(UINT nType, int cx, int cy)
 				m_Grapher.m_DeltaY = ClientRect.bottom - RefRect.bottom;
 		}
 
-		KillTimer(IDT_CIE_RESIZE_SETTLE);
-		SetTimer(IDT_CIE_RESIZE_SETTLE, 80, NULL);
-		m_bResizeSettling = TRUE;	// OnDraw scales the retained chart until the timer fires
+		SchedulePreviewSettle ( 80 );
 	}
 	Invalidate(FALSE);
 }
@@ -3257,48 +3323,42 @@ void CCIEChartView::OnCieShowMeasurements()
 	Invalidate(FALSE);
 }
 
-void CCIEChartView::OnGraphZoomIn() 
+// Restart the settle timer: OnDraw paints scaled previews of the retained
+// chart until the timer fires and runs the one real render.
+void CCIEChartView::SchedulePreviewSettle ( UINT nDelayMs )
 {
-	CRect	ClientRect, RefRect;
-	GetClientRect ( & ClientRect );
-
-	m_Grapher.m_ZoomFactor += 250;
-	if ( m_Grapher.m_ZoomFactor > 4000 )
-		m_Grapher.m_ZoomFactor = 4000;
-
-	GetReferenceRect ( & RefRect );
-	if ( m_Grapher.m_ZoomFactor >= 1200 && ( RefRect.Width () > 3000 || RefRect.Height () > 3000 ) )
-	{
-		m_Grapher.m_ZoomFactor -= 250;
-		GetReferenceRect ( & RefRect );
-	}
-
-	if ( m_Grapher.m_DeltaX > 0 )
-		m_Grapher.m_DeltaX = 0;
-	else if ( m_Grapher.m_DeltaX < ClientRect.right - RefRect.right )
-		m_Grapher.m_DeltaX = ClientRect.right - RefRect.right;
-
-	if ( m_Grapher.m_DeltaY > 0 )
-		m_Grapher.m_DeltaY = 0;
-	else if ( m_Grapher.m_DeltaY < ClientRect.bottom - RefRect.bottom )
-		m_Grapher.m_DeltaY = ClientRect.bottom - RefRect.bottom;
-
-	m_Grapher.MakeBgBitmap(RefRect,GetConfig()->m_bWhiteBkgndOnScreen);
-	
-	Invalidate ( TRUE );
+	KillTimer(IDT_CIE_RESIZE_SETTLE);
+	SetTimer(IDT_CIE_RESIZE_SETTLE, nDelayMs, NULL);
+	m_bResizeSettling = TRUE;
 }
 
-void CCIEChartView::OnGraphZoomOut() 
+// Anchored zoom shared by the mouse wheel, the menu commands and the pinch
+// gesture: the chart point under ptAnchorClient stays put while the factor
+// changes. Paints preview by scaling the retained chart; the settle timer
+// runs the one real render when the zooming pauses.
+void CCIEChartView::ZoomChart ( int nNewFactor, CPoint ptAnchorClient )
 {
 	CRect	ClientRect, RefRect;
 	GetClientRect ( & ClientRect );
+	if ( ClientRect.Width () <= 0 || ClientRect.Height () <= 0 )
+		return;
 
-	m_Grapher.m_ZoomFactor -= 250;
-	if ( m_Grapher.m_ZoomFactor < 1000 )
-		m_Grapher.m_ZoomFactor = 1000;
+	// Keep the zoomed canvas (= retained bitmap size) capped
+	int nMaxSide = max ( ClientRect.Width (), ClientRect.Height () );
+	int nMaxFactor = min ( FX_MAXZOOMFACTOR, FX_MAXZOOMCANVASPX * 1000 / nMaxSide );
+	nNewFactor = max ( 1000, min ( nNewFactor, nMaxFactor ) );
+
+	int nOldFactor = (int) m_Grapher.m_ZoomFactor;
+	if ( nNewFactor == nOldFactor )
+		return;
+
+	// Keep the canvas point under the anchor stationary: canvas coordinates
+	// scale by the factor ratio, deltas are the (negative) canvas origin
+	m_Grapher.m_ZoomFactor = nNewFactor;
+	m_Grapher.m_DeltaX = ptAnchorClient.x - (int) ( (__int64) ( ptAnchorClient.x - m_Grapher.m_DeltaX ) * nNewFactor / nOldFactor );
+	m_Grapher.m_DeltaY = ptAnchorClient.y - (int) ( (__int64) ( ptAnchorClient.y - m_Grapher.m_DeltaY ) * nNewFactor / nOldFactor );
 
 	GetReferenceRect ( & RefRect );
-
 	if ( m_Grapher.m_DeltaX > 0 )
 		m_Grapher.m_DeltaX = 0;
 	else if ( m_Grapher.m_DeltaX < ClientRect.right - RefRect.right )
@@ -3309,9 +3369,23 @@ void CCIEChartView::OnGraphZoomOut()
 	else if ( m_Grapher.m_DeltaY < ClientRect.bottom - RefRect.bottom )
 		m_Grapher.m_DeltaY = ClientRect.bottom - RefRect.bottom;
 
-	m_Grapher.MakeBgBitmap(RefRect,GetConfig()->m_bWhiteBkgndOnScreen);
-	
-	Invalidate ( TRUE );
+	// Preview now, render for real once the zoom pauses
+	SchedulePreviewSettle ( 120 );
+	Invalidate ( FALSE );
+}
+
+void CCIEChartView::OnGraphZoomIn()
+{
+	CRect ClientRect;
+	GetClientRect ( & ClientRect );
+	ZoomChart ( m_Grapher.m_ZoomFactor * 5 / 4, ClientRect.CenterPoint () );
+}
+
+void CCIEChartView::OnGraphZoomOut()
+{
+	CRect ClientRect;
+	GetClientRect ( & ClientRect );
+	ZoomChart ( m_Grapher.m_ZoomFactor * 4 / 5, ClientRect.CenterPoint () );
 }
 
 void CCIEChartView::OnCieUv() 
@@ -3426,16 +3500,14 @@ void CCIEChartView::OnLButtonUp(UINT nFlags, CPoint point)
 			
 			m_CurMousePoint = point;
 
-			ScrollWindow ( m_Grapher.m_DeltaX - OldDeltaX, m_Grapher.m_DeltaY - OldDeltaY );
-
-			// The scrolled blit shows the panned chart, but the tooltip rects
-			// registered by the last full render are anchored to the old
-			// deltas: schedule one deferred render to re-anchor them
 			if ( m_Grapher.m_DeltaX != OldDeltaX || m_Grapher.m_DeltaY != OldDeltaY )
 			{
-				KillTimer(IDT_CIE_RESIZE_SETTLE);
-				SetTimer(IDT_CIE_RESIZE_SETTLE, 80, NULL);
-				m_bResizeSettling = TRUE;
+				// Repaint from the retained canvas at the new deltas (a cheap
+				// blit). ScrollWindow would drag the pinned chip overlay along
+				// with the pixels and leave trails. The settle render then
+				// re-anchors the tooltip rects to the new deltas.
+				Invalidate ( FALSE );
+				SchedulePreviewSettle ( 80 );
 			}
 		}
 
@@ -3473,14 +3545,11 @@ void CCIEChartView::OnMouseMove(UINT nFlags, CPoint point)
 			
 			m_CurMousePoint = point;
 
-			ScrollWindow ( m_Grapher.m_DeltaX - OldDeltaX, m_Grapher.m_DeltaY - OldDeltaY );
-
-			// Re-anchor tooltip rects once the pan pauses (see OnLButtonUp)
+			// Repaint at the new deltas instead of ScrollWindow (see OnLButtonUp)
 			if ( m_Grapher.m_DeltaX != OldDeltaX || m_Grapher.m_DeltaY != OldDeltaY )
 			{
-				KillTimer(IDT_CIE_RESIZE_SETTLE);
-				SetTimer(IDT_CIE_RESIZE_SETTLE, 80, NULL);
-				m_bResizeSettling = TRUE;
+				Invalidate ( FALSE );
+				SchedulePreviewSettle ( 80 );
 			}
 		}
 
@@ -3489,46 +3558,50 @@ void CCIEChartView::OnMouseMove(UINT nFlags, CPoint point)
 }
 
 
-BOOL CCIEChartView::OnMouseWheel(UINT nFlags, short zDelta, CPoint pt) 
+BOOL CCIEChartView::OnMouseWheel(UINT nFlags, short zDelta, CPoint pt)
 {
-	// TODO: Add your message handler code here and/or call default
-	CRect	ClientRect, RefRect;
-	GetClientRect ( & ClientRect );
-
-	if ( zDelta < 0 )
-	{
-		m_Grapher.m_ZoomFactor += 250;
-		if ( m_Grapher.m_ZoomFactor > 4000 )
-			m_Grapher.m_ZoomFactor = 4000;
-
-		GetReferenceRect ( & RefRect );
-		if ( m_Grapher.m_ZoomFactor >= 1200 && ( RefRect.Width () > 3000 || RefRect.Height () > 3000 ) )
-			m_Grapher.m_ZoomFactor -= 250;
-	}
-	else if ( zDelta > 0 )
-	{
-		m_Grapher.m_ZoomFactor -= 250;
-		if ( m_Grapher.m_ZoomFactor < 1000 )
-			m_Grapher.m_ZoomFactor = 1000;
-	}
-
-	GetReferenceRect ( & RefRect );
-
-	if ( m_Grapher.m_DeltaX > 0 )
-		m_Grapher.m_DeltaX = 0;
-	else if ( m_Grapher.m_DeltaX < ClientRect.right - RefRect.right )
-		m_Grapher.m_DeltaX = ClientRect.right - RefRect.right;
-
-	if ( m_Grapher.m_DeltaY > 0 )
-		m_Grapher.m_DeltaY = 0;
-	else if ( m_Grapher.m_DeltaY < ClientRect.bottom - RefRect.bottom )
-		m_Grapher.m_DeltaY = ClientRect.bottom - RefRect.bottom;
-
-	m_Grapher.MakeBgBitmap(RefRect,GetConfig()->m_bWhiteBkgndOnScreen);
-	
-	Invalidate ( FALSE );
-
+	// Wheel up zooms in, anchored at the cursor. Precision touchpads deliver
+	// pinches as fine-grained Ctrl+wheel, so scale the step by the actual
+	// delta instead of a fixed notch for a smooth pinch.
+	ScreenToClient ( & pt );
+	double ratio = pow ( 1.25, (double) zDelta / 120.0 );
+	ZoomChart ( (int) ( m_Grapher.m_ZoomFactor * ratio + 0.5 ), pt );
 	return TRUE;
+}
+
+// Touch pinch (WM_GESTURE / GID_ZOOM): ullArguments carries the distance
+// between the two touch points; zoom follows the ratio to the distance
+// captured when the gesture began, anchored at the gesture center.
+LRESULT CCIEChartView::OnGestureMsg(WPARAM wParam, LPARAM lParam)
+{
+	GESTUREINFO gi;
+	ZeroMemory ( & gi, sizeof ( gi ) );
+	gi.cbSize = sizeof ( gi );
+
+	if ( ! ::GetGestureInfo ( (HGESTUREINFO) lParam, & gi ) || gi.dwID != GID_ZOOM )
+		return DefWindowProc ( WM_GESTURE, wParam, lParam );
+
+	if ( gi.dwFlags & GF_BEGIN )
+	{
+		m_gestureStartDist = (double) (ULONGLONG) gi.ullArguments;
+		m_gestureStartZoom = m_Grapher.m_ZoomFactor;
+	}
+	else if ( gi.dwFlags & GF_END )
+	{
+		// The END event repeats the last distance; nothing to zoom. Reset the
+		// baseline so a stray GID_ZOOM without GF_BEGIN can't scale against a
+		// previous gesture's distance.
+		m_gestureStartDist = 0.0;
+	}
+	else if ( m_gestureStartDist > 0.0 )
+	{
+		CPoint pt ( gi.ptsLocation.x, gi.ptsLocation.y );
+		ScreenToClient ( & pt );
+		ZoomChart ( (int) ( (double) m_gestureStartZoom * (double) (ULONGLONG) gi.ullArguments / m_gestureStartDist + 0.5 ), pt );
+	}
+
+	::CloseGestureInfoHandle ( (HGESTUREINFO) lParam );
+	return 0;
 }
 
 void CCIEChartView::UpdateTestColor ( CPoint point )
@@ -3639,14 +3712,11 @@ void CCIEChartView::OnKeyDown(UINT nChar, UINT nRepCnt, UINT nFlags)
 	else if ( m_Grapher.m_DeltaY < ClientRect.bottom - RefRect.bottom )
 		m_Grapher.m_DeltaY = ClientRect.bottom - RefRect.bottom;
 
-	ScrollWindow ( m_Grapher.m_DeltaX - OldDeltaX, m_Grapher.m_DeltaY - OldDeltaY );
-
-	// Re-anchor tooltip rects once the pan pauses (see OnLButtonUp)
+	// Repaint at the new deltas instead of ScrollWindow (see OnLButtonUp)
 	if ( m_Grapher.m_DeltaX != OldDeltaX || m_Grapher.m_DeltaY != OldDeltaY )
 	{
-		KillTimer(IDT_CIE_RESIZE_SETTLE);
-		SetTimer(IDT_CIE_RESIZE_SETTLE, 80, NULL);
-		m_bResizeSettling = TRUE;
+		Invalidate ( FALSE );
+		SchedulePreviewSettle ( 80 );
 	}
 
 	CSavingView::OnKeyDown(nChar, nRepCnt, nFlags);

--- a/Views/ciechartview.h
+++ b/Views/ciechartview.h
@@ -156,6 +156,7 @@ class CCIEChartGrapher
 
 	// Operations
 	void MakeBgBitmap(CRect rect,BOOL bWhiteBkgnd);
+	void DrawCoverageChips(CDC *pDC, CRect rcAnchor, CDataSetDoc * pDoc);
 	void DrawAlphaBitmap(CDC *pDC, const CCIEGraphPoint& aGraphPoint, CBitmap *pBitmap, CRect rect, CPPToolTip * pTooltip, CWnd * pWnd, CCIEGraphPoint * pRefPoint = NULL, bool isSelected = FALSE, double dE10=100.0, bool isPrimeSec = FALSE);
 	bool DrawGdiPlusMarker(CDC *pDC, CBitmap *pBitmap, int x, int y, const CCIEGraphPoint& aGraphPoint, bool isSelected);
 	void DrawChart(CDataSetDoc * pDoc, CDC* pDC, CRect rect, CPPToolTip * pTooltip, CWnd * pWnd);
@@ -203,6 +204,17 @@ protected:
 	BOOL	m_chartSelValid;
 	ColorXYZ	m_chartSel;
 
+	// Pinch-to-zoom state: distance between the two touch points and the
+	// zoom factor captured when the gesture began (GF_BEGIN).
+	double	m_gestureStartDist;
+	UINT	m_gestureStartZoom;
+
+	// Client-sized compose buffer: the chart blit and the pinned chip
+	// overlay are combined here and reach the screen in one blit, otherwise
+	// the chips flicker on every pan/zoom repaint.
+	CBitmap	m_composeBitmap;
+	CSize	m_composeSize;
+
 	CCIEChartGrapher m_Grapher;
 
 	double	m_refDeltaE;
@@ -220,6 +232,8 @@ public:
 public:
 	void	UpdateTestColor ( CPoint point );
 	void	GetReferenceRect ( LPRECT lpRect );		// Returns client rect with size increased regarding zoom factor
+	void	ZoomChart ( int nNewFactor, CPoint ptAnchorClient );	// Anchored zoom shared by wheel, menu and pinch
+	void	SchedulePreviewSettle ( UINT nDelayMs );	// Preview paints until the settle timer runs the real render
 // Overrides
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CCIEChartView)
@@ -283,6 +297,7 @@ protected:
 	afx_msg void OnKeyDown(UINT nChar, UINT nRepCnt, UINT nFlags);
 	afx_msg void NotifyDisplayTooltip(NMHDR * pNMHDR, LRESULT * result);
 	afx_msg void OnTimer(UINT_PTR nIDEvent);
+	afx_msg LRESULT OnGestureMsg(WPARAM wParam, LPARAM lParam);
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };


### PR DESCRIPTION
## What

- **Anchored zoom** — a shared `ZoomChart` keeps the chart point under the cursor (wheel), pinch center (touch), or window center (menu/Alt+arrows) stationary while zooming. Previously zoom crept toward the top-left in fixed 25% steps.
- **Pinch-to-zoom** — touch screens via `WM_GESTURE`/`GID_ZOOM` (zoom follows the finger-distance ratio from gesture start; the pan gesture is blocked so one-finger drags keep driving the existing mouse pan). Precision-touchpad pinches arrive as fine Ctrl+wheel and now scale smoothly by the actual delta.
- **Wheel direction** — wheel up now zooms in (was inverted).
- **Deeper zoom** — cap raised 4x → 8x, bounded by a 4096px canvas cap (retained chart bitmaps are canvas-sized; ~64MB per bitmap worst case, fine for the 32-bit process). Large panes are still canvas-limited; going beyond that needs viewport-only rendering (future work, pairs with reference-point caching).
- **Zoom/pan feel** — zoom steps preview by scaling the retained chart with the real render deferred to the settle timer; pans repaint from the retained canvas instead of `ScrollWindow` (which dragged overlay pixels around).
- **Pinned coverage chips** — the gamut/coverage stat chips are no longer baked into the on-screen chart; `OnDraw` composes chart + chips off-screen and flips in one blit, so they stay fixed in the window's top-right, flicker-free, under any zoom/pan. Exports still bake them into the image corner.
- **Startup robustness** (separate commit) — a torn `ColorHCFR.ini` write (duplicated `Tab1` key, out-of-range `Tab2=11`) made the tabbed-view restore index past the view-type table and killed startup with a debug assertion. Out-of-range saved indices are now treated as "no tab".

## Review

Multi-angle code review run on the diff: gesture-state hardening applied (baseline reset on `GF_END`), clamp simplified, settle-timer scheduling deduplicated into `SchedulePreviewSettle`, zoom caps named (`FX_MAXZOOMFACTOR`/`FX_MAXZOOMCANVASPX`). Verified by hand on-device: wheel/pinch/menu zoom, drag + arrow pan, tooltips after pan settle, chips pinned during all of it, exports unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
