### PR TITLE
/accuracytest: automated reference==wire==sensor-model accuracy matrix

### DIFF
--- a/AccuracyTest.cpp
+++ b/AccuracyTest.cpp
@@ -172,6 +172,7 @@ struct KnownFail
 	int				eotf;		// -1 = any / 57 = HDR (5 or 7)
 	int				family;		// Family, or -1 = any
 	int				grids;		// bitmask over kGrids indices (0xF = any)
+	double			ceiling;	// dE above which this is a REAL fail, not the known gap
 	const char *	reason;
 };
 
@@ -179,6 +180,11 @@ struct KnownFail
 #define GRID_8LIM  0x1	// kGrids[0]
 #define GRID_FULL  0xA	// kGrids[1] (8b-full) | kGrids[3] (10b-full)
 
+// The `ceiling` on each entry bounds the known gap: a matching combo is only
+// downgraded to KNOWN-FAIL while its worst dE stays <= ceiling; a larger dE is
+// a REAL fail (the known issue got WORSE = a regression the entry must not
+// mask). Ceilings sit above the first-full-run worst per class (comments give
+// the observed max) with headroom, tight enough to still catch a regression.
 static const KnownFail kKnownFails[] =
 {
 	// GetRefSat's UHDTV3/UHDTV4 sweep endpoints come from hardcoded xy tables
@@ -188,49 +194,55 @@ static const KnownFail kKnownFails[] =
 	// from ContainerPrimaryLinear (which follows the active white).
 	// GetRefPrimary/GetRefSecondary for these pseudo-spaces route through
 	// GetRefSat(i, 1.0), so the primaries family inherits the same skew.
-	{ UHDTV3, 999, -1, FAM_PRIM,   GRID_ANY, "hardcoded D65 endpoint xy tables in GetRefSat (p3Ref/p3sRef)" },
-	{ UHDTV3, 999, -1, FAM_SAT100, GRID_ANY, "hardcoded D65 endpoint xy tables in GetRefSat (p3Ref/p3sRef)" },
-	{ UHDTV3, 999, -1, FAM_SAT75,  GRID_ANY, "hardcoded D65 endpoint xy tables in GetRefSat (p3Ref/p3sRef)" },
-	{ UHDTV4, 999, -1, FAM_PRIM,   GRID_ANY, "hardcoded D65 endpoint xy tables in GetRefSat (rRef/rsRef)" },
-	{ UHDTV4, 999, -1, FAM_SAT100, GRID_ANY, "hardcoded D65 endpoint xy tables in GetRefSat (rRef/rsRef)" },
-	{ UHDTV4, 999, -1, FAM_SAT75,  GRID_ANY, "hardcoded D65 endpoint xy tables in GetRefSat (rRef/rsRef)" },
+	// (observed worst ~8 dE)
+	{ UHDTV3, 999, -1, FAM_PRIM,   GRID_ANY, 15.0, "hardcoded D65 endpoint xy tables in GetRefSat (p3Ref/p3sRef)" },
+	{ UHDTV3, 999, -1, FAM_SAT100, GRID_ANY, 15.0, "hardcoded D65 endpoint xy tables in GetRefSat (p3Ref/p3sRef)" },
+	{ UHDTV3, 999, -1, FAM_SAT75,  GRID_ANY, 15.0, "hardcoded D65 endpoint xy tables in GetRefSat (p3Ref/p3sRef)" },
+	{ UHDTV4, 999, -1, FAM_PRIM,   GRID_ANY, 15.0, "hardcoded D65 endpoint xy tables in GetRefSat (rRef/rsRef)" },
+	{ UHDTV4, 999, -1, FAM_SAT100, GRID_ANY, 15.0, "hardcoded D65 endpoint xy tables in GetRefSat (rRef/rsRef)" },
+	{ UHDTV4, 999, -1, FAM_SAT75,  GRID_ANY, 15.0, "hardcoded D65 endpoint xy tables in GetRefSat (rRef/rsRef)" },
 	// HDTVa/HDTVb under custom whites: the wire tables, the pRef/sRef
 	// reference endpoints, the simulated sensor's decode space and the dE
 	// space are all fixed Rec.709/D65 constructions, while the gray/sat
 	// reference targets follow the active custom white - custom whites are
 	// outside the special modes' model by design (CC passes because both
-	// sides share the same decode chain).
-	{ HDTVa, 999, -1, FAM_GRAY,   GRID_ANY, "special modes are fixed Rec.709/D65: gray targets follow the custom white, the wire cannot" },
-	{ HDTVb, 999, -1, FAM_GRAY,   GRID_ANY, "special modes are fixed Rec.709/D65: gray targets follow the custom white, the wire cannot" },
-	{ HDTVa, 999, -1, FAM_PRIM,   GRID_ANY, "75%-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
-	{ HDTVa, 999, -1, FAM_SAT100, GRID_ANY, "75%-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
-	{ HDTVa, 999, -1, FAM_SAT75,  GRID_ANY, "75%-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
-	{ HDTVb, 999, -1, FAM_PRIM,   GRID_ANY, "plasma-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
-	{ HDTVb, 999, -1, FAM_SAT100, GRID_ANY, "plasma-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
-	{ HDTVb, 999, -1, FAM_SAT75,  GRID_ANY, "plasma-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
+	// sides share the same decode chain). (observed worst: gray ~12, sat ~14)
+	{ HDTVa, 999, -1, FAM_GRAY,   GRID_ANY, 20.0, "special modes are fixed Rec.709/D65: gray targets follow the custom white, the wire cannot" },
+	{ HDTVb, 999, -1, FAM_GRAY,   GRID_ANY, 20.0, "special modes are fixed Rec.709/D65: gray targets follow the custom white, the wire cannot" },
+	{ HDTVa, 999, -1, FAM_SAT100, GRID_ANY, 20.0, "75%-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
+	{ HDTVa, 999, -1, FAM_SAT75,  GRID_ANY, 20.0, "75%-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
+	{ HDTVb, 999, -1, FAM_SAT100, GRID_ANY, 20.0, "plasma-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
+	{ HDTVb, 999, -1, FAM_SAT75,  GRID_ANY, 20.0, "plasma-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
+	// HDTVa/b custom-white primaries overlap the HDR-analog gap below when
+	// the EOTF is PQ/HLG, so this entry (which matches first) must clear the
+	// same ~70 dE. (observed worst ~68 dE)
+	{ HDTVa, 999, -1, FAM_PRIM,   GRID_ANY, 90.0, "75%-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
+	{ HDTVb, 999, -1, FAM_PRIM,   GRID_ANY, 90.0, "plasma-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
 	// HDTVa/b primaries under PQ/HLG: WireModeledPrimaryReference
 	// deliberately returns the ANALOG color for modes 5/7 (legacy behavior,
 	// see its header comment) while the wire re-encodes the 75% tables with
 	// the active EOTF - the two conventions are far apart (dE ~70 on blue).
-	{ HDTVa, -1, 57, FAM_PRIM, GRID_ANY, "legacy analog primaries reference under HDR (WireModeledPrimaryReference modes 5/7 early-out)" },
-	{ HDTVb, -1, 57, FAM_PRIM, GRID_ANY, "legacy analog primaries reference under HDR (WireModeledPrimaryReference modes 5/7 early-out)" },
+	{ HDTVa, -1, 57, FAM_PRIM, GRID_ANY, 90.0, "legacy analog primaries reference under HDR (WireModeledPrimaryReference modes 5/7 early-out)" },
+	{ HDTVb, -1, 57, FAM_PRIM, GRID_ANY, 90.0, "legacy analog primaries reference under HDR (WireModeledPrimaryReference modes 5/7 early-out)" },
 	// HDTVa/b PQ reduced-stim 100%-saturation point, 8-bit limited grid
 	// only: the PQ 50% anchor is exactly code 110/219, so 0.75 stim lands
 	// the encoded signal on an exact half-code (82.5). The generator and
 	// the reference reach that value through different matrix round trips
 	// whose sub-1e-9 dust falls on opposite sides of the tie -> a one-code
 	// split on two channels (constant dE 0.74 at yellow). No other
-	// grid/level combination lands on a half-code.
-	{ HDTVa, -1, 5, FAM_SAT75, GRID_8LIM, "PQ 50% anchor (code 110/219) x 0.75 stim = exact half-code tie; generator/reference dust splits it" },
-	{ HDTVb, -1, 5, FAM_SAT75, GRID_8LIM, "PQ 50% anchor (code 110/219) x 0.75 stim = exact half-code tie; generator/reference dust splits it" },
+	// grid/level combination lands on a half-code. (observed worst 0.74)
+	{ HDTVa, -1, 5, FAM_SAT75, GRID_8LIM, 2.0, "PQ 50% anchor (code 110/219) x 0.75 stim = exact half-code tie; generator/reference dust splits it" },
+	{ HDTVb, -1, 5, FAM_SAT75, GRID_8LIM, 2.0, "PQ 50% anchor (code 110/219) x 0.75 stim = exact half-code tie; generator/reference dust splits it" },
 	// Grayscale on the FULL-range grids: the whole gray pipeline
 	// (GetGrayPercent, ArrayIndexToGrayLevel, GrayLevelToGrayProp) has no
 	// range parameter - ramp codes and references live on the 219/876
 	// limited grids, and on a full-range wire the re-snap to 255/1023 is
 	// not modeled (<= ~0.4 dE, worst on the PQ 8-bit knee). Fixing requires
 	// adding a range parameter through libHCFR, which moves ColorMathTest
-	// T2/T3 goldens - out of scope for this harness.
-	{ -1, -1, -1, FAM_GRAY, GRID_FULL, "gray ramp codes/references are limited-grid only (no range parameter in GetGrayPercent/GrayLevelToGrayProp)" },
+	// T2/T3 goldens - out of scope for this harness. Tight ceiling: this
+	// entry is broad (any space/white/eotf), so it must NOT swallow a real
+	// grayscale/EOTF regression that pushes dE past ~2. (observed worst 0.39)
+	{ -1, -1, -1, FAM_GRAY, GRID_FULL, 2.0, "gray ramp codes/references are limited-grid only (no range parameter in GetGrayPercent/GrayLevelToGrayProp)" },
 };
 
 static bool s_knownFailFired[sizeof(kKnownFails)/sizeof(kKnownFails[0])] = { false };
@@ -693,11 +705,16 @@ static void RunCC ( const Combo & c, CMeasure & m, CSimulatedSensor & sensor, CC
 		return;
 	}
 
-	// UpdateGrid default-case YWhite: PrimeWhite, falling back to the
-	// grayscale/contrast white when the primaries run was dimmed (<90%).
+	// UpdateGrid default-case YWhite (MainView.cpp ~3720): OnOffWhite for the
+	// special standards (HDTVa/b), else PrimeWhite - falling back to OnOffWhite
+	// when the primaries run was dimmed (<90%) and not HDR. RunSats uses the
+	// same special?OnOffWhite:PrimeWhite selection; omitting it here would
+	// normalize HDTVa/b CC dE by the 75% PrimeWhite instead of peak white and
+	// diverge from the grid.
+	bool special = ( cfg->m_colorStandard == HDTVa || cfg->m_colorStandard == HDTVb );
 	double YWhitePrime = m.GetPrimeWhite().GetY();
 	double YWhiteOnOff = m.GetOnOffWhite().GetY();
-	double YWhite = YWhitePrime;
+	double YWhite = special ? YWhiteOnOff : YWhitePrime;
 	BOOL isHDR = ( cfg->m_GammaOffsetType == 5 );
 	if ( m.GetOnOffWhite().isValid() && !isHDR && YWhiteOnOff > 0 && (YWhitePrime / YWhiteOnOff < 0.9) )
 		YWhite = YWhiteOnOff;
@@ -794,16 +811,27 @@ static void RunCombo ( const Combo & c )
 		int iKnown = MatchKnownFail(c, fam);
 		double w = stats[fam].worst;
 		BOOL over = ( w > tol );
-		n += _snprintf(line + n, sizeof(line)-1-n, "%7.3f%c", w, over ? (iKnown >= 0 ? '#' : '*') : ' ');
+		// A known-fail only absorbs the result while it stays within the
+		// entry's documented ceiling; beyond that, the known issue has grown
+		// = a real regression, so treat it as a hard FAIL.
+		BOOL absorbed = ( iKnown >= 0 && w <= kKnownFails[iKnown].ceiling );
+		n += _snprintf(line + n, sizeof(line)-1-n, "%7.3f%c", w, over ? (absorbed ? '#' : '*') : ' ');
 		if ( over )
 		{
-			if ( iKnown >= 0 )
+			if ( absorbed )
 			{
 				bKnown = TRUE;
 				s_knownFailFired[iKnown] = true;
 				Detail("KNOWN-FAIL  %s %s %s %s %.0f%% [%s]: worst dE %.3f at %s\n            reason: %s\n",
 					   c.stdName, c.eotfName, c.whiteName, c.gridName, c.intensity * 100.,
 					   kFamilyName[fam], w, stats[fam].desc, kKnownFails[iKnown].reason);
+			}
+			else if ( iKnown >= 0 )
+			{
+				bFail = TRUE;
+				Detail("FAIL(>ceil) %s %s %s %s %.0f%% [%s]: worst dE %.3f exceeds known-fail ceiling %.2f at %s\n            the known gap GREW - likely a regression: %s\n",
+					   c.stdName, c.eotfName, c.whiteName, c.gridName, c.intensity * 100.,
+					   kFamilyName[fam], w, kKnownFails[iKnown].ceiling, stats[fam].desc, kKnownFails[iKnown].reason);
 			}
 			else
 			{
@@ -845,9 +873,12 @@ int RunAccuracyTest ( const char * pReportPath )
 
 	CColorHCFRConfig * cfg = GetConfig();
 
-	// Redirect ALL profile traffic to a scratch ini: nothing in this run may
-	// read or write the user's real configuration. (The process also exits
-	// via ExitProcess, so no settings-saving teardown ever runs.)
+	// Profile traffic is already on the scratch ini: the config was built with
+	// CColorHCFRConfig::s_bHeadless set (see the InitInstance hook), so its
+	// constructor never touched the user's real config and put m_iniFileName on
+	// this same scratch path. Re-assert it here (idempotent) as defense in
+	// depth, and because the process exits via ExitProcess, no settings-saving
+	// teardown ever runs either.
 	char tmpPath[MAX_PATH];
 	GetTempPathA(MAX_PATH, tmpPath);
 	_snprintf(cfg->m_iniFileName, MAX_PATH - 1, "%saccuracytest_scratch.ini", tmpPath);
@@ -948,11 +979,15 @@ int RunAccuracyTest ( const char * pReportPath )
 			s_nUnexpectedPass ? " (stale known-fail entries present!)" : "");
 	fclose(s_fReport);
 
-	int rc = ( s_nFail > 0 ) ? 1 : 0;
+	// Fail the run on stale known-fail entries too: a never-fired entry means
+	// a combo was dropped or an issue was fixed (and the entry now sits ready
+	// to mask a NEW nearby regression) - a coverage regression CI must catch,
+	// not a silent exit 0.
+	int rc = ( s_nFail > 0 || s_nUnexpectedPass > 0 ) ? 1 : 0;
 	if ( bConsole )
 	{
-		printf("accuracytest: %d combos: %d pass, %d FAIL, %d known-fail -> exit %d (report: %s)\n",
-			   s_nCombos, s_nPass, s_nFail, s_nKnownFail, rc, pPath);
+		printf("accuracytest: %d combos: %d pass, %d FAIL, %d known-fail, %d stale -> exit %d (report: %s)\n",
+			   s_nCombos, s_nPass, s_nFail, s_nKnownFail, s_nUnexpectedPass, rc, pPath);
 		fflush(stdout);
 	}
 	return rc;

--- a/AccuracyTest.cpp
+++ b/AccuracyTest.cpp
@@ -1,0 +1,959 @@
+/////////////////////////////////////////////////////////////////////////////
+// AccuracyTest.cpp: headless "/accuracytest" accuracy-matrix self-test.
+//
+//   ColorHCFR.exe /accuracytest [report.txt]
+//
+// WHAT IT VERIFIES
+// ----------------
+// For every meaningful combination of bit depth/range grid, color space,
+// transfer function, white point and window intensity, this harness checks
+// the app-level invariant  reference == wire == sensor-model  (dE ~ 0):
+// each patch family's wire codes (the exact percent triplets the patch
+// generators emit) are pushed through CSimulatedSensor::MeasureColor with
+// error injection off, and the result is compared against the corresponding
+// CMeasure reference (GetRefPrimary/GetRefSecondary/GetRefSat/GetRefCC24Sat
+// or the grayscale EOTF target) using the SAME normalization chain the
+// measures grid uses (CMainView::UpdateGrid + GetItemText: HDR 105.95640 /
+// GetHDRRefScale rescales, tmWhite RefWhite normalization, the
+// YWhite * 94.37844 / tmWhite rescale, per-mode YWhite source).
+//
+// A perfectly modeled configuration reads dE ~ 0 for every patch, including
+// patches clipped above m_TargetMaxL in PQ (the reference models the same
+// per-channel clip). Any dE above the epsilon means the reference no longer
+// models the wire for that combination - exactly the class of regression a
+// color-math change can introduce.
+//
+// RELATION TO tests\ColorMathTest
+// -------------------------------
+// ColorMathTest.exe verify   covers the pure libHCFR layer (patch generators,
+// SnapToVideoGrid, EOTF round trips) against golden files - it has no access
+// to the app-coupled reference layer. THIS harness covers that layer:
+// CMeasure's GetRef* functions are coupled to GetConfig() and to measured
+// state (gray array top, OnOffBlack, PrimeWhite), so they can only be
+// exercised inside the app. Run both after any color-math change.
+//
+// DESIGN NOTES
+// ------------
+// * No windows, no generators, no real measure loops: patches are
+//   synthesized with the same construction code the measure loops use
+//   (GetGrayPercent ramp, MeasurePrimaries' GenColors incl. the UHDTV3/4
+//   ContainerPrimaryLinear chain, GenerateSaturationColors,
+//   GenerateCC24Colors).
+// * Measured-state bootstrap mirrors real usage ORDER: grayscale first
+//   (OnOffWhite/OnOffBlack come from the ramp ends, and HLG/BT.1886
+//   reference decodes use the measured gray top as White), then primaries
+//   (PrimeWhite), then saturations/CC.
+// * Window Intensity is deliberately NOT modeled by the references (it dims
+//   the measured white anchor equally and cancels in the white-relative dE).
+//   The 90% combos test that CANCELLATION: patches AND the white normalizer
+//   are dimmed before the sensor, mirroring GDIGenerator's dimming of every
+//   MT_PRIMARY/MT_SECONDARY/MT_SAT_* patch (grayscale MT_IRE and CC patches
+//   are not dimmed). The cancellation is exact only for a pure power law;
+//   quantization and non-power EOTFs (BT.1886, L*, sRGB) leave a small
+//   residual, so those combos get a looser, documented epsilon.
+// * The user's configuration is never touched: all profile reads/writes are
+//   redirected to a scratch ini in %TEMP%, every relevant config member is
+//   set explicitly per combo, settings are never saved, and the process
+//   exits via ExitProcess before any teardown could write.
+/////////////////////////////////////////////////////////////////////////////
+
+#include "stdafx.h"
+#include "ColorHCFR.h"
+#include "Measure.h"
+#include "SimulatedSensor.h"
+#include "AccuracyTest.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <float.h>
+
+#ifndef ATTACH_PARENT_PROCESS
+#define ATTACH_PARENT_PROCESS ((DWORD)-1)
+#endif
+
+#ifdef _DEBUG
+#undef THIS_FILE
+static char THIS_FILE[]=__FILE__;
+#define new DEBUG_NEW
+#endif
+
+namespace
+{
+
+/////////////////////////////////////////////////////////////////////////////
+// Matrix dimensions
+
+struct SpaceDef  { ColorStandard cs; const char * name; };
+struct EotfDef   { int mode; BOOL toneMap; const char * name; };
+struct WhiteDef  { WhiteTarget wt; const char * name; };
+struct GridDef   { bool b10; bool lim; const char * name; };
+
+static const SpaceDef kSpaces[] =
+{
+	{ HDTV,   "HDTV"   },	// Rec.709
+	{ sRGB,   "sRGB"   },
+	{ UHDTV,  "UHDTV"  },	// DCI-P3
+	{ UHDTV2, "UHDTV2" },	// BT.2020
+	{ UHDTV3, "UHDTV3" },	// P3 in BT.2020
+	{ UHDTV4, "UHDTV4" },	// Rec.709 in BT.2020
+	{ HDTVa,  "HDTVa"  },	// Rec.709 75%
+	{ HDTVb,  "HDTVb"  },	// Rec.709 plasma
+	// CC6 (=11) is marked unused in the ColorStandard enum and is not
+	// selectable in the UI; not part of the matrix.
+};
+
+// UI-selectable transfer functions (ReferencesPropPage kComboToType, minus
+// mode 1 "black compensation" which only reshapes the SDR gray target).
+// sRGB-the-EOTF is exercised through the sRGB color space (every consumer
+// forces mode 99 when m_colorStandard == sRGB), so the sRGB space runs a
+// single EOTF entry.
+static const EotfDef kEotfs[] =
+{
+	{ 0, FALSE, "Power2.2"  },
+	{ 4, FALSE, "BT.1886"   },
+	{ 6, FALSE, "L-star"    },
+	{ 5, FALSE, "PQ"        },
+	{ 5, TRUE,  "PQ+BT2390" },
+	{ 7, FALSE, "HLG"       },
+};
+
+// D65 plus two custom whites that were never hand-tested: DCI white and a
+// manual xy point. The Container*Reference functions carry the active white,
+// so every reference must follow it.
+static const double kManualWhiteX = 0.3067;
+static const double kManualWhiteY = 0.3180;
+static const WhiteDef kWhites[] =
+{
+	{ D65,   "D65"    },
+	{ DCI,   "DCI"    },
+	{ DCUST, "xyCust" },	// manual xy 0.3067, 0.3180
+};
+
+static const GridDef kGrids[] =
+{
+	{ false, true,  "8b-lim"  },	// 219 codes
+	{ false, false, "8b-full" },	// 255
+	{ true,  true,  "10b-lim" },	// 876
+	{ true,  false, "10b-full"},	// 1023
+};
+
+enum Family { FAM_GRAY = 0, FAM_PRIM, FAM_SAT100, FAM_SAT75, FAM_CC_GCD, FAM_CC_AXIS, FAM_COUNT };
+static const char * kFamilyName[FAM_COUNT] = { "gray", "prim", "sat100", "sat75", "ccGCD", "ccAXIS" };
+
+struct Combo
+{
+	ColorStandard	std;
+	int				eotf;		// m_GammaOffsetType for the combo
+	BOOL			toneMap;
+	WhiteTarget		white;
+	bool			b10;
+	bool			lim;
+	int				gridIdx;	// index into kGrids
+	double			intensity;	// 1.0 or 0.9 (GDI window Intensity fraction)
+	const char *	eotfName;
+	const char *	whiteName;
+	const char *	gridName;
+	const char *	stdName;
+};
+
+/////////////////////////////////////////////////////////////////////////////
+// Known failures
+//
+// Combinations where the reference is KNOWN not to model the wire yet.
+// Each entry must state the code-level reason. Matching failures are
+// reported but do not fail the run; a matching combo that PASSES is flagged
+// as UNEXPECTED-PASS (the entry is stale - remove it).
+
+struct KnownFail
+{
+	int				std;		// ColorStandard, or -1 = any
+	int				white;		// WhiteTarget, or -1 = any / 999 = any custom (non-D65)
+	int				eotf;		// -1 = any / 57 = HDR (5 or 7)
+	int				family;		// Family, or -1 = any
+	int				grids;		// bitmask over kGrids indices (0xF = any)
+	const char *	reason;
+};
+
+#define GRID_ANY   0xF
+#define GRID_8LIM  0x1	// kGrids[0]
+#define GRID_FULL  0xA	// kGrids[1] (8b-full) | kGrids[3] (10b-full)
+
+static const KnownFail kKnownFails[] =
+{
+	// GetRefSat's UHDTV3/UHDTV4 sweep endpoints come from hardcoded xy tables
+	// (p3Ref/p3sRef/rRef/rsRef, Measure.cpp ~6955-6977). The secondary
+	// entries are white-point mixtures evaluated AT D65, so under any custom
+	// white the reference endpoints no longer match the wire patches built
+	// from ContainerPrimaryLinear (which follows the active white).
+	// GetRefPrimary/GetRefSecondary for these pseudo-spaces route through
+	// GetRefSat(i, 1.0), so the primaries family inherits the same skew.
+	{ UHDTV3, 999, -1, FAM_PRIM,   GRID_ANY, "hardcoded D65 endpoint xy tables in GetRefSat (p3Ref/p3sRef)" },
+	{ UHDTV3, 999, -1, FAM_SAT100, GRID_ANY, "hardcoded D65 endpoint xy tables in GetRefSat (p3Ref/p3sRef)" },
+	{ UHDTV3, 999, -1, FAM_SAT75,  GRID_ANY, "hardcoded D65 endpoint xy tables in GetRefSat (p3Ref/p3sRef)" },
+	{ UHDTV4, 999, -1, FAM_PRIM,   GRID_ANY, "hardcoded D65 endpoint xy tables in GetRefSat (rRef/rsRef)" },
+	{ UHDTV4, 999, -1, FAM_SAT100, GRID_ANY, "hardcoded D65 endpoint xy tables in GetRefSat (rRef/rsRef)" },
+	{ UHDTV4, 999, -1, FAM_SAT75,  GRID_ANY, "hardcoded D65 endpoint xy tables in GetRefSat (rRef/rsRef)" },
+	// HDTVa/HDTVb under custom whites: the wire tables, the pRef/sRef
+	// reference endpoints, the simulated sensor's decode space and the dE
+	// space are all fixed Rec.709/D65 constructions, while the gray/sat
+	// reference targets follow the active custom white - custom whites are
+	// outside the special modes' model by design (CC passes because both
+	// sides share the same decode chain).
+	{ HDTVa, 999, -1, FAM_GRAY,   GRID_ANY, "special modes are fixed Rec.709/D65: gray targets follow the custom white, the wire cannot" },
+	{ HDTVb, 999, -1, FAM_GRAY,   GRID_ANY, "special modes are fixed Rec.709/D65: gray targets follow the custom white, the wire cannot" },
+	{ HDTVa, 999, -1, FAM_PRIM,   GRID_ANY, "75%-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
+	{ HDTVa, 999, -1, FAM_SAT100, GRID_ANY, "75%-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
+	{ HDTVa, 999, -1, FAM_SAT75,  GRID_ANY, "75%-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
+	{ HDTVb, 999, -1, FAM_PRIM,   GRID_ANY, "plasma-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
+	{ HDTVb, 999, -1, FAM_SAT100, GRID_ANY, "plasma-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
+	{ HDTVb, 999, -1, FAM_SAT75,  GRID_ANY, "plasma-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
+	// HDTVa/b primaries under PQ/HLG: WireModeledPrimaryReference
+	// deliberately returns the ANALOG color for modes 5/7 (legacy behavior,
+	// see its header comment) while the wire re-encodes the 75% tables with
+	// the active EOTF - the two conventions are far apart (dE ~70 on blue).
+	{ HDTVa, -1, 57, FAM_PRIM, GRID_ANY, "legacy analog primaries reference under HDR (WireModeledPrimaryReference modes 5/7 early-out)" },
+	{ HDTVb, -1, 57, FAM_PRIM, GRID_ANY, "legacy analog primaries reference under HDR (WireModeledPrimaryReference modes 5/7 early-out)" },
+	// HDTVa/b PQ reduced-stim 100%-saturation point, 8-bit limited grid
+	// only: the PQ 50% anchor is exactly code 110/219, so 0.75 stim lands
+	// the encoded signal on an exact half-code (82.5). The generator and
+	// the reference reach that value through different matrix round trips
+	// whose sub-1e-9 dust falls on opposite sides of the tie -> a one-code
+	// split on two channels (constant dE 0.74 at yellow). No other
+	// grid/level combination lands on a half-code.
+	{ HDTVa, -1, 5, FAM_SAT75, GRID_8LIM, "PQ 50% anchor (code 110/219) x 0.75 stim = exact half-code tie; generator/reference dust splits it" },
+	{ HDTVb, -1, 5, FAM_SAT75, GRID_8LIM, "PQ 50% anchor (code 110/219) x 0.75 stim = exact half-code tie; generator/reference dust splits it" },
+	// Grayscale on the FULL-range grids: the whole gray pipeline
+	// (GetGrayPercent, ArrayIndexToGrayLevel, GrayLevelToGrayProp) has no
+	// range parameter - ramp codes and references live on the 219/876
+	// limited grids, and on a full-range wire the re-snap to 255/1023 is
+	// not modeled (<= ~0.4 dE, worst on the PQ 8-bit knee). Fixing requires
+	// adding a range parameter through libHCFR, which moves ColorMathTest
+	// T2/T3 goldens - out of scope for this harness.
+	{ -1, -1, -1, FAM_GRAY, GRID_FULL, "gray ramp codes/references are limited-grid only (no range parameter in GetGrayPercent/GrayLevelToGrayProp)" },
+};
+
+static bool s_knownFailFired[sizeof(kKnownFails)/sizeof(kKnownFails[0])] = { false };
+
+/////////////////////////////////////////////////////////////////////////////
+// Result bookkeeping
+
+struct FamStat
+{
+	double	worst;			// worst dE seen, -1 = family not run
+	char	desc[160];		// description of the worst patch
+
+	FamStat() : worst(-1.0) { desc[0] = 0; }
+
+	void Add ( double dE, const char * fmt, ... )
+	{
+		if ( _isnan(dE) )
+			dE = 999.0;		// NaN in a dE is always a failure
+		if ( dE > worst )
+		{
+			worst = dE;
+			va_list ap;
+			va_start(ap, fmt);
+			_vsnprintf(desc, sizeof(desc)-1, fmt, ap);
+			desc[sizeof(desc)-1] = 0;
+			va_end(ap);
+		}
+	}
+};
+
+static FILE *	s_fReport = NULL;
+static int		s_nCombos = 0, s_nPass = 0, s_nFail = 0, s_nKnownFail = 0, s_nUnexpectedPass = 0;
+static CString	s_failDetail;		// accumulated failure detail block
+
+static void Detail ( const char * fmt, ... )
+{
+	char buf[512];
+	va_list ap;
+	va_start(ap, fmt);
+	_vsnprintf(buf, sizeof(buf)-1, fmt, ap);
+	buf[sizeof(buf)-1] = 0;
+	va_end(ap);
+	s_failDetail += buf;
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// Helpers
+
+static void ScaleXYZ ( CColor & c, double s )
+{
+	c.SetX(c.GetX() * s);
+	c.SetY(c.GetY() * s);
+	c.SetZ(c.GetZ() * s);
+}
+
+// Replicates the ApplySettings reference rebuild (ColorHCFRConfig.cpp
+// ~968-998) for the target combinations this harness uses.
+static void RebuildColorReference ()
+{
+	CColorHCFRConfig * cfg = GetConfig();
+	if ( GetColorApp()->m_pColorReference )
+	{
+		delete GetColorApp()->m_pColorReference;
+		GetColorApp()->m_pColorReference = NULL;
+	}
+	if ( cfg->m_whiteTarget == DCUST && cfg->m_colorStandard != CUSTOM )
+	{
+		ColorxyY whitecolor(cfg->m_manualWhitex, cfg->m_manualWhitey);
+		GetColorApp()->m_pColorReference = new CColorReference(cfg->m_colorStandard, cfg->m_whiteTarget, -1, " modified", ColorXYZ(whitecolor));
+	}
+	else
+		GetColorApp()->m_pColorReference = new CColorReference(cfg->m_colorStandard, cfg->m_whiteTarget, -1);
+}
+
+// One synthetic sensor read. 'dim' mirrors GDIGenerator's window-Intensity
+// scaling: the percent triplet is dimmed BEFORE the sensor (i.e. before the
+// sensor's SnapToVideoGrid), exactly where the real wire dims it.
+static CColor Meas ( CSimulatedSensor & sensor, const ColorRGBDisplay & rgb, double dim )
+{
+	ColorRGBDisplay p(rgb);
+	p[0] *= dim;
+	p[1] *= dim;
+	p[2] *= dim;
+	return sensor.MeasureColor(p);
+}
+
+// Replicates CMainView::GetItemText's color-mode dE (MainView.cpp
+// ~2985-3047) for the non-grayscale families. displayMode: 1 = primaries,
+// 5..10 = saturation sweeps, 11 = color checker. DVD (manual generator) is
+// FALSE here - the harness models the GDI-family wire.
+static double GridColorDE ( const CMeasure & m, const CColor & aMeasure, const CColor & aReference,
+							double YWhiteIn, int displayMode, int nCol, int satsize )
+{
+	CColorHCFRConfig * cfg = GetConfig();
+	BOOL isHDR = ( cfg->m_GammaOffsetType == 5 && (displayMode == 1 || (displayMode >= 5 && displayMode <= 11)) );
+	double YWhite = YWhiteIn, RefWhite = 1.0;
+	CColorReference cRef = GetColorReference();
+
+	if ( isHDR )
+	{
+		CColor White = m.GetOnOffWhite();
+		CColor Black = m.GetOnOffBlack();
+		double tmWhite = TmDiffuseWhiteNits(White, Black);
+		if ( displayMode == 1 )
+		{
+			if ( cRef.m_standard == UHDTV2 || cRef.m_standard == HDTV || cRef.m_standard == UHDTV || cRef.m_standard == UHDTV3 || cRef.m_standard == UHDTV4 || nCol == 7 )
+				RefWhite = YWhite / tmWhite;
+			else
+			{
+				RefWhite = YWhite / tmWhite;
+				YWhite = YWhite * 94.37844 / tmWhite;
+			}
+		}
+		else
+		{
+			if ( cfg->m_CCMode >= MASCIOR50 && cfg->m_CCMode <= CCMAXHDR && displayMode == 11 )
+				YWhite = m.GetGray(m.GetGrayScaleSize() - 1).GetY();
+			else
+			{
+				RefWhite = YWhite / tmWhite;
+				YWhite = YWhite * 94.37844 / tmWhite;
+			}
+		}
+	}
+
+	CColorReference bRef = ((cRef.m_standard == UHDTV3 || cRef.m_standard == UHDTV4) ? ContainerTransportReference(cRef)
+						  : (cRef.m_standard == HDTVa || cRef.m_standard == HDTVb) ? CColorReference(HDTV) : cRef);
+
+	return aMeasure.GetDeltaE(YWhite, aReference, RefWhite, bRef, cfg->m_dE_form, false,
+							  cfg->m_GammaOffsetType == 5 ? 3 : cfg->gw_Weight);
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// Per-combo configuration
+
+static void ApplyComboConfig ( const Combo & c )
+{
+	CColorHCFRConfig * cfg = GetConfig();
+
+	cfg->m_colorStandard = c.std;
+	cfg->m_whiteTarget = c.white;
+	if ( c.white == DCUST )
+	{
+		cfg->m_manualWhitex = kManualWhiteX;
+		cfg->m_manualWhitey = kManualWhiteY;
+	}
+	cfg->m_CCMode = GCD;
+
+	cfg->m_GammaOffsetType = c.eotf;
+	cfg->m_useToneMap = c.toneMap;
+	cfg->m_GammaRef = 2.2;
+	cfg->m_GammaAvg = 2.2;
+	cfg->m_useMeasuredGamma = FALSE;
+	cfg->m_GammaRel = 0.0;
+	cfg->m_Split = 100.0;
+	cfg->m_manualGOffset = 0.099;
+
+	cfg->m_MasterMinL = 0.0;
+	cfg->m_MasterMaxL = 4000.0;
+	cfg->m_DiffuseL = 94.37844;
+	cfg->m_TargetSysGamma = 1.20;
+	cfg->m_BT2390_BS = 1.0;
+	cfg->m_BT2390_WS = 0.0;
+	cfg->m_BT2390_WS1 = 25.0;
+
+	// A realistic 700-nit display target so PQ actually clips/tone-maps the
+	// upper patches (the harness asserts clipped patches STILL read dE ~ 0).
+	// TargetMinL stays 0: the references target ideal black (Y=0), while the
+	// sensor pins the black patch to TargetMinL - a nonzero floor is a
+	// modeled DISPLAY property that would show up as a constant black-patch
+	// dE, not a wire-modeling error. (With black 0, BT.1886 degenerates to a
+	// pure 2.4 power - consistent on both sides.)
+	BOOL bHdr = ( c.eotf == 5 || c.eotf == 7 );
+	cfg->m_TargetMaxL = bHdr ? 700.0 : 120.0;
+	cfg->m_TargetMinL = 0.0;
+	cfg->m_bOverRideTargs = FALSE;
+	cfg->m_userBlack = FALSE;
+
+	// Grid flags: set the CACHED flags directly (RefreshUse10bitLevels would
+	// re-derive them from the scratch ini's generator keys).
+	cfg->m_bUseRoundDown = FALSE;
+	cfg->m_bUse10bit = c.b10;
+	cfg->m_bUse10bitLevels = c.b10;
+	cfg->m_bRGB16_235 = c.lim;
+
+	// dE settings: CIE2000 with the gamma-predicted gray luminance target
+	// (m_dE_gray = 1) so grayscale luminance errors are visible; the default
+	// dE_form 5 / dE_gray 2 substitute the measured luminance into the gray
+	// reference, which would blind this test to EOTF regressions.
+	cfg->m_dE_form = 3;
+	cfg->m_dE_gray = 1;
+	cfg->gw_Weight = 0;
+	cfg->m_bHDR100 = FALSE;
+
+	RebuildColorReference();
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// Family runners. Each mirrors the corresponding measure-loop patch
+// construction and the UpdateGrid reference/YWhite conventions.
+
+static const int kGraySize = 11;
+static const int kSatSize  = 5;
+
+// Grayscale ramp; also bootstraps OnOffWhite/OnOffBlack (MeasureGrayScale
+// stores the ramp ends there) and mirrors UpdateGrid's HDR target refresh.
+// UpdateGrid ~3840: refresh the HDR targets from the measured on/off pair.
+static void RefreshHdrTargets ( CMeasure & m )
+{
+	CColorHCFRConfig * cfg = GetConfig();
+	CColor White = m.GetOnOffWhite();
+	CColor Black = m.GetOnOffBlack();
+	if ( !cfg->m_bOverRideTargs && Black.isValid() && White.isValid() && (cfg->m_GammaOffsetType == 5 || cfg->m_GammaOffsetType == 7) )
+	{
+		if ( Black.GetY() < White.GetY() )
+			cfg->m_TargetMinL = Black.GetY() > 1e-5 ? Black.GetY() : 0.0;
+		else
+			cfg->m_TargetMinL = 0.0;
+		if ( White.GetY() > 0 )
+			cfg->m_TargetMaxL = White.GetY();
+		cfg->m_TargetSysGamma = floor((1.2 + 0.42 * log10(cfg->m_TargetMaxL / 1000.)) * 100. + 0.5) / 100.0;
+	}
+}
+
+static void RunGray ( const Combo & c, CMeasure & m, CSimulatedSensor & sensor, FamStat & stat )
+{
+	CColorHCFRConfig * cfg = GetConfig();
+
+	// Bootstrap pass: measure the on/off pair and refresh the HDR targets
+	// BEFORE the ramp. In the real app UpdateGrid has already converged
+	// m_TargetMinL/MaxL/m_TargetSysGamma from earlier measurements by the
+	// time a sweep runs, and the sensor reads those at measure time (HLG's
+	// OOTF uses TargetSysGamma) - measuring the ramp with the un-refreshed
+	// system gamma would skew every HLG mid-gray by ~2 dE.
+	m.SetOnOffWhite(Meas(sensor, ColorRGBDisplay(100, 100, 100), 1.0));
+	m.SetOnOffBlack(Meas(sensor, ColorRGBDisplay(0, 0, 0), 1.0));
+	RefreshHdrTargets(m);
+
+	m.SetGrayScaleSize(kGraySize);
+	double lv[kGraySize];
+	int i;
+	for ( i = 0 ; i < kGraySize ; i ++ )
+		lv[i] = i * 100.0 / (kGraySize - 1);
+	m.SetGrayScaleLevels(lv, kGraySize);
+
+	for ( i = 0 ; i < kGraySize ; i ++ )
+	{
+		double x = m.GetGrayPercent(i, cfg->m_bUseRoundDown != FALSE, cfg->GetUse10bitLevels() != FALSE);
+		// MT_IRE patches are never Intensity-dimmed
+		m.SetGray(i, Meas(sensor, ColorRGBDisplay(x, x, x), 1.0));
+	}
+	m.SetOnOffBlack(m.GetGray(0));					// MeasureGrayScale: measuredColor[0]
+	m.SetOnOffWhite(m.GetGray(kGraySize - 1));		// MeasureGrayScale: measuredColor[size-1]
+	RefreshHdrTargets(m);							// converges (same values as bootstrap)
+
+	CColor White = m.GetOnOffWhite();
+	CColor Black = m.GetOnOffBlack();
+
+	// dE per UpdateGrid case 0 + GetItemText grayscale branch. The grid
+	// leaves the first column (black) without a dE; skip it the same way.
+	double YWhite = m.GetGray(kGraySize - 1).GetY();
+	for ( i = 1 ; i < kGraySize ; i ++ )
+	{
+		CColor aColor = m.GetGray(i);
+		double x = m.GetGrayPercent(i, cfg->m_bUseRoundDown != FALSE, cfg->GetUse10bitLevels() != FALSE);
+		int mode = cfg->m_GammaOffsetType;
+		if ( cfg->m_colorStandard == sRGB ) mode = 99;
+		double valy;
+		if ( mode >= 4 )
+		{
+			double valx = GrayLevelToGrayProp(x, cfg->m_bUseRoundDown != FALSE, cfg->GetUse10bitLevels() != FALSE);
+			valy = getL_EOTF(valx, White, Black, cfg->m_GammaRel, cfg->m_Split, mode, cfg->m_DiffuseL, cfg->m_MasterMinL, cfg->m_MasterMaxL, cfg->m_TargetMinL, cfg->m_TargetMaxL, cfg->m_useToneMap, FALSE, cfg->m_TargetSysGamma, cfg->m_BT2390_BS, cfg->m_BT2390_WS, cfg->m_BT2390_WS1);
+			valy = min(valy, cfg->m_TargetMaxL);
+		}
+		else
+		{
+			double valx = GrayLevelToGrayProp(x, cfg->m_bUseRoundDown != FALSE, cfg->GetUse10bitLevels() != FALSE);	// Offset = 0
+			valy = pow(valx, cfg->m_GammaRef);
+		}
+
+		ColorxyY tmpColor(GetColorReference().GetWhite());
+		tmpColor[2] = ( mode == 5 ) ? valy * 100. / YWhite : valy;
+		CColor refColor;
+		refColor.SetxyYValue(tmpColor);
+
+		double dE = aColor.GetDeltaE(YWhite, refColor, 1.0, GetColorReference(), cfg->m_dE_form, true,
+									 cfg->m_GammaOffsetType == 5 ? 3 : cfg->gw_Weight);
+		stat.Add(dE, "gray %d%% (code %.4f%%)", i * 10, x);
+	}
+}
+
+// Primaries + secondaries + white/black rows; mirrors MeasurePrimaries'
+// GenColors construction (Measure.cpp ~1693-1785) incl. the UHDTV3/4
+// ContainerPrimaryLinear chain and the HDTVa/b HDR re-encode.
+static void RunPrimaries ( const Combo & c, CMeasure & m, CSimulatedSensor & sensor, FamStat & stat )
+{
+	CColorHCFRConfig * cfg = GetConfig();
+	int mode = cfg->m_GammaOffsetType;
+	BOOL isSpecial = FALSE;
+
+	double primaryIRELevel = 100.0;
+	if ( mode == 5 )
+		primaryIRELevel = 50.22831;		// non-DVD wire (manual-generator Mascior 50.00 not modeled here)
+
+	ColorRGBDisplay GenColors[8] =
+	{
+		ColorRGBDisplay(primaryIRELevel,0,0),
+		ColorRGBDisplay(0,primaryIRELevel,0),
+		ColorRGBDisplay(0,0,primaryIRELevel),
+		ColorRGBDisplay(primaryIRELevel,primaryIRELevel,0),
+		ColorRGBDisplay(0,primaryIRELevel,primaryIRELevel),
+		ColorRGBDisplay(primaryIRELevel,0,primaryIRELevel),
+		ColorRGBDisplay(primaryIRELevel,primaryIRELevel,primaryIRELevel),
+		ColorRGBDisplay(0,0,0)
+	};
+	if ( GetColorReference().m_standard == HDTVb )
+	{
+		GenColors[0] = ColorRGBDisplay(79.9087,10.0457,10.0457);
+		GenColors[1] = ColorRGBDisplay(30.137,79.9087,30.137);
+		GenColors[2] = ColorRGBDisplay(50.2283,50.2283,79.9087);
+		GenColors[3] = ColorRGBDisplay(79.9087,79.9087,10.0457);
+		GenColors[4] = ColorRGBDisplay(10.0457,79.9087,79.9087);
+		GenColors[5] = ColorRGBDisplay(79.9087,10.0457,79.9087);
+		isSpecial = TRUE;
+	}
+	else if ( GetColorReference().m_standard == HDTVa )
+	{
+		GenColors[0] = ColorRGBDisplay(68.04,20.09,20.09);
+		GenColors[1] = ColorRGBDisplay(27.85,73.06,27.85);
+		GenColors[2] = ColorRGBDisplay(19.18,19.18,50.22);
+		GenColors[3] = ColorRGBDisplay(73.9726,73.9726,33.3333);
+		GenColors[4] = ColorRGBDisplay(36.07,73.06,73.06);
+		GenColors[5] = ColorRGBDisplay(64.3836,29.2237,64.3836);
+		GenColors[6] = ColorRGBDisplay(75.0,75.0,75.0);
+		isSpecial = TRUE;
+	}
+	else if ( GetColorReference().m_standard == UHDTV3 || GetColorReference().m_standard == UHDTV4 )
+	{
+		if ( !(mode == 5 || mode == 7) )
+			isSpecial = TRUE;
+		GenColors[6] = ColorRGBDisplay(primaryIRELevel,primaryIRELevel,primaryIRELevel);
+		GenColors[7] = ColorRGBDisplay(0,0,0);
+	}
+
+	if ( GetColorReference().m_standard == UHDTV3 || GetColorReference().m_standard == UHDTV4 )
+	{
+		CColor tmW = m.GetGray(m.GetGrayScaleSize() - 1);
+		CColor tmB = m.GetOnOffBlack();
+		for ( int ci = 0 ; ci < 6 ; ci ++ )
+		{
+			ColorRGB clin = ContainerPrimaryLinear(GetColorReference(), ci);
+			for ( int ck = 0 ; ck < 3 ; ck ++ )
+			{
+				double cv = clin[ck];
+				if ( mode == 5 )
+					cv = (cv <= 0.0) ? 0.0 : getL_EOTF(cv / 105.95640, tmW, tmB, cfg->m_GammaRel, cfg->m_Split, -5);
+				else if ( mode == 7 )
+					cv = (cv <= 0.0) ? 0.0 : getL_EOTF(cv, tmW, tmB, cfg->m_GammaRel, cfg->m_Split, -7);
+				else
+					cv = (cv <= 0.0 || cv >= 1.0) ? min(max(cv, 0.0), 1.0) : pow(cv, 1.0 / 2.22);
+				GenColors[ci][ck] = min(max(cv, 0.0), 1.0) * 100.0;
+			}
+		}
+	}
+
+	if ( (mode == 5 || mode == 7) && isSpecial )
+	{
+		for ( int i = 0 ; i <= 5 ; i ++ )
+		{
+			GenColors[i][0] = 100. * getL_EOTF(pow(GenColors[i][0] / 100., 2.22), noDataColor, noDataColor, 0, 0, -1 * mode);
+			GenColors[i][1] = 100. * getL_EOTF(pow(GenColors[i][1] / 100., 2.22), noDataColor, noDataColor, 0, 0, -1 * mode);
+			GenColors[i][2] = 100. * getL_EOTF(pow(GenColors[i][2] / 100., 2.22), noDataColor, noDataColor, 0, 0, -1 * mode);
+		}
+	}
+
+	// MT_PRIMARY/MT_SECONDARY patches (incl. the white anchor) are dimmed by
+	// the window Intensity on the real wire.
+	int i;
+	for ( i = 0 ; i < 3 ; i ++ )
+		m.SetPrimary(i, Meas(sensor, GenColors[i], c.intensity));
+	for ( i = 3 ; i < 6 ; i ++ )
+		m.SetSecondary(i - 3, Meas(sensor, GenColors[i], c.intensity));
+	m.SetPrimeWhite(Meas(sensor, GenColors[6], c.intensity));
+
+	// dE per UpdateGrid case 1 (j = 0..6; the black row has no reference)
+	for ( int j = 0 ; j < 7 ; j ++ )
+	{
+		CColor aColor, refColor;
+		double YWhite = m.GetPrimeWhite().GetY();
+		if ( j < 3 )
+		{
+			aColor = m.GetPrimary(j);
+			refColor = m.GetRefPrimary(j);
+		}
+		else if ( j < 6 )
+		{
+			aColor = m.GetSecondary(j - 3);
+			refColor = m.GetRefSecondary(j - 3);
+		}
+		else
+		{
+			refColor = GetColorReference().GetWhite();
+			aColor = m.GetPrimeWhite();
+			YWhite = aColor.GetY();
+		}
+		// No 105.95640 rescale here: UpdateGrid's HDR block (~4219) only
+		// covers displayMode 5..11 - primaries references are already
+		// self-scaled (GetRefPrimary applies GetHDRRefScale internally for
+		// the pseudo-spaces).
+
+		static const char * names[7] = { "red", "green", "blue", "yellow", "cyan", "magenta", "white" };
+		double dE = GridColorDE(m, aColor, refColor, YWhite, 1, j + 1, kSatSize);
+		stat.Add(dE, "%s", names[j]);
+	}
+}
+
+// Six saturation sweeps at one stimulus level.
+static void RunSats ( const Combo & c, CMeasure & m, CSimulatedSensor & sensor, double stim, FamStat & stat )
+{
+	CColorHCFRConfig * cfg = GetConfig();
+	bool special = ( cfg->m_colorStandard == HDTVa || cfg->m_colorStandard == HDTVb );
+	static const char * names[6] = { "red", "green", "blue", "yellow", "cyan", "magenta" };
+	static const bool flags[6][3] =
+	{
+		{ true,false,false }, { false,true,false }, { false,false,true },
+		{ true,true,false }, { false,true,true }, { true,false,true },
+	};
+
+	m.SetSaturationSize(kSatSize);
+	for ( int s = 0 ; s < 6 ; s ++ )
+	{
+		ColorRGBDisplay GenColors[kSatSize];
+		GenerateSaturationColors(GetColorReference(), GenColors, kSatSize, flags[s][0], flags[s][1], flags[s][2],
+								 cfg->m_GammaOffsetType, stim, cfg->GetUse10bitLevels() != FALSE, cfg->GetRGB16_235() != FALSE);
+		for ( int j = 0 ; j < kSatSize ; j ++ )
+		{
+			// MT_SAT_* patches are Intensity-dimmed on the real wire
+			CColor aColor = Meas(sensor, GenColors[j], c.intensity);
+			CColor refColor = m.GetRefSat(s, (double)j / (double)(kSatSize - 1), special, stim);
+			if ( cfg->m_GammaOffsetType == 5 )
+				ScaleXYZ(refColor, 105.95640);	// UpdateGrid ~4229
+			double YWhite = special ? m.GetOnOffWhite().GetY() : m.GetPrimeWhite().GetY();
+			double dE = GridColorDE(m, aColor, refColor, YWhite, 5 + s, j + 1, kSatSize);
+			stat.Add(dE, "%s sat %d%% stim %.0f%%", names[s], j * 25, stim * 100.);
+		}
+	}
+}
+
+// One color-checker set (GCD 24 or AXIS 71).
+static void RunCC ( const Combo & c, CMeasure & m, CSimulatedSensor & sensor, CCPatterns ccMode, int count, FamStat & stat )
+{
+	CColorHCFRConfig * cfg = GetConfig();
+	cfg->m_CCMode = ccMode;
+
+	ColorRGBDisplay GenColors[128];
+	if ( !GenerateCC24Colors(GetColorReference(), GenColors, ccMode, cfg->m_GammaOffsetType,
+							 cfg->GetUse10bitLevels() != FALSE, cfg->GetRGB16_235() != FALSE) )
+	{
+		stat.Add(999.0, "GenerateCC24Colors failed for mode %d", (int)ccMode);
+		return;
+	}
+
+	// UpdateGrid default-case YWhite: PrimeWhite, falling back to the
+	// grayscale/contrast white when the primaries run was dimmed (<90%).
+	double YWhitePrime = m.GetPrimeWhite().GetY();
+	double YWhiteOnOff = m.GetOnOffWhite().GetY();
+	double YWhite = YWhitePrime;
+	BOOL isHDR = ( cfg->m_GammaOffsetType == 5 );
+	if ( m.GetOnOffWhite().isValid() && !isHDR && YWhiteOnOff > 0 && (YWhitePrime / YWhiteOnOff < 0.9) )
+		YWhite = YWhiteOnOff;
+
+	for ( int j = 0 ; j < count ; j ++ )
+	{
+		// CC patches are NOT in GDIGenerator's Intensity-dimmed pattern types
+		CColor aColor = Meas(sensor, GenColors[j], 1.0);
+		CColor refColor;
+		m.GetRefCC24Sat(j, refColor);
+		if ( cfg->m_GammaOffsetType == 5 )
+			ScaleXYZ(refColor, (ccMode >= MASCIOR50 && ccMode <= CCMAXHDR) ? 100. : 105.95640);	// UpdateGrid ~4221-4231
+		double dE = GridColorDE(m, aColor, refColor, YWhite, 11, j + 1, kSatSize);
+		stat.Add(dE, "patch %d (%.2f/%.2f/%.2f%%)", j, GenColors[j][0], GenColors[j][1], GenColors[j][2]);
+	}
+
+	cfg->m_CCMode = GCD;
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// Tolerances and known-fail matching
+
+static double TolFor ( const Combo & c, int fam )
+{
+	if ( c.intensity < 0.999 )
+	{
+		// Dimmed combos verify the Intensity CANCELLATION, which is exact
+		// only for an ideal power law. Quantization (the dimmed code snaps
+		// to a different grid point than the undimmed one) and the non-power
+		// EOTFs (BT.1886's black lift, L*'s linear toe, sRGB's linear
+		// segment) leave a real residual; it is bounded and level-dependent,
+		// not a modeling error. Measured residual ceilings across the full
+		// matrix: pure power law ~0.8 (8-bit dark saturation steps, where a
+		// one-code snap difference moves chroma most; the UHDTV3/4
+		// transport-space encode adds a second quantization), BT.1886/L*/
+		// sRGB ~1.2 (their toes amplify the same one-code difference).
+		if ( fam == FAM_PRIM || fam == FAM_SAT100 || fam == FAM_SAT75 )
+			return ( c.eotf == 0 && c.std != sRGB ) ? 0.9 : 1.5;
+	}
+	return 0.05;
+}
+
+static int MatchKnownFail ( const Combo & c, int fam )	// index into kKnownFails, or -1
+{
+	for ( int i = 0 ; i < (int)(sizeof(kKnownFails)/sizeof(kKnownFails[0])) ; i ++ )
+	{
+		const KnownFail & k = kKnownFails[i];
+		if ( k.std != -1 && k.std != (int)c.std ) continue;
+		if ( k.white == 999 ) { if ( c.white == D65 ) continue; }
+		else if ( k.white != -1 && k.white != (int)c.white ) continue;
+		if ( k.eotf == 57 ) { if ( c.eotf != 5 && c.eotf != 7 ) continue; }
+		else if ( k.eotf != -1 && k.eotf != c.eotf ) continue;
+		if ( k.family != -1 && k.family != fam ) continue;
+		if ( !( k.grids & (1 << c.gridIdx) ) ) continue;
+		return i;
+	}
+	return -1;
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// One combo
+
+static void RunCombo ( const Combo & c )
+{
+	ApplyComboConfig(c);
+
+	CMeasure m;
+	CSimulatedSensor sensor;
+	sensor.m_doOffsetError = FALSE;
+	sensor.m_doGainError = FALSE;
+	sensor.m_doGammaError = FALSE;
+	sensor.Init(FALSE);
+
+	FamStat stats[FAM_COUNT];
+
+	// Order matters and mirrors real usage: grayscale bootstraps
+	// OnOffWhite/OnOffBlack (the HLG/BT.1886 reference decode White), then
+	// primaries set PrimeWhite (the sat/CC dE normalizer).
+	RunGray(c, m, sensor, stats[FAM_GRAY]);
+	RunPrimaries(c, m, sensor, stats[FAM_PRIM]);
+	RunSats(c, m, sensor, 1.0, stats[FAM_SAT100]);
+	RunSats(c, m, sensor, 0.75, stats[FAM_SAT75]);
+	RunCC(c, m, sensor, GCD, 24, stats[FAM_CC_GCD]);
+	RunCC(c, m, sensor, AXIS, 71, stats[FAM_CC_AXIS]);
+
+	// Evaluate
+	char line[512];
+	int n = _snprintf(line, sizeof(line)-1, "%-8s %-10s %-6s %-8s %3.0f%%  ",
+					  c.stdName, c.eotfName, c.whiteName, c.gridName, c.intensity * 100.);
+	BOOL bFail = FALSE, bKnown = FALSE;
+	for ( int fam = 0 ; fam < FAM_COUNT ; fam ++ )
+	{
+		double tol = TolFor(c, fam);
+		int iKnown = MatchKnownFail(c, fam);
+		double w = stats[fam].worst;
+		BOOL over = ( w > tol );
+		n += _snprintf(line + n, sizeof(line)-1-n, "%7.3f%c", w, over ? (iKnown >= 0 ? '#' : '*') : ' ');
+		if ( over )
+		{
+			if ( iKnown >= 0 )
+			{
+				bKnown = TRUE;
+				s_knownFailFired[iKnown] = true;
+				Detail("KNOWN-FAIL  %s %s %s %s %.0f%% [%s]: worst dE %.3f at %s\n            reason: %s\n",
+					   c.stdName, c.eotfName, c.whiteName, c.gridName, c.intensity * 100.,
+					   kFamilyName[fam], w, stats[fam].desc, kKnownFails[iKnown].reason);
+			}
+			else
+			{
+				bFail = TRUE;
+				Detail("FAIL        %s %s %s %s %.0f%% [%s]: worst dE %.3f (tol %.2f) at %s\n",
+					   c.stdName, c.eotfName, c.whiteName, c.gridName, c.intensity * 100.,
+					   kFamilyName[fam], w, tol, stats[fam].desc);
+			}
+		}
+		// An in-tolerance result on a known-fail-covered family is fine (the
+		// gaps are level/grid dependent); an entry is only stale if it never
+		// fires across the entire run - checked after the matrix completes.
+	}
+
+	const char * verdict = bFail ? "FAIL" : (bKnown ? "KNOWN-FAIL" : "PASS");
+	fprintf(s_fReport, "%s %s\n", line, verdict);
+
+	s_nCombos ++;
+	if ( bFail )			s_nFail ++;
+	else if ( bKnown )		s_nKnownFail ++;
+	else					s_nPass ++;
+}
+
+} // namespace
+
+/////////////////////////////////////////////////////////////////////////////
+// Entry point
+
+int RunAccuracyTest ( const char * pReportPath )
+{
+	// Show progress/summary when launched from a console
+	BOOL bConsole = AttachConsole(ATTACH_PARENT_PROCESS);
+	if ( bConsole )
+	{
+		freopen("CONOUT$", "w", stdout);
+		freopen("CONOUT$", "w", stderr);
+		printf("\n");
+	}
+
+	CColorHCFRConfig * cfg = GetConfig();
+
+	// Redirect ALL profile traffic to a scratch ini: nothing in this run may
+	// read or write the user's real configuration. (The process also exits
+	// via ExitProcess, so no settings-saving teardown ever runs.)
+	char tmpPath[MAX_PATH];
+	GetTempPathA(MAX_PATH, tmpPath);
+	_snprintf(cfg->m_iniFileName, MAX_PATH - 1, "%saccuracytest_scratch.ini", tmpPath);
+	cfg->m_iniFileName[MAX_PATH - 1] = 0;
+	DeleteFileA(cfg->m_iniFileName);
+
+	// Non-manual generator: DVD-specific reference conventions stay off and
+	// the wire is the GDI-family model this harness reproduces.
+	cfg->SetGeneratorType(CColorHCFRConfig::enumAutomatic);
+
+	CSimulatedSensor::s_bInstantMeasure = TRUE;
+
+	const char * pPath = pReportPath && pReportPath[0] ? pReportPath : "accuracytest_report.txt";
+	s_fReport = fopen(pPath, "w");
+	if ( !s_fReport )
+	{
+		if ( bConsole ) printf("accuracytest: cannot open report file '%s'\n", pPath);
+		return 2;
+	}
+
+	fprintf(s_fReport, "ColorHCFR /accuracytest - reference == wire == sensor-model matrix\n");
+	fprintf(s_fReport, "Columns are the worst dE per patch family; '*' = over tolerance (FAIL),\n");
+	fprintf(s_fReport, "'#' = over tolerance but documented KNOWN-FAIL (see detail below).\n");
+	fprintf(s_fReport, "Tolerance: 0.05; Intensity-90%% combos: 0.9 (power law) / 1.5 (other EOTFs)\n");
+	fprintf(s_fReport, "dE settings: dE_form=3 (CIE2000), dE_gray=1 (gamma-predicted gray target), gw_Weight=0\n\n");
+	fprintf(s_fReport, "%-8s %-10s %-6s %-8s %-5s %8s %7s %7s %7s %7s %7s  %s\n",
+			"space", "eotf", "white", "grid", "inten",
+			"gray", "prim", "sat100", "sat75", "ccGCD", "ccAXIS", "result");
+
+	int iSpace, iEotf, iWhite, iGrid, iInt;
+	for ( iSpace = 0 ; iSpace < (int)(sizeof(kSpaces)/sizeof(kSpaces[0])) ; iSpace ++ )
+	{
+		const SpaceDef & sp = kSpaces[iSpace];
+		int nEotfs = ( sp.cs == sRGB ) ? 1 : (int)(sizeof(kEotfs)/sizeof(kEotfs[0]));
+
+		for ( iEotf = 0 ; iEotf < nEotfs ; iEotf ++ )
+		{
+			// sRGB space: every consumer forces mode 99; run it once as
+			// its own transfer function.
+			const EotfDef & e = kEotfs[iEotf];
+			int eotf = ( sp.cs == sRGB ) ? 0 : e.mode;
+			BOOL bSdr = !( eotf == 5 || eotf == 7 );
+
+			for ( iWhite = 0 ; iWhite < (int)(sizeof(kWhites)/sizeof(kWhites[0])) ; iWhite ++ )
+			{
+				for ( iGrid = 0 ; iGrid < (int)(sizeof(kGrids)/sizeof(kGrids[0])) ; iGrid ++ )
+				{
+					// Window Intensity is SDR-only (the generator UI
+					// disables it for modes 5/7). HDTVa/b are also
+					// excluded: their saturation dE normalizes to the
+					// UNdimmed OnOff white (UpdateGrid isSpecial branch),
+					// so the cancellation the 90% combos verify does not
+					// exist for them by construction (dE ~5).
+					int nInt = ( bSdr && sp.cs != HDTVa && sp.cs != HDTVb ) ? 2 : 1;
+					for ( iInt = 0 ; iInt < nInt ; iInt ++ )
+					{
+						Combo c;
+						c.std = sp.cs;
+						c.eotf = eotf;
+						c.toneMap = ( sp.cs == sRGB ) ? FALSE : e.toneMap;
+						c.white = kWhites[iWhite].wt;
+						c.b10 = kGrids[iGrid].b10;
+						c.lim = kGrids[iGrid].lim;
+						c.gridIdx = iGrid;
+						c.intensity = iInt ? 0.9 : 1.0;
+						c.eotfName = ( sp.cs == sRGB ) ? "sRGB" : e.name;
+						c.whiteName = kWhites[iWhite].name;
+						c.gridName = kGrids[iGrid].name;
+						c.stdName = sp.name;
+						RunCombo(c);
+					}
+				}
+			}
+			if ( bConsole )
+			{
+				printf("accuracytest: %-8s %-10s done (%d combos so far, %d fail)\n",
+					   sp.name, (sp.cs == sRGB) ? "sRGB" : e.name, s_nCombos, s_nFail);
+				fflush(stdout);
+			}
+		}
+	}
+
+	// A known-fail entry that never fired anywhere in the matrix is stale.
+	for ( int k = 0 ; k < (int)(sizeof(kKnownFails)/sizeof(kKnownFails[0])) ; k ++ )
+	{
+		if ( !s_knownFailFired[k] )
+		{
+			s_nUnexpectedPass ++;
+			Detail("STALE KNOWN-FAIL entry %d never fired - remove it: %s\n", k, kKnownFails[k].reason);
+		}
+	}
+
+	fprintf(s_fReport, "\n");
+	if ( !s_failDetail.IsEmpty() )
+		fprintf(s_fReport, "---- DETAIL ----\n%s\n", (LPCSTR)s_failDetail);
+	fprintf(s_fReport, "SUMMARY: %d combos: %d pass, %d FAIL, %d known-fail%s\n",
+			s_nCombos, s_nPass, s_nFail, s_nKnownFail,
+			s_nUnexpectedPass ? " (stale known-fail entries present!)" : "");
+	fclose(s_fReport);
+
+	int rc = ( s_nFail > 0 ) ? 1 : 0;
+	if ( bConsole )
+	{
+		printf("accuracytest: %d combos: %d pass, %d FAIL, %d known-fail -> exit %d (report: %s)\n",
+			   s_nCombos, s_nPass, s_nFail, s_nKnownFail, rc, pPath);
+		fflush(stdout);
+	}
+	return rc;
+}

--- a/AccuracyTest.h
+++ b/AccuracyTest.h
@@ -1,0 +1,22 @@
+/////////////////////////////////////////////////////////////////////////////
+// AccuracyTest.h: headless "/accuracytest" self-test entry point.
+//
+// ColorHCFR.exe /accuracytest [report.txt]
+//
+// Runs the reference-vs-simulated-sensor accuracy matrix (see
+// AccuracyTest.cpp for the full description) and exits the process with
+// code 0 (all combos passed) or 1 (unexpected failures - see the report).
+/////////////////////////////////////////////////////////////////////////////
+
+#if !defined(AFX_ACCURACYTEST_H__INCLUDED_)
+#define AFX_ACCURACYTEST_H__INCLUDED_
+
+#if _MSC_VER > 1000
+#pragma once
+#endif
+
+// pReportPath may be NULL: defaults to "accuracytest_report.txt" in the
+// current directory. Returns the process exit code (0 pass / 1 fail).
+int RunAccuracyTest ( const char * pReportPath );
+
+#endif

--- a/ColorHCFR.cpp
+++ b/ColorHCFR.cpp
@@ -46,6 +46,7 @@
 #include "VersionInfoFromFile.h"
 #include "ximage.h"
 #include "HcfrUpdateUI.h"
+#include "AccuracyTest.h"
 #include <time.h>
 
 #ifdef USE_NON_FREE_CODE
@@ -217,6 +218,26 @@ void	UpdateDataRef(BOOL ActiveDataRef, CDataSetDoc * pDoc)
 
 BOOL CColorHCFRApp::InitInstance()
 {
+	// /accuracytest [report.txt] : headless reference==wire==sensor-model
+	// self-test (see AccuracyTest.cpp). Handled before any UI is created;
+	// only the config and the color reference are initialized, then the
+	// process exits with 0 (pass) / 1 (failures). ExitProcess (instead of
+	// returning FALSE) guarantees no teardown path can save settings over
+	// the user's configuration.
+	for ( int na = 1 ; na < __argc ; na ++ )
+	{
+		if ( _tcsicmp(__targv[na], _T("/accuracytest")) == 0 || _tcsicmp(__targv[na], _T("-accuracytest")) == 0 )
+		{
+			m_pColorReference = new CColorReference(SDTV,D65,2.2);
+			m_pConfig = new CColorHCFRConfig();
+			m_pszRegistryKey = NULL;
+			m_pszProfileName = _tcsdup(m_pConfig->m_iniFileName);
+			LPCTSTR pReport = ( na + 1 < __argc && __targv[na+1][0] != _T('/') && __targv[na+1][0] != _T('-') )
+							  ? __targv[na+1] : NULL;
+			::ExitProcess ( RunAccuracyTest ( pReport ) );
+		}
+	}
+
 	// Create splash screen (layered window with per-pixel alpha)
 	CxImage SplashImage;
 	CWnd	SplashWnd;

--- a/ColorHCFR.cpp
+++ b/ColorHCFR.cpp
@@ -228,6 +228,10 @@ BOOL CColorHCFRApp::InitInstance()
 	{
 		if ( _tcsicmp(__targv[na], _T("/accuracytest")) == 0 || _tcsicmp(__targv[na], _T("-accuracytest")) == 0 )
 		{
+			// Construct the config in headless mode so it cannot read/write the
+			// user's real ini or pop the language/help pickers (which would
+			// hang a truly headless/CI run). Must be set BEFORE construction.
+			CColorHCFRConfig::s_bHeadless = TRUE;
 			m_pColorReference = new CColorReference(SDTV,D65,2.2);
 			m_pConfig = new CColorHCFRConfig();
 			m_pszRegistryKey = NULL;

--- a/ColorHCFR.vcxproj
+++ b/ColorHCFR.vcxproj
@@ -294,6 +294,12 @@
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
+    <ClCompile Include="AccuracyTest.cpp">
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Include="ModelessPropertySheet.cpp">
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -895,6 +901,7 @@
     <ClInclude Include="MainFrm.h" />
     <ClInclude Include="Tools\GoogleCastWrapper\GoogleCastWrapper.h" />
     <ClInclude Include="Tools\MainWndPlacement.h" />
+    <ClInclude Include="AccuracyTest.h" />
     <ClInclude Include="AsyncMeasurer.h" />
     <ClInclude Include="Measure.h" />
     <ClInclude Include="ModelessPropertySheet.h" />

--- a/ColorHCFRConfig.cpp
+++ b/ColorHCFRConfig.cpp
@@ -48,6 +48,8 @@ static char THIS_FILE[]=__FILE__;
 #define LANG_PREFIX "CHCFR21_"
 #define HELP_PREFIX "ColorHCFR_"
 
+BOOL CColorHCFRConfig::s_bHeadless = FALSE;
+
 CString GetColorStandardName(int nStandard)
 {
 	static const UINT ids[] = { IDS_STD_PALSECAM, IDS_STD_SDTV, IDS_STD_REC709, IDS_STD_REC709_75, IDS_STD_REC709_PLASMA, IDS_STD_SRGB, IDS_STD_DCIP3, IDS_STD_REC2020, IDS_STD_P3IN2020, IDS_STD_709IN2020, IDS_STD_CUSTOM };
@@ -158,10 +160,23 @@ CColorHCFRConfig::CColorHCFRConfig()
 	lpStr = strrchr ( m_logFileName, (int) '\\' );
 	strcpy ( lpStr + 1, "ColorHCFR.log" );
 
+	// Headless (/accuracytest): keep the INI on a throwaway scratch path and
+	// skip the APPDATA redirect, previous-install migration and data-file
+	// seeding entirely - none of the user's real config may be read or
+	// written during a self-test run.
+	if ( s_bHeadless )
+	{
+		char szTmp[MAX_PATH];
+		GetTempPathA(MAX_PATH, szTmp);
+		_snprintf(m_iniFileName, sizeof(m_iniFileName) - 1, "%saccuracytest_scratch.ini", szTmp);
+		m_iniFileName[sizeof(m_iniFileName) - 1] = '\0';
+		DeleteFileA(m_iniFileName);
+	}
 	// Config must live in a per-user writable location: the exe folder is
 	// read-only when installed under Program Files, and UAC virtualization is
 	// off for this build. Keep the INI and log under %APPDATA%\color; read-only
 	// files (help, language DLLs, res\images) still load from the exe folder.
+	else
 	{
 		const char *pAppData = getenv("APPDATA");
 		if (pAppData && *pAppData)
@@ -240,9 +255,16 @@ CColorHCFRConfig::CColorHCFRConfig()
 		default:
 			 if ( strLang.IsEmpty () || ! dlg.m_Languages.Find ( strLang ) )
 			 {
-				dlg.DoModal ();
-				strLang = dlg.m_Selection;
-				WriteProfileString ( "Options", "Language", strLang );
+				if ( s_bHeadless )
+					// No UI, no config write: take the first available language
+					// so the resource DLL still loads.
+					strLang = dlg.m_Languages.GetHead ();
+				else
+				{
+					dlg.DoModal ();
+					strLang = dlg.m_Selection;
+					WriteProfileString ( "Options", "Language", strLang );
+				}
 			 }
 			 break;
 	}
@@ -300,7 +322,7 @@ CColorHCFRConfig::CColorHCFRConfig()
 				FindClose ( hFind );
 			}
 			
-			if ( dlgHelp.m_Languages.GetCount () > 0 )
+			if ( !s_bHeadless && dlgHelp.m_Languages.GetCount () > 0 )
 			{
 				if ( IDOK == dlgHelp.DoModal () )
 				{

--- a/ColorHCFRConfig.h
+++ b/ColorHCFRConfig.h
@@ -40,7 +40,7 @@
 #include <map>
 extern CString GetColorStandardName(int nStandard);
 
-class CColorHCFRConfig  
+class CColorHCFRConfig
 {
 public:
 	enum GeneratorType
@@ -48,6 +48,13 @@ public:
 		enumAutomatic,
 		enumManual,
 	};
+
+	// Headless mode (set TRUE before construction by the /accuracytest hook):
+	// the constructor must not touch the user's real config or block on UI.
+	// When set it keeps the INI on a throwaway scratch path (no APPDATA
+	// redirect, migration, or data-file seeding), suppresses the modal
+	// language/help pickers, and writes nothing. Never set in interactive use.
+	static BOOL s_bHeadless;
 
 	// Exe Path, with an ending backslash
 	char m_ApplicationPath [MAX_PATH];

--- a/Measure.cpp
+++ b/Measure.cpp
@@ -6809,16 +6809,35 @@ void CMeasure::AppendMeasurements(const CColor & aColor, int isPrimary, int last
 	FreeMeasurementAppended(isPrimary, last_minCol); 
 }
 
+// The EXACT percent triplets MeasurePrimaries sends for the special
+// standards (R,G,B,Y,C,M) - the reference must decode these actual wire
+// codes: re-encoding the analog color lands up to half a code away from the
+// 2-decimal-rounded tables (~0.4 dE). Keep byte-identical to the GenColors
+// tables in MeasurePrimaries.
+static const double kHDTVaWireCodes[6][3] =
+{
+	{ 68.04,20.09,20.09 }, { 27.85,73.06,27.85 }, { 19.18,19.18,50.22 },
+	{ 73.9726,73.9726,33.3333 }, { 36.07,73.06,73.06 }, { 64.3836,29.2237,64.3836 },
+};
+static const double kHDTVbWireCodes[6][3] =
+{
+	{ 79.9087,10.0457,10.0457 }, { 30.137,79.9087,30.137 }, { 50.2283,50.2283,79.9087 },
+	{ 79.9087,79.9087,10.0457 }, { 10.0457,79.9087,79.9087 }, { 79.9087,10.0457,79.9087 },
+};
+
 // Shared by GetRefPrimary/GetRefSecondary: turn the analog primary/secondary
 // XYZ into the reference the wire actually produces. Plain standards send
 // pure 0/100% codes - exact on every grid and under any gamma - so the analog
-// color IS the wire-exact reference. The special 75%-style standards (HDTVa/b,
-// CC6) send fractional codes that must be encoded, grid-quantized and decoded.
+// color IS the wire-exact reference. The special 75%-style standards send
+// fractional codes that must be grid-quantized and decoded: HDTVa/b decode
+// the actual hardcoded wire tables (in the HDTV space the sensor/dE path
+// uses); CC6 (no wire table) keeps the analog encode->quantize->decode
+// chain. 'idx' is the patch index (0-2 primaries, 3-5 secondaries).
 // HDR modes 5/7 keep the analog reference (patch levels are recalculated at
 // measure time; legacy behavior). Window Intensity is deliberately NOT
 // modeled - it dims the measured white anchor equally and cancels in the
 // white-relative dE (see the note above TmDiffuseWhiteNits).
-static CColor WireModeledPrimaryReference ( const CMeasure & measure, const ColorXYZ & xyz, const CColorReference & cRef )
+static CColor WireModeledPrimaryReference ( const CMeasure & measure, const ColorXYZ & xyz, const CColorReference & cRef, int idx )
 {
 	int mode = GetConfig()->m_GammaOffsetType;
 	if (GetConfig()->m_colorStandard == sRGB) mode = 99;
@@ -6837,21 +6856,56 @@ static CColor WireModeledPrimaryReference ( const CMeasure & measure, const Colo
 	bool b10 = GetConfig()->GetUse10bitLevels();
 	bool lim = GetConfig()->GetRGB16_235();
 
+	const double (*pWire)[3] = ( cRef.m_standard == HDTVa ) ? kHDTVaWireCodes
+							 : ( cRef.m_standard == HDTVb ) ? kHDTVbWireCodes : NULL;
+
 	CColor aColor;
-	aColor.SetXYZValue ( xyz );
-	ColorRGB rgb = aColor.GetRGBValue ( cRef );
+	ColorRGB rgb;
+	if ( !pWire )
+	{
+		aColor.SetXYZValue ( xyz );
+		rgb = aColor.GetRGBValue ( cRef );
+	}
 	for ( int ch = 0 ; ch < 3 ; ch ++ )
 	{
-		double q = min ( max ( rgb[ch], 0.0 ), 1.0 );
-		q = ( q <= 0.0 || q >= 1.0 ) ? q : pow ( q, 1.0 / 2.22 );
+		double q;
+		if ( pWire )
+			q = pWire[idx][ch] / 100.0;
+		else
+		{
+			q = min ( max ( rgb[ch], 0.0 ), 1.0 );
+			q = ( q <= 0.0 || q >= 1.0 ) ? q : pow ( q, 1.0 / 2.22 );
+		}
 		q = SnapToVideoGrid ( q, b10, lim );
 		if ( mode >= 4 )
 			rgb[ch] = ( q <= 0.0 || q >= 1.0 ) ? q : getL_EOTF ( q, White, Black, GetConfig()->m_GammaRel, GetConfig()->m_Split, mode );
 		else
 			rgb[ch] = ( q <= 0.0 || q >= 1.0 ) ? q : pow ( q, gamma );
 	}
-	aColor.SetRGBValue ( rgb, cRef );
-	return aColor.GetXYZValue();
+	// HDTVa/b wire codes are HDTV-space signals: the sensor and the dE path
+	// both operate in plain HDTV for the special modes.
+	aColor.SetRGBValue ( rgb, pWire ? CColorReference(HDTV) : cRef );
+	ColorXYZ out = aColor.GetXYZValue();
+
+	// HDTVa's white anchor is the 75% patch (MeasurePrimaries GenColors[6] =
+	// 75/75/75), and the primaries dE normalizes the measurement to that
+	// PrimeWhite while the reference is normalized to 1.0 - so express the
+	// reference relative to the decoded 75% white, exactly as the sensor's
+	// 75% patch relates to the measured white. (HDTVb's white patch is 100%:
+	// no rescale.)
+	if ( cRef.m_standard == HDTVa )
+	{
+		double qw = SnapToVideoGrid ( 0.75, b10, lim );
+		double w = ( mode >= 4 ) ? getL_EOTF ( qw, White, Black, GetConfig()->m_GammaRel, GetConfig()->m_Split, mode )
+								 : pow ( qw, gamma );
+		if ( w > 0.0 )
+		{
+			out[0] /= w;
+			out[1] /= w;
+			out[2] /= w;
+		}
+	}
+	return out;
 }
 
 CColor CMeasure::GetRefPrimary(int i) const
@@ -6883,13 +6937,13 @@ CColor CMeasure::GetRefPrimary(int i) const
 	switch ( i )
 	{
 		case 0:	// red
-			return WireModeledPrimaryReference ( *this, ColorXYZ(cRef.GetRed()), cRef );
+			return WireModeledPrimaryReference ( *this, ColorXYZ(cRef.GetRed()), cRef, 0 );
 
 		case 1:	// green
-			return WireModeledPrimaryReference ( *this, ColorXYZ(cRef.GetGreen()), cRef );
+			return WireModeledPrimaryReference ( *this, ColorXYZ(cRef.GetGreen()), cRef, 1 );
 
 		case 2:	// blue
-			return WireModeledPrimaryReference ( *this, ColorXYZ(cRef.GetBlue()), cRef );
+			return WireModeledPrimaryReference ( *this, ColorXYZ(cRef.GetBlue()), cRef, 2 );
 	}
 
 	// Cannot execute this if "i" is OK.
@@ -6919,13 +6973,13 @@ CColor CMeasure::GetRefSecondary(int i) const
 	switch ( i )
 	{
 		case 0:	// Yellow
-			return WireModeledPrimaryReference ( *this, ColorXYZ(cRef.GetYellow()), cRef );
+			return WireModeledPrimaryReference ( *this, ColorXYZ(cRef.GetYellow()), cRef, 3 );
 
 		case 1:	// Cyan
-			return WireModeledPrimaryReference ( *this, ColorXYZ(cRef.GetCyan()), cRef );
+			return WireModeledPrimaryReference ( *this, ColorXYZ(cRef.GetCyan()), cRef, 4 );
 
 		case 2:	// Magenta
-			return WireModeledPrimaryReference ( *this, ColorXYZ(cRef.GetMagenta()), cRef );
+			return WireModeledPrimaryReference ( *this, ColorXYZ(cRef.GetMagenta()), cRef, 5 );
 	}
 
 	// Cannot execute this if "i" is OK.
@@ -7045,7 +7099,12 @@ CColor CMeasure::GetRefSat(int i, double sat_ratio, bool special, double stimLev
 
 	double tmWhite = TmDiffuseWhiteNits(White, Black);
 
-	if (mode == 5 && sat_ratio == 1 && GetConfig()->m_colorStandard != UHDTV3 && GetConfig()->m_colorStandard != UHDTV4)
+	// 100%-saturation luma convention for the analog (unquantized) HDR-10
+	// reference. Full-stimulus only: at reduced stimLevel the quantize gate
+	// below opens and the wire (GenerateSaturationColors) encodes the plain
+	// K-luma color - carrying this scale into that encode lands the
+	// reference up to a code away from the signal.
+	if (mode == 5 && sat_ratio == 1 && stimLevel >= 1.0 && GetConfig()->m_colorStandard != UHDTV3 && GetConfig()->m_colorStandard != UHDTV4)
 		YLuma = YLuma * tmWhite / 94.37844;
 
 	aColor.SetxyYValue (x, y, YLuma);
@@ -7602,7 +7661,12 @@ void CMeasure::GetRefCC24Sat(int i, CColor& ccRef) const
 			g = getL_EOTF(qg,White,Black,GetConfig()->m_GammaRel, GetConfig()->m_Split, mode,GetConfig()->m_DiffuseL, GetConfig()->m_MasterMinL, GetConfig()->m_MasterMaxL, GetConfig()->m_TargetMinL, GetConfig()->m_TargetMaxL,GetConfig()->m_useToneMap, FALSE, GetConfig()->m_TargetSysGamma, GetConfig()->m_BT2390_BS, GetConfig()->m_BT2390_WS, GetConfig()->m_BT2390_WS1) / (mode==5?100.:1.0);
 			b = getL_EOTF(qb,White,Black,GetConfig()->m_GammaRel, GetConfig()->m_Split, mode,GetConfig()->m_DiffuseL, GetConfig()->m_MasterMinL, GetConfig()->m_MasterMaxL, GetConfig()->m_TargetMinL, GetConfig()->m_TargetMaxL,GetConfig()->m_useToneMap, FALSE, GetConfig()->m_TargetSysGamma, GetConfig()->m_BT2390_BS, GetConfig()->m_BT2390_WS, GetConfig()->m_BT2390_WS1) / (mode==5?100.:1.0);
 		}
-		if ( mode == 6 || mode == 4 || mode == 8 )
+		// mode 99 (sRGB standard) belongs here too: the wire quantizes the
+		// 2.22-encoded signal and the sensor/gray targets decode it with the
+		// sRGB curve via getL_EOTF(99) - same chain GetRefSat models. It
+		// previously fell through every branch, leaving CC references
+		// unquantized AND 2.22-decoded (up to ~5 dE on dark AXIS steps).
+		if ( mode == 6 || mode == 4 || mode == 8 || mode == 99 )
 		{
 			qr = (r==0)?0:pow(r, 1.0 / 2.22);
 			qg = (g==0)?0:pow(g, 1.0 / 2.22);

--- a/Sensors/SimulatedSensor.cpp
+++ b/Sensors/SimulatedSensor.cpp
@@ -42,6 +42,8 @@ extern Matrix defaultSensorToXYZMatrix;	// Implemented in Color.cpp
 
 IMPLEMENT_SERIAL(CSimulatedSensor, COneDeviceSensor, 1) ;
 
+BOOL CSimulatedSensor::s_bInstantMeasure = FALSE;
+
 CSimulatedSensor::CSimulatedSensor()
 {
 	m_offsetRed=2;
@@ -305,7 +307,8 @@ CColor CSimulatedSensor::MeasureColorInternal(const ColorRGBDisplay& aRGBValue, 
 	else
 		simulColor[2]=(pow(value/100.0,gamma));
 
-	Sleep(50);
+	if (!s_bInstantMeasure)
+		Sleep(50);
 	ColorRGB colMeasure(simulColor);
 	bool isSpecial = (GetConfig()->m_colorStandard == HDTVa || GetConfig()->m_colorStandard == HDTVb);
 

--- a/Sensors/SimulatedSensor.h
+++ b/Sensors/SimulatedSensor.h
@@ -14,7 +14,7 @@
 //  GNU General Public License for more details
 /////////////////////////////////////////////////////////////////////////////
 //  Author(s):
-//	François-Xavier CHABOUD
+//	Franï¿½ois-Xavier CHABOUD
 /////////////////////////////////////////////////////////////////////////////
 
 // SimulatedSensor.h: interface for the CSimulatedSensor class.
@@ -54,6 +54,11 @@ public:
 
 	// returns unique sensor identifier (for simultaneous measures: cannot use twice the same sensor on two documents)
 	virtual void GetUniqueIdentifier( CString & strId );
+
+	// AccuracyTest support (/accuracytest): TRUE skips the 50 ms UI pacing
+	// sleep in MeasureColorInternal so the headless matrix can run ~100k
+	// synthetic reads in seconds. Never set in interactive use.
+	static BOOL s_bInstantMeasure;
 
 	// Settings
 	UINT m_offsetRed;

--- a/tests/ACCURACYTEST.md
+++ b/tests/ACCURACYTEST.md
@@ -35,9 +35,16 @@ echo %ERRORLEVEL%     rem 0 = pass, 1 = failures, 2 = cannot write report
 Headless: no windows, no generators, no real measure loops; the run takes
 seconds and writes `accuracytest_report.txt` (or the given path) in the
 current directory. When started from a console it also prints progress and
-the summary line. The user's configuration is untouched — all profile reads
-and writes are redirected to a scratch ini in `%TEMP%`, and the process exits
-before any settings-saving teardown.
+the summary line.
+
+Truly headless and config-safe, so it is safe to run in CI on a fresh machine.
+The hook sets `CColorHCFRConfig::s_bHeadless` **before** constructing the
+config, so the constructor never reads or writes the user's real ini, never
+migrates/seeds `%APPDATA%\color`, and never pops the modal language/help
+pickers (which would otherwise hang a headless run on a box that has never
+launched HCFR interactively). All profile traffic lands on a throwaway scratch
+ini in `%TEMP%`, and the process exits via `ExitProcess` before any
+settings-saving teardown.
 
 ## The matrix
 
@@ -85,10 +92,24 @@ measured gray top as White; then primaries, which set PrimeWhite):
 ## Reading the report
 
 One line per combo with the worst dE per family; `*` marks over-tolerance
-(FAIL), `#` marks over-tolerance but documented KNOWN-FAIL. A detail block
-lists every failing family with its worst patch, and known-fail entries print
-their code-level reason. `UNEXPECTED-PASS` means a known-fail entry became
-stale — remove it from `kKnownFails` in `AccuracyTest.cpp`.
+(FAIL), `#` marks over-tolerance but a documented KNOWN-FAIL *within its
+ceiling*. A detail block lists every failing family with its worst patch, and
+known-fail entries print their code-level reason.
+
+Known-fails **do not mask regressions**. Each `kKnownFails` entry carries a
+`ceiling`: a matching combo is only downgraded to KNOWN-FAIL while its worst dE
+stays at or below that ceiling. If the known gap *grows* past the ceiling the
+line is reported as `FAIL(>ceil)` and the run fails — a widening known gap is a
+regression the entry must not swallow. Ceilings sit above the first-full-run
+worst per class with headroom; the broad full-range-gray entry is deliberately
+tight (2.0 vs an observed 0.39) so it cannot absorb a real grayscale/EOTF
+regression.
+
+A known-fail entry that never fires anywhere in a run is **stale** (a combo was
+dropped, or the issue was fixed and the entry now sits ready to mask a new
+nearby regression). Stale entries print a warning **and fail the run** (nonzero
+exit) — remove them from `kKnownFails` in `AccuracyTest.cpp`. The exit code is
+nonzero if there is any real FAIL **or** any stale entry.
 
 Tolerances: **0.05** for exact-model combos (SnapToVideoGrid's 1e-9
 tie-breaker means no extra slack is needed). The Intensity-90% combos get

--- a/tests/ACCURACYTEST.md
+++ b/tests/ACCURACYTEST.md
@@ -1,0 +1,157 @@
+# /accuracytest — in-app reference == wire == sensor-model matrix
+
+Automates the manual simulated-sensor sweeps used to validate color-math
+changes: for every meaningful configuration combination it verifies that the
+app's **references** (CMeasure `GetRefPrimary` / `GetRefSecondary` /
+`GetRefSat` / `GetRefCC24Sat` and the grayscale EOTF target) model the **wire**
+(the exact patch codes the generators emit) exactly, by pushing those codes
+through `CSimulatedSensor` (error injection off) and asserting dE ~ 0 with the
+**same normalization the measures grid uses** (`CMainView::UpdateGrid` +
+`GetItemText`: the HDR `105.95640` / `GetHDRRefScale` rescales, the
+`tmWhite`-based `RefWhite`, the `YWhite * 94.37844 / tmWhite` rescale, the
+per-view YWhite source — gray-ramp top, PrimeWhite, or OnOff white).
+
+## Relation to `tests\ColorMathTest`
+
+They are complementary layers — run **both** after any color-math change:
+
+| Harness | Layer | How it checks |
+|---|---|---|
+| `ColorMathTest.exe verify` | pure libHCFR (patch generators, quantizers, EOTF round trips) | byte-exact golden files |
+| `ColorHCFR.exe /accuracytest` | app-coupled reference layer (CMeasure GetRef*, grid dE conventions) | dE ~ 0 invariant vs the simulated sensor |
+
+The GetRef* functions are coupled to `GetConfig()` and to measured state
+(gray-array top, OnOffBlack, PrimeWhite), so ColorMathTest cannot reach them.
+`/accuracytest` never asserts absolute golden values — it asserts the
+*invariant* that a perfect display model measures its own reference.
+
+## Running
+
+```
+Debug\ColorHCFR.exe /accuracytest [report.txt]
+echo %ERRORLEVEL%     rem 0 = pass, 1 = failures, 2 = cannot write report
+```
+
+Headless: no windows, no generators, no real measure loops; the run takes
+seconds and writes `accuracytest_report.txt` (or the given path) in the
+current directory. When started from a console it also prints progress and
+the summary line. The user's configuration is untouched — all profile reads
+and writes are redirected to a scratch ini in `%TEMP%`, and the process exits
+before any settings-saving teardown.
+
+## The matrix
+
+Full cross product where meaningful (~800 combos):
+
+- **Grid (bit depth x range)**: 8-bit limited (219), 8-bit full (255),
+  10-bit limited (876), 10-bit full (1023) — via the cached
+  `GetUse10bitLevels()` / `GetRGB16_235()` flags.
+- **Color space**: HDTV (Rec.709), sRGB, UHDTV (P3), UHDTV2 (BT.2020),
+  UHDTV3 (P3-in-2020), UHDTV4 (709-in-2020), HDTVa (75%), HDTVb (plasma).
+  CC6 is marked unused in the enum and is not UI-selectable — excluded.
+- **Transfer function**: power 2.2, BT.1886, L*, PQ (tone map OFF and ON /
+  BT.2390), HLG. sRGB-the-EOTF is exercised through the sRGB color space
+  (every consumer forces mode 99 for it), so that space runs one entry.
+  Mode 1 (SDR black compensation) only reshapes the gray target and mode 8
+  is not UI-reachable — excluded.
+- **White point**: D65, DCI white, and manual xy 0.3067/0.3180 (`DCUST`).
+  The custom whites were never hand-tested; the known-fail table below
+  documents where the references are still D65-bound.
+- **Window intensity**: 100% always; 90% additionally for the SDR transfer
+  functions (the generator UI disables Intensity for PQ/HLG). Intensity is
+  deliberately NOT modeled by the references — it dims the measured white
+  anchor equally and cancels in the white-relative dE. The 90% combos test
+  that *cancellation*: the harness dims exactly the patches GDIGenerator
+  dims (MT_PRIMARY / MT_SECONDARY / MT_SAT_*, **including** the PrimeWhite
+  anchor; grayscale MT_IRE and CC patches are not dimmed).
+
+Patch families per combo, built with the same construction code the measure
+loops use, in the real measurement order (grayscale first — OnOffWhite/Black
+come from the ramp ends and the HLG/BT.1886 reference decodes use the
+measured gray top as White; then primaries, which set PrimeWhite):
+
+- `gray` — 11-point ramp via `GetGrayPercent` (black column carries no dE in
+  the grid and is skipped the same way here).
+- `prim` — primaries + secondaries + white row, mirroring `MeasurePrimaries`'
+  GenColors (incl. the UHDTV3/4 `ContainerPrimaryLinear` chain and the
+  HDTVa/b HDR re-encode).
+- `sat100` / `sat75` — six saturation sweeps at 100% and 75% stimulus via
+  `GenerateSaturationColors`.
+- `ccGCD` / `ccAXIS` — color-checker sets GCD (24) and AXIS (71 patches,
+  indices 0..70) via `GenerateCC24Colors`. AXIS covers the clipped-ramp-top
+  cases in PQ: patches above `m_TargetMaxL` must STILL read dE ~ 0 because
+  the reference models the same per-channel clip.
+
+## Reading the report
+
+One line per combo with the worst dE per family; `*` marks over-tolerance
+(FAIL), `#` marks over-tolerance but documented KNOWN-FAIL. A detail block
+lists every failing family with its worst patch, and known-fail entries print
+their code-level reason. `UNEXPECTED-PASS` means a known-fail entry became
+stale — remove it from `kKnownFails` in `AccuracyTest.cpp`.
+
+Tolerances: **0.05** for exact-model combos (SnapToVideoGrid's 1e-9
+tie-breaker means no extra slack is needed). The Intensity-90% combos get
+**0.9** (power law) / **1.5** (BT.1886, L*, sRGB): the cancellation is exact
+only for an ideal power law — the dimmed code snaps to a different grid point
+than the undimmed one, and non-power EOTFs break the ratio identity — so a
+bounded, level-dependent residual is expected behavior, not a modeling error
+(measured ceilings ~0.8 and ~1.2 across the full matrix; worst on 8-bit dark
+saturation steps).
+
+Harness dE settings (fixed, independent of the user's config): `dE_form=3`
+(CIE2000), `dE_gray=1` (gamma-predicted gray luminance target — the app's
+default `dE_form=5`/`dE_gray=2` substitutes the *measured* luminance into the
+gray reference, which would blind the test to EOTF regressions), `gw_Weight=0`,
+`m_TargetMinL=0` (the references target ideal black; the sensor's nonzero
+floor is a display property, not a wire property).
+
+## Fixes that came out of the first full run
+
+The first matrix run surfaced three reference-vs-wire gaps that were fixed in
+`Measure.cpp` (the reference must model the wire):
+
+- `GetRefCC24Sat` had no branch for mode 99 (the sRGB standard): CC
+  references were left unquantized and 2.22-decoded while the sensor/gray
+  targets decode with the sRGB curve (up to ~5 dE on dark AXIS steps).
+- `GetRefSat` applied the `YLuma * tmWhite / 94.37844` 100%-saturation
+  convention even at reduced stimulus, where the quantize path opens and the
+  generator encodes the plain K-luma color — the reference landed a code away
+  (up to ~1.2 dE). Now gated on `stimLevel >= 1`.
+- `WireModeledPrimaryReference` re-encoded the analog HDTVa/b colors while
+  the wire sends 2-decimal-rounded hardcoded tables (~0.4 dE); it now decodes
+  the actual wire codes (in HDTV space, HDTVa normalized to its 75% white
+  anchor).
+
+## Known failures
+
+Kept in `kKnownFails` in `AccuracyTest.cpp`, each with the code-level reason
+and (where relevant) a grid filter. An entry that never fires across a whole
+run is reported as STALE. Current entries (expected, pre-existing):
+
+- **UHDTV3/UHDTV4 with custom whites** (`prim`, `sat*`): `GetRefSat`'s sweep
+  endpoints are hardcoded D65 xy tables (`p3Ref`/`p3sRef`/`rRef`/`rsRef`,
+  Measure.cpp ~6955-6977), while the wire patches follow the active white via
+  `ContainerPrimaryLinear`.
+- **HDTVa/HDTVb with custom whites** (`gray`, `prim`, `sat*`): the wire
+  tables, `pRef`/`sRef` endpoints, the simulated sensor's decode space and
+  the dE space are all fixed Rec.709/D65 constructions, while gray/sat
+  reference targets follow the active white. (CC passes — both sides share
+  the decode chain.)
+- **HDTVa/HDTVb primaries under PQ/HLG**: `WireModeledPrimaryReference`
+  deliberately keeps the legacy ANALOG reference for modes 5/7 while the
+  wire re-encodes the 75% tables with the active EOTF (dE ~70 on blue).
+- **HDTVa/HDTVb PQ `sat75` on 8-bit limited only**: the PQ 50% anchor is
+  exactly code 110/219, so 0.75 stim = an exact half-code (82.5); generator
+  and reference reach it through different matrix round trips whose sub-1e-9
+  dust splits the tie (constant dE 0.74 at yellow).
+- **`gray` on the full-range grids**: the gray pipeline (`GetGrayPercent` /
+  `ArrayIndexToGrayLevel` / `GrayLevelToGrayProp`) has no range parameter —
+  ramp codes and references live on the 219/876 limited grids and the
+  full-range re-snap to 255/1023 is unmodeled (≤ ~0.4 dE, worst at the PQ
+  8-bit knee). Fixing requires a range parameter through libHCFR, which
+  moves ColorMathTest T2/T3 goldens — out of scope here.
+
+Reference result (2026-07-13, first full run after the fixes):
+`708 combos: 311 pass, 0 FAIL, 397 known-fail`, ColorMathTest verify green
+with no golden movement.


### PR DESCRIPTION
## What

`ColorHCFR.exe /accuracytest [report.txt]` — a headless self-test that automates the manual simulated-sensor sweeps: for every meaningful configuration combination it verifies **reference == wire == sensor-model (dE ~ 0)**, so any color-math change can be validated by one command. Exit 0 = pass, 1 = failures; report written to the given path (default `accuracytest_report.txt`). Runs in seconds (new instant mode on the simulated sensor skips the 50 ms pacing sleep); no windows, no generators; the user's configuration is untouched (all profile traffic redirected to a scratch ini in `%TEMP%`, process exits before any settings-saving teardown).

Docs: `tests/ACCURACYTEST.md` (how to run, how to read the report, relation to ColorMathTest, known-fail registry).

## The matrix (708 combos)

- Grids: 8-bit limited/full, 10-bit limited/full (cached `GetUse10bitLevels`/`GetRGB16_235` flags)
- Spaces: HDTV, sRGB, UHDTV (P3), UHDTV2 (BT.2020), UHDTV3, UHDTV4, HDTVa, HDTVb
- EOTFs: power 2.2, BT.1886, L*, PQ (tone map off/on), HLG; sRGB via its color space (mode 99)
- Whites: D65, DCI, manual xy 0.3067/0.3180 — the never-hand-tested dimension
- Intensity: 100% + 90% (SDR only) — verifies the deliberate cancellation of window Intensity in the white-relative dE, dimming exactly the patches GDIGenerator dims
- Families per combo: gray ramp, primaries/secondaries (incl. UHDTV3/4 ContainerPrimaryLinear construction), 6 saturation sweeps at 100% and 75% stimulus, CC GCD (24) + AXIS (71, incl. PQ-clipped ramp tops which must still read dE ~ 0)

All dE evaluation replicates the measures-grid conventions exactly (UpdateGrid + GetItemText: 105.95640/GetHDRRefScale rescales, tmWhite RefWhite, YWhite*94.37844/tmWhite rescale, per-view YWhite source, real measurement order so HLG decodes against the measured gray top).

## Reference fixes surfaced by the first full run

1. **GetRefCC24Sat, sRGB (mode 99)**: fell through every quantize branch — CC references were unquantized and 2.22-decoded while the wire/sensor use the sRGB curve (up to ~5 dE on dark AXIS steps). Now handled like GetRefSat.
2. **GetRefSat, reduced-stimulus 100%-saturation under PQ**: the `YLuma * tmWhite / 94.37844` convention leaked into the quantize path at stim < 1, landing the reference a code off the generator (up to ~1.2 dE). Now gated on full stimulus.
3. **WireModeledPrimaryReference, HDTVa/b**: re-encoded the analog color while the wire sends 2-decimal hardcoded tables (~0.4 dE). Now decodes the actual wire codes in HDTV space, with HDTVa normalized to its 75% white anchor.

## Known-fails (documented in-code, reported with reasons, never mask new regressions)

UHDTV3/4 custom whites (hardcoded D65 endpoint tables in GetRefSat — the expected custom-white finding), HDTVa/b custom whites (fixed Rec.709/D65 constructions), HDTVa/b legacy analog HDR primaries, one PQ half-code tie (code 110/219 × 0.75 stim = exactly 82.5), and gray on full-range grids (gray pipeline has no range parameter; fixing moves ColorMathTest T2/T3 goldens — out of scope). A known-fail entry that never fires in a run is flagged STALE.

## Results

- `/accuracytest`: **708 combos: 311 pass, 0 FAIL, 397 known-fail** (deterministic across repeated runs)
- `ColorMathTest.exe verify`: **ALL TESTS PASSED**, no golden movement (libHCFR untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
