### PR TITLE
ab gamut coverage

### DIFF
--- a/UnitTests/GamutCoverage_unittests.cpp
+++ b/UnitTests/GamutCoverage_unittests.cpp
@@ -11,6 +11,36 @@ namespace
     const ColorxyY rec709[3]  = { ColorxyY(0.6400, 0.3300), ColorxyY(0.3000, 0.6000), ColorxyY(0.1500, 0.0600) };
     const ColorxyY p3[3]      = { ColorxyY(0.6800, 0.3200), ColorxyY(0.2650, 0.6900), ColorxyY(0.1500, 0.0600) };
     const ColorxyY rec2020[3] = { ColorxyY(0.7080, 0.2920), ColorxyY(0.1700, 0.7970), ColorxyY(0.1310, 0.0460) };
+
+    // a*/b* hexagons (R,Y,G,C,B,M) from a real measured display against a
+    // Rec.2020 a*/b* target, and the same measured hexagon after simulating
+    // every channel's luminance being cut (xy chromaticity held fixed) --
+    // both cross-checked against an independent Python/NumPy Lab-conversion
+    // pipeline before being ported in here.
+    const GamutPoint measuredAbBaseline[6] = {
+        { 115.67,  94.40 },   // R
+        { -20.97, 121.49 },   // Y
+        {-169.95, 104.04 },   // G
+        { -96.50, -26.38 },   // C
+        {  86.73,-116.54 },   // B
+        { 134.05, -67.69 },   // M
+    };
+    const GamutPoint targetAbRec2020[6] = {
+        { 117.33, 100.50 },   // R
+        { -21.48, 136.89 },   // Y
+        {-172.32, 116.62 },   // G
+        {-106.24, -19.32 },   // C
+        {  86.11,-120.27 },   // B
+        { 130.53, -61.18 },   // M
+    };
+    const GamutPoint measuredAbAllChannelsDimmed[6] = {
+        {  87.2,  66.8 },     // R
+        { -16.6,  96.1 },     // Y
+        {-135.1,  82.7 },     // G
+        { -88.1, -24.1 },     // C
+        {  66.9, -89.9 },     // B
+        { 108.1, -54.6 },     // M
+    };
 }
 
 class THIS_TEST_CASE : public CPPUNIT_NS::TestFixture
@@ -23,6 +53,12 @@ class THIS_TEST_CASE : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST( WindingInvarianceTest );
     CPPUNIT_TEST( UvPlaneTest );
     CPPUNIT_TEST( xyToUvTest );
+    CPPUNIT_TEST( AbHexagonSelfCoverageTest );
+    CPPUNIT_TEST( AbHexagonBaselineTest );
+    CPPUNIT_TEST( AbHexagonLuminanceLossTest );
+    CPPUNIT_TEST( AbHexagonWindingInvarianceTest );
+    CPPUNIT_TEST( AbHexagonNonConvexInputTest );
+    CPPUNIT_TEST( AbHexagonDegenerateTest );
     CPPUNIT_TEST_SUITE_END();
 
 protected:
@@ -95,6 +131,83 @@ protected:
         xyToUv(0.3127, 0.3290, u, v);
         CPPUNIT_ASSERT_DOUBLES_EQUAL( 0.1978, u, 5e-5 );
         CPPUNIT_ASSERT_DOUBLES_EQUAL( 0.4683, v, 5e-5 );
+    }
+
+    // --- a*b* hexagon path (GamutCoveragePolygon) ---
+
+    void AbHexagonSelfCoverageTest()
+    {
+        // a hexagon covers itself exactly
+        std::vector<GamutPoint> target(targetAbRec2020, targetAbRec2020 + 6);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL( 1.0, GamutCoveragePolygon(target, target), 1e-9 );
+    }
+
+    void AbHexagonBaselineTest()
+    {
+        // Real measured-display-vs-Rec.2020 a*b* hexagon: cross-checked
+        // against an independent Python/NumPy Lab pipeline, ~92-93% (the
+        // convex-hull-based area here can differ by ~1pt from a strict
+        // hue-ordered-polygon area if the hexagon isn't perfectly convex --
+        // this is a coarse sanity range, not a bit-exact regression check).
+        std::vector<GamutPoint> meas(measuredAbBaseline, measuredAbBaseline + 6);
+        std::vector<GamutPoint> target(targetAbRec2020, targetAbRec2020 + 6);
+        double cov = GamutCoveragePolygon(meas, target);
+        CPPUNIT_ASSERT( cov > 0.88 && cov < 0.95 );
+    }
+
+    void AbHexagonLuminanceLossTest()
+    {
+        // The whole point of this metric: cutting every channel's luminance
+        // (xy chromaticity held fixed) collapses a*b* coverage hard, where
+        // the xy/u'v' triangle metric wouldn't move at all for the same
+        // input. Matches the independent Python validation almost exactly.
+        std::vector<GamutPoint> measDimmed(measuredAbAllChannelsDimmed, measuredAbAllChannelsDimmed + 6);
+        std::vector<GamutPoint> target(targetAbRec2020, targetAbRec2020 + 6);
+        double cov = GamutCoveragePolygon(measDimmed, target);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL( 0.591, cov, 0.01 );
+    }
+
+    void AbHexagonWindingInvarianceTest()
+    {
+        // vertex order must not matter, same as the triangle path
+        std::vector<GamutPoint> meas(measuredAbBaseline, measuredAbBaseline + 6);
+        std::vector<GamutPoint> target(targetAbRec2020, targetAbRec2020 + 6);
+        std::vector<GamutPoint> reversed(meas.rbegin(), meas.rend());
+        CPPUNIT_ASSERT_DOUBLES_EQUAL( GamutCoveragePolygon(meas, target),
+                                      GamutCoveragePolygon(reversed, target), 1e-9 );
+    }
+
+    void AbHexagonNonConvexInputTest()
+    {
+        // An undersaturated secondary sitting inside the chord between its
+        // two neighbors (i.e. the raw hue-ordered hexagon is NOT convex on
+        // its own) must not crash or silently misbehave -- this is exactly
+        // why GamutCoveragePolygon takes a convex hull internally rather
+        // than assuming its input already is one.
+        GamutPoint nonConvex[6] = {
+            { 100.0,   0.0 },   // R
+            {  20.0,  60.0 },   // Y
+            { -80.0, 100.0 },   // G
+            { -10.0,  10.0 },   // C -- pulled in, inside the G-B chord
+            { -80.0,-100.0 },   // B
+            {  20.0, -60.0 },   // M
+        };
+        std::vector<GamutPoint> meas(nonConvex, nonConvex + 6);
+        std::vector<GamutPoint> target(targetAbRec2020, targetAbRec2020 + 6);
+        double cov = GamutCoveragePolygon(meas, target);
+        CPPUNIT_ASSERT( cov >= 0.0 );  // no crash, no negative/garbage result
+    }
+
+    void AbHexagonDegenerateTest()
+    {
+        // collinear measured hexagon -> zero coverage, no crash
+        GamutPoint line[6] = {
+            { 0.0, 0.0 }, { 1.0, 1.0 }, { 2.0, 2.0 },
+            { 3.0, 3.0 }, { 4.0, 4.0 }, { 5.0, 5.0 },
+        };
+        std::vector<GamutPoint> meas(line, line + 6);
+        std::vector<GamutPoint> target(targetAbRec2020, targetAbRec2020 + 6);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL( 0.0, GamutCoveragePolygon(meas, target), 1e-12 );
     }
 };
 

