### PR TITLE
Reset the correct measure buttons when a sweep is stopped

### DIFF
--- a/Views/MainView.cpp
+++ b/Views/MainView.cpp
@@ -549,6 +549,7 @@ END_MESSAGE_MAP()
 // Tool functions and variables implemented in DataSetDoc.cpp
 BOOL StartBackgroundMeasures ( CDataSetDoc * pDoc );
 void StopBackgroundMeasures ();
+BOOL IsAllLevelsSweepActive ();
 extern CDataSetDoc *	g_pDataDocRunningThread;
 extern BOOL				g_bTerminateThread;
 extern CWinThread*			g_hThread;
@@ -5854,7 +5855,12 @@ void CMainView::OnSelchangeComboMode()
 	if(m_pGrayScaleGrid)
 		UpdateGrid();
 	if ( IsMeasureSweepActive() )
-		SetMeasureButtonStop ( TRUE );
+	{
+		if ( IsAllLevelsSweepActive() )
+			SetAllLevelsButtonStop ( TRUE );
+		else
+			SetMeasureButtonStop ( TRUE );
+	}
 }
 
 BOOL CMainView::CurrentModeSweepHasData()
@@ -6287,7 +6293,28 @@ void CMainView::SetMeasureButtonStop(BOOL bStop)
 		SetMeasureButtonForMode ();
 }
 