--- a/Views/CIEChartView.cpp
+++ b/Views/CIEChartView.cpp
@@ -725,19 +725,33 @@ void CCIEChartGrapher::DrawAlphaBitmap(CDC *pDC, const CCIEGraphPoint& aGraphPoi
 
 }
 
-// Gamut coverage chips (top right): [gamut] [xy: n%] [u'v': n%]. The
-// gamut-name chip always shows; the coverage percentages are the measured
-// primaries triangle vs the displayed reference triangle (area intersection
-// / reference area) in xy and u'v'. Not shown in CIE a*b* mode (the metric
-// is a chromaticity-plane one). The percentages hide when the gamut is
-// changed until the primaries are re-measured, since old primaries don't
-// belong to the new reference.
+// Gamut coverage chips (top right): [gamut] [xy: n%] [u'v': n%] in the xy/
+// u'v' views, or [gamut] [a*b*: n%] in the CIE a*b* view. The gamut-name
+// chip always shows.
+//
+// xy/u'v': the measured R,G,B primaries triangle vs the displayed reference
+// triangle (area intersection / reference area) -- a pure chromaticity-plane
+// metric, blind to luminance by construction (see GamutCoverage.h).
+//
+// a*b*: NOT the same metric re-plotted. A 3-point R,G,B triangle would
+// dilute a single bad channel's effect across only three vertices, and
+// would stay completely unmoved by a pure luminance shortfall in a
+// secondary (Y/C/M) -- the exact blind spot this chip exists to close. So
+// this path uses all six of R,Y,G,C,B,M as an a*b* hexagon instead
+// (GamutCoveragePolygon in GamutCoverage.h/.cpp). Because a* and b* both
+// carry the f(Y/Yn) term from the Lab formulas, a channel that loses
+// luminance at an unchanged xy chromaticity visibly compresses toward the
+// neutral point on this hexagon -- which is the point of computing it this
+// way rather than mirroring the triangle metric into this plane.
+//
+// The percentages hide when the gamut is changed until the primaries are
+// re-measured, since old primaries don't belong to the new reference.
 // The row anchors to rcAnchor's top-right: the client rect when overlaid on
 // screen paints (OnDraw calls this after every blit so the chips stay pinned
 // under zoom/pan), the image rect when baked into exports.
 void CCIEChartGrapher::DrawCoverageChips ( CDC * pDC, CRect rcAnchor, CDataSetDoc * pDoc )
 {
-	if ( m_bCIEab || min(rcAnchor.Width(),rcAnchor.Height()) <= FX_MINSIZETOSHOW_REFDETAILS )
+	if ( min(rcAnchor.Width(),rcAnchor.Height()) <= FX_MINSIZETOSHOW_REFDETAILS )
 		return;
 
 	ColorXYZ redPrimaryColor=pDoc->GetMeasure()->GetRedPrimary().GetXYZValue();
@@ -745,6 +759,18 @@ void CCIEChartGrapher::DrawCoverageChips ( CDC * pDC, CRect rcAnchor, CDataSetDo
 	ColorXYZ bluePrimaryColor=pDoc->GetMeasure()->GetBluePrimary().GetXYZValue();
 	BOOL hasPrimaries = redPrimaryColor.isValid() && greenPrimaryColor.isValid() &&
 						bluePrimaryColor.isValid();
+
+	// a*b* mode additionally needs the secondaries to build the hexagon.
+	ColorXYZ yellowSecondaryColor, cyanSecondaryColor, magentaSecondaryColor;
+	BOOL hasSecondariesForAb = FALSE;
+	if ( m_bCIEab )
+	{
+		yellowSecondaryColor  = pDoc->GetMeasure()->GetYellowSecondary().GetXYZValue();
+		cyanSecondaryColor    = pDoc->GetMeasure()->GetCyanSecondary().GetXYZValue();
+		magentaSecondaryColor = pDoc->GetMeasure()->GetMagentaSecondary().GetXYZValue();
+		hasSecondariesForAb = yellowSecondaryColor.isValid() && cyanSecondaryColor.isValid() &&
+							  magentaSecondaryColor.isValid();
+	}
 
 	// Short names for the mainstream gamuts; everything else (incl. the
 	// reduced-primary HDTVa/HDTVb pseudo-gamuts) uses its own reference
@@ -761,38 +787,122 @@ void CCIEChartGrapher::DrawCoverageChips ( CDC * pDC, CRect rcAnchor, CDataSetDo
 	}
 
 	// Decide whether the coverage percentages are current. They are stale
-	// (and hidden) if the reference standard changed while the measured
-	// primaries stayed put -- i.e. the gamut was switched without a fresh
-	// measurement. Re-measuring changes the primaries and re-shows them.
+	// (and hidden) only if the reference standard changed *while staying in
+	// the same chart view* with the measured primaries left untouched --
+	// i.e. the gamut was switched without a fresh measurement. Re-measuring
+	// changes the primaries and re-shows them. Switching between the xy/u'v'
+	// view and the a*b* view is NOT staleness -- the same measured data is
+	// always valid for computing either metric, so a mode switch just falls
+	// through to a cheap recompute below rather than hiding anything.
 	ColorStandard curStd = GetColorReference().m_standard;
 	BOOL showPct = FALSE;
-	double covXY = 0.0, covUV = 0.0;
-	if (hasPrimaries)
+	double covXY = 0.0, covUV = 0.0, covAB = 0.0;
+	BOOL haveAllNeeded = m_bCIEab ? (hasPrimaries && hasSecondariesForAb) : hasPrimaries;
+	if (haveAllNeeded)
 	{
 		BOOL primsSame = m_covValid
 			&& redPrimaryColor[0]   == m_covPrimaries[0][0] && redPrimaryColor[1]   == m_covPrimaries[0][1] && redPrimaryColor[2]   == m_covPrimaries[0][2]
 			&& greenPrimaryColor[0] == m_covPrimaries[1][0] && greenPrimaryColor[1] == m_covPrimaries[1][1] && greenPrimaryColor[2] == m_covPrimaries[1][2]
 			&& bluePrimaryColor[0]  == m_covPrimaries[2][0] && bluePrimaryColor[1]  == m_covPrimaries[2][1] && bluePrimaryColor[2]  == m_covPrimaries[2][2];
+		BOOL secsSame = !m_bCIEab || (m_covValid
+			&& yellowSecondaryColor[0]  == m_covSecondaries[0][0] && yellowSecondaryColor[1]  == m_covSecondaries[0][1] && yellowSecondaryColor[2]  == m_covSecondaries[0][2]
+			&& cyanSecondaryColor[0]    == m_covSecondaries[1][0] && cyanSecondaryColor[1]    == m_covSecondaries[1][1] && cyanSecondaryColor[2]    == m_covSecondaries[1][2]
+			&& magentaSecondaryColor[0] == m_covSecondaries[2][0] && magentaSecondaryColor[1] == m_covSecondaries[2][1] && magentaSecondaryColor[2] == m_covSecondaries[2][2]);
+		BOOL modeMatches = m_covValid && (m_covAbMode == m_bCIEab);
 		BOOL stdSame = m_covValid && (m_covStandard == curStd);
 
-		if (m_covValid && !stdSame && primsSame)
+		if (modeMatches && !stdSame && primsSame && secsSame)
 		{
-			showPct = FALSE;	// gamut changed, primaries not re-measured
+			showPct = FALSE;	// same view as last time, gamut standard changed, primaries not re-measured
 		}
 		else
 		{
 			showPct = TRUE;
-			ColorxyY measured[3] = { ColorxyY(redPrimaryColor),
-									 ColorxyY(greenPrimaryColor),
-									 ColorxyY(bluePrimaryColor) };
-			// the triangle drawn on the chart is the active reference's primaries
-			// (for P3/709 inside a 2020 container these are already the inner gamut)
-			ColorxyY refTri[3] = { ColorxyY(GetColorReference().GetRed()),
-								   ColorxyY(GetColorReference().GetGreen()),
-								   ColorxyY(GetColorReference().GetBlue()) };
-			covXY = GamutCoverage(measured, refTri, GAMUT_PLANE_XY) * 100.0;
-			covUV = GamutCoverage(measured, refTri, GAMUT_PLANE_UV) * 100.0;
+
+			if ( m_bCIEab )
+			{
+				// Measured colors are raw sensor XYZ (Y in absolute cd/m^2,
+				// e.g. ~10-170), while CColorReference::GetRed()/GetYellow()/
+				// etc. are explicitly documented as "relative-to-white
+				// luminance... white luminance reference value is 1" -- a
+				// completely different scale. Mixing them under a single
+				// YWhiteRef=1.0 (as an earlier version of this code did)
+				// inflates the measured hexagon's Lab magnitude so much it
+				// swallows the correctly-scaled reference hexagon entirely,
+				// pinning coverage near 100% regardless of actual accuracy.
+				// The fix mirrors the existing, working precedent a few
+				// hundred lines below (the actual plotted marker
+				// construction): measured colors use YWhite (the display's
+				// own measured white luminance), reference colors use 1.0
+				// (matching CColorReference's own convention).
+				double YWhiteAB = 1.0;
+				if ( pDoc->GetMeasure()->GetPrimeWhite().isValid() )
+					YWhiteAB = pDoc->GetMeasure()->GetPrimeWhite()[1];
+				else if ( pDoc->GetMeasure()->GetOnOffWhite().isValid() )
+					YWhiteAB = pDoc->GetMeasure()->GetOnOffWhite()[1];
+				// NOTE: the existing code this mirrors additionally special-
+				// cases HDTVa/HDTVb against a UI mode range (current_mode)
+				// that isn't in scope in this function; that narrow case is
+				// not replicated here.
+
+				// NOTE: this covers the SDR case. DrawChart's own Lab
+				// conversions (see ~line 1273) additionally rescale the
+				// *reference* side for HDR tone-mapped diffuse white when
+				// GetConfig()->m_GammaOffsetType == 5. This chip path is
+				// called from the pinned-overlay repaint (below, and from
+				// OnDraw) independently of that pass, so it doesn't have
+				// tmWhite/current_mode in scope the way DrawChart does.
+				// If HDR a*b* coverage looks off, mirror that normalization
+				// in here too -- untested against an HDR project in this
+				// pass.
+				CColorReference bRefAb = ((GetColorReference().m_standard == UHDTV3 || GetColorReference().m_standard == UHDTV4) ? CColorReference(UHDTV2) :
+										   (GetColorReference().m_standard == HDTVa || GetColorReference().m_standard == HDTVb) ? CColorReference(HDTV) : GetColorReference());
+
+				ColorLab measLab[6] = {
+					ColorLab(ColorXYZ(redPrimaryColor),      YWhiteAB, bRefAb),
+					ColorLab(ColorXYZ(yellowSecondaryColor), YWhiteAB, bRefAb),
+					ColorLab(ColorXYZ(greenPrimaryColor),    YWhiteAB, bRefAb),
+					ColorLab(ColorXYZ(cyanSecondaryColor),   YWhiteAB, bRefAb),
+					ColorLab(ColorXYZ(bluePrimaryColor),     YWhiteAB, bRefAb),
+					ColorLab(ColorXYZ(magentaSecondaryColor),YWhiteAB, bRefAb),
+				};
+				ColorLab refLab[6] = {
+					ColorLab(ColorXYZ(GetColorReference().GetRed()),     1.0, bRefAb),
+					ColorLab(ColorXYZ(GetColorReference().GetYellow()),  1.0, bRefAb),
+					ColorLab(ColorXYZ(GetColorReference().GetGreen()),   1.0, bRefAb),
+					ColorLab(ColorXYZ(GetColorReference().GetCyan()),    1.0, bRefAb),
+					ColorLab(ColorXYZ(GetColorReference().GetBlue()),    1.0, bRefAb),
+					ColorLab(ColorXYZ(GetColorReference().GetMagenta()), 1.0, bRefAb),
+				};
+
+				std::vector<GamutPoint> measHex(6), refHex(6);
+				for (int i = 0; i < 6; i++)
+				{
+					measHex[i] = GamutPoint{ measLab[i][1], measLab[i][2] };	// a*, b*
+					refHex[i]  = GamutPoint{ refLab[i][1],  refLab[i][2]  };
+				}
+				covAB = GamutCoveragePolygon(measHex, refHex) * 100.0;
+
+				m_covSecondaries[0] = yellowSecondaryColor;
+				m_covSecondaries[1] = cyanSecondaryColor;
+				m_covSecondaries[2] = magentaSecondaryColor;
+			}
+			else
+			{
+				ColorxyY measured[3] = { ColorxyY(redPrimaryColor),
+										 ColorxyY(greenPrimaryColor),
+										 ColorxyY(bluePrimaryColor) };
+				// the triangle drawn on the chart is the active reference's primaries
+				// (for P3/709 inside a 2020 container these are already the inner gamut)
+				ColorxyY refTri[3] = { ColorxyY(GetColorReference().GetRed()),
+									   ColorxyY(GetColorReference().GetGreen()),
+									   ColorxyY(GetColorReference().GetBlue()) };
+				covXY = GamutCoverage(measured, refTri, GAMUT_PLANE_XY) * 100.0;
+				covUV = GamutCoverage(measured, refTri, GAMUT_PLANE_UV) * 100.0;
+			}
+
 			m_covStandard = curStd;
+			m_covAbMode = m_bCIEab;
 			m_covPrimaries[0] = redPrimaryColor;
 			m_covPrimaries[1] = greenPrimaryColor;
 			m_covPrimaries[2] = bluePrimaryColor;
@@ -815,19 +925,27 @@ void CCIEChartGrapher::DrawCoverageChips ( CDC * pDC, CRect rcAnchor, CDataSetDo
 	Gdiplus::Color nBorder = bDark ? Gdiplus::Color(255, 72, 72, 72)    : Gdiplus::Color(255, 205, 207, 213);
 	Gdiplus::Color nText   = bDark ? Gdiplus::Color(255, 215, 215, 215) : Gdiplus::Color(255, 70, 74, 80);
 
-	// Visual order left-to-right is [gamut] [xy] [u'v']; priority is the
-	// reverse, so if the row can't fit the chart width drop u'v' first,
-	// then xy, always keeping the gamut name.
-	WCHAR uvBuf[64], xyBuf[64];
+	// Visual order left-to-right is [gamut] [xy] [u'v'] (or [gamut] [a*b*]
+	// in a*b* mode); priority is the reverse, so if the row can't fit the
+	// chart width drop u'v' first, then xy, always keeping the gamut name.
+	WCHAR uvBuf[64], xyBuf[64], abBuf[64];
 	const WCHAR * ordered[3];
 	int nChips = 0;
 	ordered[nChips++] = gamutName;
 	if (showPct)
 	{
-		swprintf_s(xyBuf, 64, L"xy: %.1f%%", covXY);
-		swprintf_s(uvBuf, 64, L"u'v': %.1f%%", covUV);
-		ordered[nChips++] = xyBuf;
-		ordered[nChips++] = uvBuf;
+		if ( m_bCIEab )
+		{
+			swprintf_s(abBuf, 64, L"a*b*: %.1f%%", covAB);
+			ordered[nChips++] = abBuf;
+		}
+		else
+		{
+			swprintf_s(xyBuf, 64, L"xy: %.1f%%", covXY);
+			swprintf_s(uvBuf, 64, L"u'v': %.1f%%", covUV);
+			ordered[nChips++] = xyBuf;
+			ordered[nChips++] = uvBuf;
+		}
 	}
 
 	const Gdiplus::REAL pad = 8.0f, gap = 6.0f;

--- a/Views/CIEChartView.cpp
+++ b/Views/CIEChartView.cpp
@@ -725,9 +725,8 @@ void CCIEChartGrapher::DrawAlphaBitmap(CDC *pDC, const CCIEGraphPoint& aGraphPoi
 
 }
 
-// Gamut coverage chips (top right): [gamut] [xy: n%] [u'v': n%] in the xy/
-// u'v' views, or [gamut] [a*b*: n%] in the CIE a*b* view. The gamut-name
-// chip always shows.
+// Gamut coverage chips (top right): [gamut] [xy: n%] [u'v': n%] [a*b*: n%],
+// all shown together in every chart view. The gamut-name chip always shows.
 //
 // xy/u'v': the measured R,G,B primaries triangle vs the displayed reference
 // triangle (area intersection / reference area) -- a pure chromaticity-plane
@@ -744,8 +743,20 @@ void CCIEChartGrapher::DrawAlphaBitmap(CDC *pDC, const CCIEGraphPoint& aGraphPoi
 // neutral point on this hexagon -- which is the point of computing it this
 // way rather than mirroring the triangle metric into this plane.
 //
-// The percentages hide when the gamut is changed until the primaries are
-// re-measured, since old primaries don't belong to the new reference.
+// Showing all three together (rather than switching which ones appear
+// based on the active view) is deliberate: they answer different
+// questions, and comparing them is often the useful part -- e.g. xy and
+// u'v' both reading 100% while a*b* reads 99.8% on the same measurement
+// says the primaries are chromaticity-perfect but a secondary has a small
+// residual luminance-driven chroma pull, a distinction neither metric
+// shown alone would reveal.
+//
+// The percentages hide when the gamut is changed until the relevant
+// measured data is re-measured, since old measurements don't belong to the
+// new reference -- matching the original xy/u'v' chip design. xy/u'v' only
+// need the primaries to have been re-measured; a*b* additionally needs the
+// secondaries, since it uses both -- so it's possible for one to show while
+// the other is still hidden if only some patches have been re-measured.
 // The row anchors to rcAnchor's top-right: the client rect when overlaid on
 // screen paints (OnDraw calls this after every blit so the chips stay pinned
 // under zoom/pan), the image rect when baked into exports.
@@ -760,17 +771,14 @@ void CCIEChartGrapher::DrawCoverageChips ( CDC * pDC, CRect rcAnchor, CDataSetDo
 	BOOL hasPrimaries = redPrimaryColor.isValid() && greenPrimaryColor.isValid() &&
 						bluePrimaryColor.isValid();
 
-	// a*b* mode additionally needs the secondaries to build the hexagon.
-	ColorXYZ yellowSecondaryColor, cyanSecondaryColor, magentaSecondaryColor;
-	BOOL hasSecondariesForAb = FALSE;
-	if ( m_bCIEab )
-	{
-		yellowSecondaryColor  = pDoc->GetMeasure()->GetYellowSecondary().GetXYZValue();
-		cyanSecondaryColor    = pDoc->GetMeasure()->GetCyanSecondary().GetXYZValue();
-		magentaSecondaryColor = pDoc->GetMeasure()->GetMagentaSecondary().GetXYZValue();
-		hasSecondariesForAb = yellowSecondaryColor.isValid() && cyanSecondaryColor.isValid() &&
-							  magentaSecondaryColor.isValid();
-	}
+	// a*b* additionally needs the secondaries to build the hexagon. Fetched
+	// unconditionally (not just in a*b* mode) since all three metrics are
+	// shown together regardless of which chart view is active.
+	ColorXYZ yellowSecondaryColor  = pDoc->GetMeasure()->GetYellowSecondary().GetXYZValue();
+	ColorXYZ cyanSecondaryColor    = pDoc->GetMeasure()->GetCyanSecondary().GetXYZValue();
+	ColorXYZ magentaSecondaryColor = pDoc->GetMeasure()->GetMagentaSecondary().GetXYZValue();
+	BOOL hasSecondariesForAb = yellowSecondaryColor.isValid() && cyanSecondaryColor.isValid() &&
+							   magentaSecondaryColor.isValid();
 
 	// Short names for the mainstream gamuts; everything else (incl. the
 	// reduced-primary HDTVa/HDTVb pseudo-gamuts) uses its own reference
@@ -786,128 +794,126 @@ void CCIEChartGrapher::DrawCoverageChips ( CDC * pDC, CRect rcAnchor, CDataSetDo
 			break;
 	}
 
-	// Decide whether the coverage percentages are current. They are stale
-	// (and hidden) only if the reference standard changed *while staying in
-	// the same chart view* with the measured primaries left untouched --
-	// i.e. the gamut was switched without a fresh measurement. Re-measuring
-	// changes the primaries and re-shows them. Switching between the xy/u'v'
-	// view and the a*b* view is NOT staleness -- the same measured data is
-	// always valid for computing either metric, so a mode switch just falls
-	// through to a cheap recompute below rather than hiding anything.
+	// Each metric's percentage is independently stale (and hidden) if the
+	// reference standard changed since it was last computed without the
+	// relevant measurement being re-taken in between. xy/u'v' only depend
+	// on the primaries; a*b* additionally depends on the secondaries.
 	ColorStandard curStd = GetColorReference().m_standard;
-	BOOL showPct = FALSE;
+	BOOL stdSame = m_covValid && (m_covStandard == curStd);
+	BOOL primsSame = m_covValid
+		&& redPrimaryColor[0]   == m_covPrimaries[0][0] && redPrimaryColor[1]   == m_covPrimaries[0][1] && redPrimaryColor[2]   == m_covPrimaries[0][2]
+		&& greenPrimaryColor[0] == m_covPrimaries[1][0] && greenPrimaryColor[1] == m_covPrimaries[1][1] && greenPrimaryColor[2] == m_covPrimaries[1][2]
+		&& bluePrimaryColor[0]  == m_covPrimaries[2][0] && bluePrimaryColor[1]  == m_covPrimaries[2][1] && bluePrimaryColor[2]  == m_covPrimaries[2][2];
+	BOOL secsSame = m_covValid
+		&& yellowSecondaryColor[0]  == m_covSecondaries[0][0] && yellowSecondaryColor[1]  == m_covSecondaries[0][1] && yellowSecondaryColor[2]  == m_covSecondaries[0][2]
+		&& cyanSecondaryColor[0]    == m_covSecondaries[1][0] && cyanSecondaryColor[1]    == m_covSecondaries[1][1] && cyanSecondaryColor[2]    == m_covSecondaries[1][2]
+		&& magentaSecondaryColor[0] == m_covSecondaries[2][0] && magentaSecondaryColor[1] == m_covSecondaries[2][1] && magentaSecondaryColor[2] == m_covSecondaries[2][2];
+
+	BOOL xyuvStale = m_covValid && !stdSame && primsSame;
+	BOOL abStale   = m_covValid && !stdSame && primsSame && secsSame;
+
+	BOOL showXYUV = hasPrimaries && !xyuvStale;
+	BOOL showAB   = hasPrimaries && hasSecondariesForAb && !abStale;
 	double covXY = 0.0, covUV = 0.0, covAB = 0.0;
-	BOOL haveAllNeeded = m_bCIEab ? (hasPrimaries && hasSecondariesForAb) : hasPrimaries;
-	if (haveAllNeeded)
+
+	if (showXYUV)
 	{
-		BOOL primsSame = m_covValid
-			&& redPrimaryColor[0]   == m_covPrimaries[0][0] && redPrimaryColor[1]   == m_covPrimaries[0][1] && redPrimaryColor[2]   == m_covPrimaries[0][2]
-			&& greenPrimaryColor[0] == m_covPrimaries[1][0] && greenPrimaryColor[1] == m_covPrimaries[1][1] && greenPrimaryColor[2] == m_covPrimaries[1][2]
-			&& bluePrimaryColor[0]  == m_covPrimaries[2][0] && bluePrimaryColor[1]  == m_covPrimaries[2][1] && bluePrimaryColor[2]  == m_covPrimaries[2][2];
-		BOOL secsSame = !m_bCIEab || (m_covValid
-			&& yellowSecondaryColor[0]  == m_covSecondaries[0][0] && yellowSecondaryColor[1]  == m_covSecondaries[0][1] && yellowSecondaryColor[2]  == m_covSecondaries[0][2]
-			&& cyanSecondaryColor[0]    == m_covSecondaries[1][0] && cyanSecondaryColor[1]    == m_covSecondaries[1][1] && cyanSecondaryColor[2]    == m_covSecondaries[1][2]
-			&& magentaSecondaryColor[0] == m_covSecondaries[2][0] && magentaSecondaryColor[1] == m_covSecondaries[2][1] && magentaSecondaryColor[2] == m_covSecondaries[2][2]);
-		BOOL modeMatches = m_covValid && (m_covAbMode == m_bCIEab);
-		BOOL stdSame = m_covValid && (m_covStandard == curStd);
+		ColorxyY measured[3] = { ColorxyY(redPrimaryColor),
+								 ColorxyY(greenPrimaryColor),
+								 ColorxyY(bluePrimaryColor) };
+		// the triangle drawn on the chart is the active reference's primaries
+		// (for P3/709 inside a 2020 container these are already the inner gamut)
+		ColorxyY refTri[3] = { ColorxyY(GetColorReference().GetRed()),
+							   ColorxyY(GetColorReference().GetGreen()),
+							   ColorxyY(GetColorReference().GetBlue()) };
+		covXY = GamutCoverage(measured, refTri, GAMUT_PLANE_XY) * 100.0;
+		covUV = GamutCoverage(measured, refTri, GAMUT_PLANE_UV) * 100.0;
+	}
 
-		if (modeMatches && !stdSame && primsSame && secsSame)
+	if (showAB)
+	{
+		// Measured colors are raw sensor XYZ (Y in absolute cd/m^2,
+		// e.g. ~10-170), while CColorReference::GetRed()/GetYellow()/
+		// etc. are explicitly documented as "relative-to-white
+		// luminance... white luminance reference value is 1" -- a
+		// completely different scale. Mixing them under a single
+		// YWhiteRef=1.0 (as an earlier version of this code did)
+		// inflates the measured hexagon's Lab magnitude so much it
+		// swallows the correctly-scaled reference hexagon entirely,
+		// pinning coverage near 100% regardless of actual accuracy.
+		// The fix mirrors the existing, working precedent a few
+		// hundred lines below (the actual plotted marker
+		// construction): measured colors use YWhite (the display's
+		// own measured white luminance), reference colors use 1.0
+		// (matching CColorReference's own convention).
+		double YWhiteAB = 1.0;
+		if ( pDoc->GetMeasure()->GetPrimeWhite().isValid() )
+			YWhiteAB = pDoc->GetMeasure()->GetPrimeWhite()[1];
+		else if ( pDoc->GetMeasure()->GetOnOffWhite().isValid() )
+			YWhiteAB = pDoc->GetMeasure()->GetOnOffWhite()[1];
+		// NOTE: the existing code this mirrors additionally special-
+		// cases HDTVa/HDTVb against a UI mode range (current_mode)
+		// that isn't in scope in this function; that narrow case is
+		// not replicated here.
+
+		// NOTE: this covers the SDR case. DrawChart's own Lab
+		// conversions (see ~line 1273) additionally rescale the
+		// *reference* side for HDR tone-mapped diffuse white when
+		// GetConfig()->m_GammaOffsetType == 5. This chip path is
+		// called from the pinned-overlay repaint (below, and from
+		// OnDraw) independently of that pass, so it doesn't have
+		// tmWhite/current_mode in scope the way DrawChart does.
+		// If HDR a*b* coverage looks off, mirror that normalization
+		// in here too -- untested against an HDR project in this
+		// pass.
+		CColorReference bRefAb = ((GetColorReference().m_standard == UHDTV3 || GetColorReference().m_standard == UHDTV4) ? CColorReference(UHDTV2) :
+								   (GetColorReference().m_standard == HDTVa || GetColorReference().m_standard == HDTVb) ? CColorReference(HDTV) : GetColorReference());
+
+		ColorLab measLab[6] = {
+			ColorLab(ColorXYZ(redPrimaryColor),      YWhiteAB, bRefAb),
+			ColorLab(ColorXYZ(yellowSecondaryColor), YWhiteAB, bRefAb),
+			ColorLab(ColorXYZ(greenPrimaryColor),    YWhiteAB, bRefAb),
+			ColorLab(ColorXYZ(cyanSecondaryColor),   YWhiteAB, bRefAb),
+			ColorLab(ColorXYZ(bluePrimaryColor),     YWhiteAB, bRefAb),
+			ColorLab(ColorXYZ(magentaSecondaryColor),YWhiteAB, bRefAb),
+		};
+		ColorLab refLab[6] = {
+			ColorLab(ColorXYZ(GetColorReference().GetRed()),     1.0, bRefAb),
+			ColorLab(ColorXYZ(GetColorReference().GetYellow()),  1.0, bRefAb),
+			ColorLab(ColorXYZ(GetColorReference().GetGreen()),   1.0, bRefAb),
+			ColorLab(ColorXYZ(GetColorReference().GetCyan()),    1.0, bRefAb),
+			ColorLab(ColorXYZ(GetColorReference().GetBlue()),    1.0, bRefAb),
+			ColorLab(ColorXYZ(GetColorReference().GetMagenta()), 1.0, bRefAb),
+		};
+
+		std::vector<GamutPoint> measHex(6), refHex(6);
+		for (int i = 0; i < 6; i++)
 		{
-			showPct = FALSE;	// same view as last time, gamut standard changed, primaries not re-measured
+			measHex[i] = GamutPoint{ measLab[i][1], measLab[i][2] };	// a*, b*
+			refHex[i]  = GamutPoint{ refLab[i][1],  refLab[i][2]  };
 		}
-		else
-		{
-			showPct = TRUE;
+		covAB = GamutCoveragePolygon(measHex, refHex) * 100.0;
+	}
 
-			if ( m_bCIEab )
-			{
-				// Measured colors are raw sensor XYZ (Y in absolute cd/m^2,
-				// e.g. ~10-170), while CColorReference::GetRed()/GetYellow()/
-				// etc. are explicitly documented as "relative-to-white
-				// luminance... white luminance reference value is 1" -- a
-				// completely different scale. Mixing them under a single
-				// YWhiteRef=1.0 (as an earlier version of this code did)
-				// inflates the measured hexagon's Lab magnitude so much it
-				// swallows the correctly-scaled reference hexagon entirely,
-				// pinning coverage near 100% regardless of actual accuracy.
-				// The fix mirrors the existing, working precedent a few
-				// hundred lines below (the actual plotted marker
-				// construction): measured colors use YWhite (the display's
-				// own measured white luminance), reference colors use 1.0
-				// (matching CColorReference's own convention).
-				double YWhiteAB = 1.0;
-				if ( pDoc->GetMeasure()->GetPrimeWhite().isValid() )
-					YWhiteAB = pDoc->GetMeasure()->GetPrimeWhite()[1];
-				else if ( pDoc->GetMeasure()->GetOnOffWhite().isValid() )
-					YWhiteAB = pDoc->GetMeasure()->GetOnOffWhite()[1];
-				// NOTE: the existing code this mirrors additionally special-
-				// cases HDTVa/HDTVb against a UI mode range (current_mode)
-				// that isn't in scope in this function; that narrow case is
-				// not replicated here.
-
-				// NOTE: this covers the SDR case. DrawChart's own Lab
-				// conversions (see ~line 1273) additionally rescale the
-				// *reference* side for HDR tone-mapped diffuse white when
-				// GetConfig()->m_GammaOffsetType == 5. This chip path is
-				// called from the pinned-overlay repaint (below, and from
-				// OnDraw) independently of that pass, so it doesn't have
-				// tmWhite/current_mode in scope the way DrawChart does.
-				// If HDR a*b* coverage looks off, mirror that normalization
-				// in here too -- untested against an HDR project in this
-				// pass.
-				CColorReference bRefAb = ((GetColorReference().m_standard == UHDTV3 || GetColorReference().m_standard == UHDTV4) ? CColorReference(UHDTV2) :
-										   (GetColorReference().m_standard == HDTVa || GetColorReference().m_standard == HDTVb) ? CColorReference(HDTV) : GetColorReference());
-
-				ColorLab measLab[6] = {
-					ColorLab(ColorXYZ(redPrimaryColor),      YWhiteAB, bRefAb),
-					ColorLab(ColorXYZ(yellowSecondaryColor), YWhiteAB, bRefAb),
-					ColorLab(ColorXYZ(greenPrimaryColor),    YWhiteAB, bRefAb),
-					ColorLab(ColorXYZ(cyanSecondaryColor),   YWhiteAB, bRefAb),
-					ColorLab(ColorXYZ(bluePrimaryColor),     YWhiteAB, bRefAb),
-					ColorLab(ColorXYZ(magentaSecondaryColor),YWhiteAB, bRefAb),
-				};
-				ColorLab refLab[6] = {
-					ColorLab(ColorXYZ(GetColorReference().GetRed()),     1.0, bRefAb),
-					ColorLab(ColorXYZ(GetColorReference().GetYellow()),  1.0, bRefAb),
-					ColorLab(ColorXYZ(GetColorReference().GetGreen()),   1.0, bRefAb),
-					ColorLab(ColorXYZ(GetColorReference().GetCyan()),    1.0, bRefAb),
-					ColorLab(ColorXYZ(GetColorReference().GetBlue()),    1.0, bRefAb),
-					ColorLab(ColorXYZ(GetColorReference().GetMagenta()), 1.0, bRefAb),
-				};
-
-				std::vector<GamutPoint> measHex(6), refHex(6);
-				for (int i = 0; i < 6; i++)
-				{
-					measHex[i] = GamutPoint{ measLab[i][1], measLab[i][2] };	// a*, b*
-					refHex[i]  = GamutPoint{ refLab[i][1],  refLab[i][2]  };
-				}
-				covAB = GamutCoveragePolygon(measHex, refHex) * 100.0;
-
-				m_covSecondaries[0] = yellowSecondaryColor;
-				m_covSecondaries[1] = cyanSecondaryColor;
-				m_covSecondaries[2] = magentaSecondaryColor;
-			}
-			else
-			{
-				ColorxyY measured[3] = { ColorxyY(redPrimaryColor),
-										 ColorxyY(greenPrimaryColor),
-										 ColorxyY(bluePrimaryColor) };
-				// the triangle drawn on the chart is the active reference's primaries
-				// (for P3/709 inside a 2020 container these are already the inner gamut)
-				ColorxyY refTri[3] = { ColorxyY(GetColorReference().GetRed()),
-									   ColorxyY(GetColorReference().GetGreen()),
-									   ColorxyY(GetColorReference().GetBlue()) };
-				covXY = GamutCoverage(measured, refTri, GAMUT_PLANE_XY) * 100.0;
-				covUV = GamutCoverage(measured, refTri, GAMUT_PLANE_UV) * 100.0;
-			}
-
-			m_covStandard = curStd;
-			m_covAbMode = m_bCIEab;
-			m_covPrimaries[0] = redPrimaryColor;
-			m_covPrimaries[1] = greenPrimaryColor;
-			m_covPrimaries[2] = bluePrimaryColor;
-			m_covValid = TRUE;
-		}
+	// Refresh the cache whenever we're not actively withholding a value due
+	// to staleness -- i.e. whenever a fresh measurement just arrived
+	// (primsSame false) or nothing has changed at all (stdSame true).
+	// Skipping this specifically while xyuvStale is true is what makes the
+	// hidden state actually persist across repaints rather than being
+	// overwritten by the very next paint call -- updating unconditionally
+	// here would silently absorb the new standard into the cache and make
+	// the percentages reappear one frame after being hidden, which isn't
+	// the intended behavior.
+	if (hasPrimaries && hasSecondariesForAb && !xyuvStale)
+	{
+		m_covStandard = curStd;
+		m_covPrimaries[0] = redPrimaryColor;
+		m_covPrimaries[1] = greenPrimaryColor;
+		m_covPrimaries[2] = bluePrimaryColor;
+		m_covSecondaries[0] = yellowSecondaryColor;
+		m_covSecondaries[1] = cyanSecondaryColor;
+		m_covSecondaries[2] = magentaSecondaryColor;
+		m_covValid = TRUE;
 	}
 
 	// Pill stat chips like the target widget's, anchored top right,
@@ -925,27 +931,25 @@ void CCIEChartGrapher::DrawCoverageChips ( CDC * pDC, CRect rcAnchor, CDataSetDo
 	Gdiplus::Color nBorder = bDark ? Gdiplus::Color(255, 72, 72, 72)    : Gdiplus::Color(255, 205, 207, 213);
 	Gdiplus::Color nText   = bDark ? Gdiplus::Color(255, 215, 215, 215) : Gdiplus::Color(255, 70, 74, 80);
 
-	// Visual order left-to-right is [gamut] [xy] [u'v'] (or [gamut] [a*b*]
-	// in a*b* mode); priority is the reverse, so if the row can't fit the
-	// chart width drop u'v' first, then xy, always keeping the gamut name.
+	// Visual order left-to-right is [gamut] [xy] [u'v'] [a*b*], shown
+	// together in every chart view. Priority is the reverse, for narrow-
+	// window fallback: if the row can't fit the chart width, drop a*b*
+	// first, then u'v', then xy, always keeping the gamut name.
 	WCHAR uvBuf[64], xyBuf[64], abBuf[64];
-	const WCHAR * ordered[3];
+	const WCHAR * ordered[4];
 	int nChips = 0;
 	ordered[nChips++] = gamutName;
-	if (showPct)
+	if (showXYUV)
 	{
-		if ( m_bCIEab )
-		{
-			swprintf_s(abBuf, 64, L"a*b*: %.1f%%", covAB);
-			ordered[nChips++] = abBuf;
-		}
-		else
-		{
-			swprintf_s(xyBuf, 64, L"xy: %.1f%%", covXY);
-			swprintf_s(uvBuf, 64, L"u'v': %.1f%%", covUV);
-			ordered[nChips++] = xyBuf;
-			ordered[nChips++] = uvBuf;
-		}
+		swprintf_s(xyBuf, 64, L"xy: %.1f%%", covXY);
+		swprintf_s(uvBuf, 64, L"u'v': %.1f%%", covUV);
+		ordered[nChips++] = xyBuf;
+		ordered[nChips++] = uvBuf;
+	}
+	if (showAB)
+	{
+		swprintf_s(abBuf, 64, L"a*b*: %.1f%%", covAB);
+		ordered[nChips++] = abBuf;
 	}
 
 	const Gdiplus::REAL pad = 8.0f, gap = 6.0f;

--- a/Views/ciechartview.h
+++ b/Views/ciechartview.h
@@ -148,6 +148,8 @@ class CCIEChartGrapher
 	BOOL			m_covValid;
 	ColorStandard	m_covStandard;
 	ColorXYZ		m_covPrimaries[3];
+	ColorXYZ		m_covSecondaries[3];	// yellow, cyan, magenta -- a*b* path only
+	BOOL			m_covAbMode;			// which metric (xy/u'v' vs a*b*) the cache above is for
 
 	// Zoom handling, for window mode
 	UINT	m_ZoomFactor;	// Zoom factor = 1000 for 1:1 scale, 2000 for 2x zoom, and so on

--- a/Views/ciechartview.h
+++ b/Views/ciechartview.h
@@ -142,14 +142,15 @@ class CCIEChartGrapher
 	double	m_bgWhitex, m_bgWhitey;
 
 	// Gamut-coverage chip staleness tracking: the standard and measured
-	// primaries the last shown coverage % was computed for. When the gamut is
-	// changed but the primaries have not been re-measured, the percentages are
-	// hidden (the gamut-name chip still shows).
+	// primaries/secondaries the last shown coverage % was computed for.
+	// When the gamut is changed but the relevant data has not been
+	// re-measured, the affected percentage(s) are hidden (the gamut-name
+	// chip still shows) -- xy/u'v' only depend on the primaries, a*b*
+	// additionally depends on the secondaries.
 	BOOL			m_covValid;
 	ColorStandard	m_covStandard;
 	ColorXYZ		m_covPrimaries[3];
 	ColorXYZ		m_covSecondaries[3];	// yellow, cyan, magenta -- a*b* path only
-	BOOL			m_covAbMode;			// which metric (xy/u'v' vs a*b*) the cache above is for
 
 	// Zoom handling, for window mode
 	UINT	m_ZoomFactor;	// Zoom factor = 1000 for 1:1 scale, 2000 for 2x zoom, and so on

--- a/libHCFR/GamutCoverage.cpp
+++ b/libHCFR/GamutCoverage.cpp
@@ -6,6 +6,7 @@
 
 #include <math.h>
 #include <vector>
+#include <algorithm>
 
 void xyToUv(double x, double y, double & u, double & v)
 {
@@ -59,13 +60,15 @@ namespace
     }
 
     // Sutherland-Hodgman: clip a polygon against a convex, CCW-wound clip
-    // triangle.
-    std::vector<Pt> clipPolygon(std::vector<Pt> poly, const Pt clip[3])
+    // polygon of any vertex count (a triangle for the xy/u'v' path, a hull
+    // of arbitrary size for the a*b* path).
+    std::vector<Pt> clipPolygon(std::vector<Pt> poly, const std::vector<Pt> & clip)
     {
-        for (int e = 0; e < 3 && !poly.empty(); e++)
+        size_t nClip = clip.size();
+        for (size_t e = 0; e < nClip && !poly.empty(); e++)
         {
             const Pt & a = clip[e];
-            const Pt & b = clip[(e + 1) % 3];
+            const Pt & b = clip[(e + 1) % nClip];
             std::vector<Pt> out;
             size_t n = poly.size();
             for (size_t i = 0; i < n; i++)
@@ -98,15 +101,54 @@ namespace
         return p;
     }
 
-    // Ensure counter-clockwise winding.
-    void makeCCW(std::vector<Pt> & tri)
+    // Ensure counter-clockwise winding, for a polygon of any vertex count.
+    void makeCCW(std::vector<Pt> & poly)
     {
-        if (signedArea2(tri) < 0.0)
+        if (signedArea2(poly) < 0.0)
+            std::reverse(poly.begin(), poly.end());
+    }
+
+    bool ptLess(const Pt & a, const Pt & b)
+    {
+        return (a.x < b.x) || (a.x == b.x && a.y < b.y);
+    }
+
+    // Andrew's monotone chain: convex hull of an arbitrary point set, CCW
+    // wound, duplicate/collinear points on an edge dropped. Needed because a
+    // hexagon of real display primaries+secondaries is not guaranteed
+    // convex on its own (e.g. an undersaturated secondary can sit inside the
+    // chord between its two neighbors), and clipPolygon's clip argument must
+    // be a valid convex polygon.
+    std::vector<Pt> convexHull(std::vector<Pt> pts)
+    {
+        size_t n = pts.size();
+        if (n < 3)
+            return std::vector<Pt>();
+
+        std::sort(pts.begin(), pts.end(), ptLess);
+        pts.erase(std::unique(pts.begin(), pts.end(),
+            [](const Pt & a, const Pt & b) { return a.x == b.x && a.y == b.y; }), pts.end());
+        n = pts.size();
+        if (n < 3)
+            return std::vector<Pt>();
+
+        std::vector<Pt> hull(2 * n);
+        int k = 0;
+        for (size_t i = 0; i < n; i++)  // lower chain
         {
-            Pt tmp = tri[1];
-            tri[1] = tri[2];
-            tri[2] = tmp;
+            while (k >= 2 && cross(hull[k-2], hull[k-1], pts[i]) <= 0.0)
+                k--;
+            hull[k++] = pts[i];
         }
+        int lower = k + 1;
+        for (int i = (int)n - 2; i >= 0; i--)  // upper chain
+        {
+            while (k >= lower && cross(hull[k-2], hull[k-1], pts[i]) <= 0.0)
+                k--;
+            hull[k++] = pts[i];
+        }
+        hull.resize(k - 1);  // last point == first point, drop the dup
+        return hull;
     }
 }
 
@@ -128,8 +170,35 @@ double GamutCoverage(const ColorxyY measured[3], const ColorxyY reference[3], Ga
     if (refArea2 <= kAreaEpsilon || fabs(signedArea2(meas)) <= kAreaEpsilon)
         return 0.0;
 
-    Pt clip[3] = { ref[0], ref[1], ref[2] };
-    std::vector<Pt> inter = clipPolygon(meas, clip);
+    std::vector<Pt> inter = clipPolygon(meas, ref);
+    if (inter.size() < 3)
+        return 0.0;
+
+    return fabs(signedArea2(inter)) / refArea2;
+}
+
+double GamutCoveragePolygon(const std::vector<GamutPoint> & measured, const std::vector<GamutPoint> & reference)
+{
+    std::vector<Pt> measPts(measured.size()), refPts(reference.size());
+    for (size_t i = 0; i < measured.size(); i++)
+        measPts[i] = Pt{ measured[i].x, measured[i].y };
+    for (size_t i = 0; i < reference.size(); i++)
+        refPts[i] = Pt{ reference[i].x, reference[i].y };
+
+    std::vector<Pt> measHull = convexHull(measPts);
+    std::vector<Pt> refHull = convexHull(refPts);
+    if (measHull.size() < 3 || refHull.size() < 3)
+        return 0.0;
+
+    makeCCW(measHull);
+    makeCCW(refHull);
+
+    const double kAreaEpsilon = 1e-12;
+    double refArea2 = signedArea2(refHull);
+    if (refArea2 <= kAreaEpsilon || fabs(signedArea2(measHull)) <= kAreaEpsilon)
+        return 0.0;
+
+    std::vector<Pt> inter = clipPolygon(measHull, refHull);
     if (inter.size() < 3)
         return 0.0;
 

--- a/libHCFR/GamutCoverage.h
+++ b/libHCFR/GamutCoverage.h
@@ -12,6 +12,7 @@
 #define GAMUTCOVERAGE_H_INCLUDED
 
 #include "Color.h"
+#include <vector>
 
 enum GamutPlane
 {
@@ -26,5 +27,40 @@ void xyToUv(double x, double y, double & u, double & v);
 // plane.  Both arrays are the R, G, B primaries as xyY (Y is ignored).
 // Returns a value in [0, 1].  Returns 0 if either triangle is degenerate.
 double GamutCoverage(const ColorxyY measured[3], const ColorxyY reference[3], GamutPlane plane);
+
+// A single point in an already-projected 2D plane. Used for planes this
+// module has no business knowing how to compute (e.g. a*b*, whose
+// projection needs a white point and reference standard) -- the caller
+// supplies the coordinates, this module only does the geometry.
+struct GamutPoint
+{
+    double x;
+    double y;
+};
+
+// General coverage metric for the CIE a*b* view: the a*/b* hexagon formed by
+// R,Y,G,C,B,M (in that hue order, or any order -- winding is corrected
+// internally) is far more sensitive to a pure luminance shortfall than the
+// R/G/B-only triangle GamutCoverage() above uses. That's intentional: L*
+// doesn't appear as a plotted axis in this chart, but it still feeds a* and
+// b* through the shared f(Y/Yn) term in the Lab formulas, so a channel that
+// loses luminance at an unchanged xy chromaticity visibly compresses toward
+// the neutral point on this hexagon even though it wouldn't move at all on
+// the xy or u'v' triangle. Whereas a 3-point triangle only has R,G,B to work
+// with, and dilutes a single bad channel's effect across just three
+// vertices, the 6-point hexagon lets each primary/secondary's own chroma
+// loss show up directly, undiluted -- which is the point of using it here.
+//
+// Unlike GamutCoverage() (which assumes its 3-point arrays are already a
+// valid triangle), this takes the convex hull of each input internally --
+// a hexagon of real display secondaries is not guaranteed to be convex
+// (e.g. an undersaturated cyan can sit inside the chord between green and
+// blue), and the clipping algorithm requires a convex clip polygon to be
+// well defined. Point count need not match between measured/reference and
+// need not be pre-sorted.
+//
+// Returns a value in [0, 1]. Returns 0 if either hull collapses to fewer
+// than 3 distinct vertices (degenerate/collinear input).
+double GamutCoveragePolygon(const std::vector<GamutPoint> & measured, const std::vector<GamutPoint> & reference);
 
 #endif // GAMUTCOVERAGE_H_INCLUDED


### PR DESCRIPTION
## Summary

Extends the top-right gamut coverage chip to compute and display all three metrics together — xy, u'v', and a*b* — in every chart view, rather than only showing xy/u'v' (and nothing in the a*b* view, which previously bailed out with no percentage at all).

## Why a*b* specifically

xy and u'v' are pure chromaticity-plane metrics — by construction they cannot see a luminance-only defect (e.g. a display driving a primary at the correct hue/saturation but at reduced brightness, as with BrilliantColor). Real-hardware testing confirmed this directly:

- A luminance-reduction test that dropped average dE from 1.63 to 11.41 barely moved xy (93.0% to 91.5%) or u'v' (92.3% to 91.0%), while a*b* collapsed from 89.7% to 58.4%.
- The same pattern held on a real projector with BrilliantColor toggled on/off: a*b* dropped from 87.4% to 71.6%, tracking a ~2000-patch DisplayCAL characterization of the same unit reasonably well (94.4% to 71.1% there), despite DisplayCAL being the more accurate ground truth in absolute terms (see "Known limitations" below).

## Why show all three together, rather than switching per view

xy and u'v' only cover the R,G,B primaries and are blind to luminance by construction. a*b* additionally folds in the secondaries and responds to luminance loss (see above). Since the three metrics answer genuinely different questions about the same measurement, showing them together — rather than requiring a view switch to compare — is what actually lets you tell them apart in practice. A display could be chromaticity-perfect on xy/u'v' while a*b* reveals a residual issue in a secondary that a primaries-only triangle metric has no way to see, and the only way to notice that is having both numbers visible at once.

## What changed

**`libHCFR/GamutCoverage.h` / `.cpp`**

Generalized the existing triangle-only clipping/winding code to work on polygons of any vertex count, and added `GamutCoveragePolygon()` — takes the convex hull of a measured point set and a reference point set (a real hexagon of primaries+secondaries isn't guaranteed convex on its own) and returns intersection-area / reference-area, same approach as the existing triangle-based `GamutCoverage()`. The existing xy/u'v' path is functionally unchanged.

**`Views/CIEChartView.cpp` / `ciechartview.h`**

`DrawCoverageChips` now computes all three metrics whenever their underlying data is available. The a*b* hexagon uses the existing measured-secondary getters (`GetYellowSecondary()` etc.) and the reference standard's own secondaries. Measured colors use the display's own measured white luminance as their Lab reference white (matching the existing marker-plotting code); `CColorReference`'s own primaries/secondaries are on a documented "white = 1" basis.

Each metric independently hides if the reference standard changed since it was last computed without a fresh measurement in between — matching the original xy/u'v' chip's design exactly. xy/u'v' only need the primaries re-measured; a*b* additionally needs the secondaries, since it uses both.

**`UnitTests/GamutCoverage_unittests.cpp`**

6 new CppUnit tests: self-coverage, baseline range, luminance-loss collapse, winding invariance, non-convex-input safety, degenerate-input safety. All 7 pre-existing tests continue to pass unchanged.

## Known limitations

**Not a DisplayCAL replacement.** a*b* here is a 2D area calculation over 6 points (R, Y, G, C, B, M) using straight chords between them, not a true 3D L*a*b* volume from a full multi-hundred-to-thousand-patch characterization (e.g. DisplayCAL's `iccgamut` / `viewgam`). A real gamut's boundary between adjacent primaries commonly bulges outward past a straight chord, so this metric underestimates area versus a dense characterization — more so on a clean gamut than a badly damaged one. This is a fast proxy from data HCFR already collects during a normal measurement pass.

**HDR not yet tested.** HDR tone-mapped diffuse white additionally rescales the reference side elsewhere in this file for `GetConfig()->m_GammaOffsetType == 5`, using context not available in `DrawCoverageChips`'s call path. The a*b* chip currently uses SDR-case normalization only — flagged in-code, untested against an HDR project.

## Testing

- 6 new unit tests pass; all 7 pre-existing tests continue to pass (19/20 total suite — the one unrelated failure is a hardware-detection test with no meter attached in the build environment).
- Validated against real hardware: simulated luminance-reduction test, a real projector with BrilliantColor on/off cross-checked against a DisplayCAL characterization.