-void CMainView::OnMeasureGrayScale() 
+void CMainView::SetAllLevelsButtonStop(BOOL bStop)
+{
+	if ( !m_satAllLevelsButton.GetSafeHwnd () )
+		return;
+
+	if ( bStop )
+	{
+		m_satAllLevelsButton.SetIcon ( HCFR_LoadPngHIcon ( _T("toolbar"), _T("measure-stop"), (fxUseCustomColor!=FALSE), HCFR_ScaleIconPx(24,GetSafeHwnd()), HCFR_ScaleIconPx(24,GetSafeHwnd()) ), (HICON)NULL );
+		CString sStop; sStop.LoadString ( IDS_STOPSWEEP ); m_satAllLevelsButton.SetTooltipText ( sStop );
+		CString sBtn; sBtn.LoadString ( IDS_STOP_BTN ); m_satAllLevelsButton.SetWindowText ( sBtn );
+		m_satAllLevelsButton.SetRoundedBorder ( RGB(211,47,47) );   // red: measuring (click to stop)
+	}
+	else
+	{
+		m_satAllLevelsButton.SetIcon ( HCFR_LoadPngHIcon ( _T("toolbar"), _T("measure-sat-all"), (fxUseCustomColor!=FALSE), HCFR_ScaleIconPx(24,GetSafeHwnd()), HCFR_ScaleIconPx(24,GetSafeHwnd()) ), (HICON)NULL );
+		CString sBtn; sBtn.LoadString ( IDS_ALLSTIM_BTN ); m_satAllLevelsButton.SetWindowText ( sBtn );
+		CString sTip; sTip.LoadString ( IDS_ALLSTIM_TIP ); m_satAllLevelsButton.SetTooltipText ( sTip );
+		m_satAllLevelsButton.SetRoundedBorder ( ButtonBorderColor() );
+	}
+}
+
+void CMainView::OnMeasureGrayScale()
 {
 	if ( IsMeasureSweepActive() )
 	{
@@ -9215,7 +9242,13 @@ void CMainView::OnRefs()
 
 void CMainView::OnMeasureSatColorAllLevels()
 {
-	if ( IsMeasureSweepActive() ) return;
+	// While a sweep runs this button shows the red "click to stop" state
+	// (SetAllLevelsButtonStop), so a click here must abort -- mirror OnMeasureGrayScale.
+	if ( IsMeasureSweepActive() )
+	{
+		GetDocument()->GetMeasure()->AbortMeasure();
+		return;
+	}
 	if ( m_displayMode < 5 || m_displayMode > 10 ) return;   // saturation modes only
 	GetDocument()->MeasureSatColorAllLevels( m_displayMode - 5 );   // 0=R..5=M
 }
@@ -9223,5 +9256,19 @@ void CMainView::OnMeasureSatColorAllLevels()
 BOOL CMainView::PreTranslateMessage(MSG* pMsg)
 {
 	m_tooltip.RelayEvent(pMsg);
+
+	// Continuous free-run measurement (case 2's "Run continuous" toggle) is driven by a
+	// background thread that has no accelerator wired to it -- Escape falls through untouched,
+	// so the Go button is stuck showing its red "click to stop" state. Only act when this view's
+	// own document owns the running thread: OnContinuousMeasurement() toggles based on
+	// g_pDataDocRunningThread, and calling it for an unrelated document would stop that one and
+	// start a new run here instead of just cancelling.
+	if ( pMsg->message == WM_KEYDOWN && pMsg->wParam == VK_ESCAPE &&
+	     g_pDataDocRunningThread && g_pDataDocRunningThread == GetDocument() )
+	{
+		GetDocument()->OnContinuousMeasurement();
+		return TRUE;
+	}
+
 	return CWnd::PreTranslateMessage(pMsg);
 }

--- a/Views/MainView.h
+++ b/Views/MainView.h
@@ -308,6 +308,7 @@ protected:
 	void SetMeasureButtonForMode();
 public:
 	void SetMeasureButtonStop(BOOL bStop);
+	void SetAllLevelsButtonStop(BOOL bStop);
 protected:
 	afx_msg void OnDeleteGrayscale();
 	afx_msg void OnSize(UINT nType, int cx, int cy);

--- a/datasetdoc.cpp
+++ b/datasetdoc.cpp
@@ -1136,12 +1136,22 @@ BOOL CDataSetDoc::CanCloseFrame(CFrameWnd* pFrame)
 }
 
 
+static volatile BOOL g_bAllLevelsSweepActive = FALSE;
+BOOL IsAllLevelsSweepActive() { return g_bAllLevelsSweepActive; }
+
 namespace {
 struct MeasureButtonStopScope
 {
 	CDataSetDoc * m_pDoc;
-	explicit MeasureButtonStopScope(CDataSetDoc * pDoc) : m_pDoc(pDoc) { Set(TRUE); }
-	~MeasureButtonStopScope() { Set(FALSE); }
+	bool m_bAllLevels;
+	// bAllLevels: the "All stim" button drives this sweep (CDataSetDoc::MeasureSatColorAllLevels),
+	// so it -- not the per-hue Go button -- should show the red "click to stop" state.
+	explicit MeasureButtonStopScope(CDataSetDoc * pDoc, bool bAllLevels = false) : m_pDoc(pDoc), m_bAllLevels(bAllLevels)
+	{
+		if (m_bAllLevels) g_bAllLevelsSweepActive = TRUE;
+		Set(TRUE);
+	}
+	~MeasureButtonStopScope() { Set(FALSE); if (m_bAllLevels) g_bAllLevelsSweepActive = FALSE; }
 	void Set(BOOL bStop)
 	{
 		if (!m_pDoc) return;
@@ -1150,7 +1160,12 @@ struct MeasureButtonStopScope
 		{
 			CView * v = m_pDoc->GetNextView(pos);
 			if (v && v->IsKindOf(RUNTIME_CLASS(CMainView)))
-				((CMainView*)v)->SetMeasureButtonStop(bStop);
+			{
+				if (m_bAllLevels)
+					((CMainView*)v)->SetAllLevelsButtonStop(bStop);
+				else
+					((CMainView*)v)->SetMeasureButtonStop(bStop);
+			}
 		}
 	}
 };
@@ -4859,7 +4874,7 @@ void CDataSetDoc::MeasureSatColorAllLevels(int hue)
 		return;
 
 	StopBackgroundMeasures ();
-	MeasureButtonStopScope _btn(this);
+	MeasureButtonStopScope _btn(this, true);
 
 	std::vector<double> levels;
 	ParseSatStimLevels ( levels );


### PR DESCRIPTION
Two button-state fixes in the measurement UI.

## Continuous measurement: Escape now resets the button
The continuous (free-run) sweep is driven by a background thread with no accelerator wired to it, so pressing Escape fell through untouched and the Go button stayed stuck in its red "click to stop" state. `CMainView::PreTranslateMessage` now toggles it off via `OnContinuousMeasurement`, guarded so it only acts when this view's own document owns the running thread.

## Saturation "All stim" sweep: correct button shows and honors stop
The all-levels sweep used the shared `MeasureButtonStopScope`, which lit up the main **Go** button rather than the **All stim** button that launched it — and clicking that red button did nothing.

- `MeasureButtonStopScope` gains a `bAllLevels` flag that targets `m_satAllLevelsButton` (new `SetAllLevelsButtonStop`).
- `OnMeasureSatColorAllLevels` now calls `AbortMeasure()` when clicked mid-sweep, mirroring `OnMeasureGrayScale`, so the red stop button actually stops the run.

## Notes
- Rebased onto current `main` (includes the ASCII-normalization from #149).
- Builds clean (Debug/Win32, 0 errors). Verified in-app: continuous Escape resets the button; the All-stim button turns red and stops the sweep.
- Known edge case left as-is: switching the mode dropdown to a non-saturation mode mid all-levels sweep hides the All-stim stop button (Escape still aborts). A clean fix would require a mode-switch-during-sweep policy decision, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)