### PR TITLE
Unify the PQ-HDR reference rescale conventions on GetHDRRefScale

### DIFF
--- a/AccuracyTest.cpp
+++ b/AccuracyTest.cpp
@@ -13,9 +13,9 @@
 // error injection off, and the result is compared against the corresponding
 // CMeasure reference (GetRefPrimary/GetRefSecondary/GetRefSat/GetRefCC24Sat
 // or the grayscale EOTF target) using the SAME normalization chain the
-// measures grid uses (CMainView::UpdateGrid + GetItemText: HDR 105.95640 /
-// GetHDRRefScale rescales, tmWhite RefWhite normalization, the
-// YWhite * 94.37844 / tmWhite rescale, per-mode YWhite source).
+// measures grid uses (CMainView::UpdateGrid + GetItemText: the unified HDR
+// GetHDRRefScale reference rescale (= 105.95640 with tone mapping off),
+// tmWhite RefWhite normalization, per-mode YWhite source).
 //
 // A perfectly modeled configuration reads dE ~ 0 for every patch, including
 // patches clipped above m_TargetMaxL in PQ (the reference models the same
@@ -138,8 +138,8 @@ static const GridDef kGrids[] =
 	{ true,  false, "10b-full"},	// 1023
 };
 
-enum Family { FAM_GRAY = 0, FAM_PRIM, FAM_SAT100, FAM_SAT75, FAM_CC_GCD, FAM_CC_AXIS, FAM_COUNT };
-static const char * kFamilyName[FAM_COUNT] = { "gray", "prim", "sat100", "sat75", "ccGCD", "ccAXIS" };
+enum Family { FAM_GRAY = 0, FAM_PRIM, FAM_SAT100, FAM_SAT75, FAM_CC_GCD, FAM_CC_AXIS, FAM_CONV, FAM_COUNT };
+static const char * kFamilyName[FAM_COUNT] = { "gray", "prim", "sat100", "sat75", "ccGCD", "ccAXIS", "convPV" };
 
 struct Combo
 {
@@ -329,6 +329,15 @@ static CColor Meas ( CSimulatedSensor & sensor, const ColorRGBDisplay & rgb, dou
 	return sensor.MeasureColor(p);
 }
 
+// Single source for the pane-side HDR-10 (mode 5) reference rescale the
+// measures grid applies to non-Mascior sat/CC references (UpdateGrid ~4294):
+// the unified CMeasure::GetHDRRefScale() (= 10000 / tone-mapped diffuse
+// white; reduces to the legacy 105.95640 with tone mapping off), the same
+// scale the 3D viewer uses. FAM_CONV below locks that unification: swapping
+// this back to the fixed 105.95640 makes convPV nonzero on the tone-map-ON
+// combos (measured 0.015-0.023 dE at TargetMaxL=300 - small because a
+// common normalizer shift largely cancels inside a dE difference, hence
+// FAM_CONV's dedicated 0.005 tolerance in TolFor).
 // Replicates CMainView::GetItemText's color-mode dE (MainView.cpp
 // ~2985-3047) for the non-grayscale families. displayMode: 1 = primaries,
 // 5..10 = saturation sweeps, 11 = color checker. DVD (manual generator) is
@@ -362,8 +371,9 @@ static double GridColorDE ( const CMeasure & m, const CColor & aMeasure, const C
 				YWhite = m.GetGray(m.GetGrayScaleSize() - 1).GetY();
 			else
 			{
+				// Unified convention (GetItemText sat/CC, non-DVD): reference is
+				// GetHDRRefScale-scaled, measured white stays unrescaled.
 				RefWhite = YWhite / tmWhite;
-				YWhite = YWhite * 94.37844 / tmWhite;
 			}
 		}
 	}
@@ -373,6 +383,73 @@ static double GridColorDE ( const CMeasure & m, const CColor & aMeasure, const C
 
 	return aMeasure.GetDeltaE(YWhite, aReference, RefWhite, bRef, cfg->m_dE_form, false,
 							  cfg->m_GammaOffsetType == 5 ? 3 : cfg->gw_Weight);
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// FAM_CONV: pane-vs-viewer dE convention equality (PQ HDR, mode 5 only).
+//
+// The 3D viewer computes sat/CC dE as
+//   measured.GetDeltaE( tmWhite, ref * GetHDRRefScale(), 1.0, ... , gw = 3 )
+// (Color3DView SceneDiffuseWhiteY + AppendMeasure). The measures grid uses
+// the GridColorDE chain above with the GetHDRRefScale reference rescale.
+// With the ideal sensor a perfect patch reads dE ~ 0 under EITHER convention,
+// so the wire-model families cannot see a convention mismatch. This check
+// perturbs the measured color (fixed asymmetric XYZ gains -> a few dE of
+// luminance + chroma error) and requires both formulas to yield the SAME dE.
+// The ideal sensor's prime white equals TmDiffuseWhiteNits exactly (the
+// 50.22831% wire code and the helper's 0.5022283 snap to the same grid code
+// on all four grids), so matched conventions agree to machine precision;
+// tone mapping ON exposes any 105.95640-vs-GetHDRRefScale divergence.
+//
+// HDTVa/b are excluded: the grid normalizes their sat/CC dE to the measured
+// ON/OFF (peak) white while the viewer always uses the tone-mapped diffuse
+// white - a real, separate legacy divergence outside this check's scope.
+static void ConvCheck ( const CMeasure & m, const CColor & aColor, const CColor & refRaw,
+						double YWhite, int displayMode, int nCol, int satsize,
+						FamStat & stat, const char * name, int idx )
+{
+	CColorHCFRConfig * cfg = GetConfig();
+	if ( cfg->m_GammaOffsetType != 5 || !aColor.isValid() || !refRaw.isValid() )
+		return;
+	if ( cfg->m_colorStandard == HDTVa || cfg->m_colorStandard == HDTVb )
+		return;
+
+	bool bCC = ( displayMode == 11 );
+	bool mascior = ( bCC && cfg->m_CCMode >= MASCIOR50 && cfg->m_CCMode <= CCMAXHDR );
+
+	CColor pert = aColor;
+	pert.SetX(pert.GetX() * 1.07);
+	pert.SetY(pert.GetY() * 1.05);
+	pert.SetZ(pert.GetZ() * 1.03);
+
+	// Pane side: the Mascior HDR CC sets keep their * 100 convention on BOTH
+	// sides (RunCC applies it too) - scaling only the viewer side here would
+	// report a ~1.06x phantom mismatch the moment a Mascior set joins kSpaces.
+	CColor refPane = refRaw;
+	ScaleXYZ(refPane, mascior ? 100. : m.GetHDRRefScale());
+	double dEpane = GridColorDE(m, pert, refPane, YWhite, displayMode, nCol, satsize);
+
+	// Viewer side, as C3DColorView::BuildScene builds it: the reference scaled
+	// to the SHARED grid white (CMeasure::GetColorDEWhiteY) with YWhiteRef 1.0,
+	// and the grid's dE evaluation space. Scaling by 10000/white with
+	// YWhiteRef 1.0 is algebraically the grid's (ref * GetHDRRefScale(),
+	// RefWhite = YWhite/tmWhite) pair, so any drift between the two - a
+	// reference rescale, a white source, or a dE space - shows up here.
+	double wDE = m.GetColorDEWhiteY(false, bCC, mascior);
+	if ( wDE <= 0.0 )
+	{
+		// GetDeltaE would divide by this; a NaN here surfaces as a bogus 999
+		// convention failure whose real cause is a missing white.
+		stat.Add(0.0, "%s %d (no white; convention check skipped)", name, idx);
+		return;
+	}
+	CColor refView = refRaw;
+	ScaleXYZ(refView, mascior ? 100. : 10000. / wDE);
+	CColorReference vRef = ( GetColorReference().m_standard == UHDTV3 || GetColorReference().m_standard == UHDTV4 )
+						 ? ContainerTransportReference(GetColorReference()) : GetColorReference();
+	double dEview = pert.GetDeltaE(wDE, refView, 1.0, vRef, cfg->m_dE_form, false, 3);
+
+	stat.Add(fabs(dEpane - dEview), "%s %d (pane %.3f vs viewer %.3f)", name, idx, dEpane, dEview);
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -410,13 +487,19 @@ static void ApplyComboConfig ( const Combo & c )
 
 	// A realistic 700-nit display target so PQ actually clips/tone-maps the
 	// upper patches (the harness asserts clipped patches STILL read dE ~ 0).
+	// Tone-map-ON combos target 300 nits instead: BT.2390's knee
+	// (KS = 1.5*PQ(Lmax) - 0.5) then falls BELOW the 50.23% diffuse-white
+	// code, so tone mapping actually compresses diffuse white and the HDR
+	// reference-rescale/white-anchor conventions get real coverage - at 700
+	// nits the knee sits ~245 nits and diffuse white passes through untouched
+	// (TM-off PQ keeps 700 for hard-clip coverage).
 	// TargetMinL stays 0: the references target ideal black (Y=0), while the
 	// sensor pins the black patch to TargetMinL - a nonzero floor is a
 	// modeled DISPLAY property that would show up as a constant black-patch
 	// dE, not a wire-modeling error. (With black 0, BT.1886 degenerates to a
 	// pure 2.4 power - consistent on both sides.)
 	BOOL bHdr = ( c.eotf == 5 || c.eotf == 7 );
-	cfg->m_TargetMaxL = bHdr ? 700.0 : 120.0;
+	cfg->m_TargetMaxL = bHdr ? ( c.toneMap ? 300.0 : 700.0 ) : 120.0;
 	cfg->m_TargetMinL = 0.0;
 	cfg->m_bOverRideTargs = FALSE;
 	cfg->m_userBlack = FALSE;
@@ -660,7 +743,7 @@ static void RunPrimaries ( const Combo & c, CMeasure & m, CSimulatedSensor & sen
 }
 
 // Six saturation sweeps at one stimulus level.
-static void RunSats ( const Combo & c, CMeasure & m, CSimulatedSensor & sensor, double stim, FamStat & stat )
+static void RunSats ( const Combo & c, CMeasure & m, CSimulatedSensor & sensor, double stim, FamStat & stat, FamStat & convStat )
 {
 	CColorHCFRConfig * cfg = GetConfig();
 	bool special = ( cfg->m_colorStandard == HDTVa || cfg->m_colorStandard == HDTVb );
@@ -682,9 +765,10 @@ static void RunSats ( const Combo & c, CMeasure & m, CSimulatedSensor & sensor, 
 			// MT_SAT_* patches are Intensity-dimmed on the real wire
 			CColor aColor = Meas(sensor, GenColors[j], c.intensity);
 			CColor refColor = m.GetRefSat(s, (double)j / (double)(kSatSize - 1), special, stim);
-			if ( cfg->m_GammaOffsetType == 5 )
-				ScaleXYZ(refColor, 105.95640);	// UpdateGrid ~4229
 			double YWhite = special ? m.GetOnOffWhite().GetY() : m.GetPrimeWhite().GetY();
+			ConvCheck(m, aColor, refColor, YWhite, 5 + s, j + 1, kSatSize, convStat, names[s], j);
+			if ( cfg->m_GammaOffsetType == 5 )
+				ScaleXYZ(refColor, m.GetHDRRefScale());	// UpdateGrid ~4294
 			double dE = GridColorDE(m, aColor, refColor, YWhite, 5 + s, j + 1, kSatSize);
 			stat.Add(dE, "%s sat %d%% stim %.0f%%", names[s], j * 25, stim * 100.);
 		}
@@ -692,7 +776,7 @@ static void RunSats ( const Combo & c, CMeasure & m, CSimulatedSensor & sensor, 
 }
 
 // One color-checker set (GCD 24 or AXIS 71).
-static void RunCC ( const Combo & c, CMeasure & m, CSimulatedSensor & sensor, CCPatterns ccMode, int count, FamStat & stat )
+static void RunCC ( const Combo & c, CMeasure & m, CSimulatedSensor & sensor, CCPatterns ccMode, int count, FamStat & stat, FamStat & convStat )
 {
 	CColorHCFRConfig * cfg = GetConfig();
 	cfg->m_CCMode = ccMode;
@@ -725,8 +809,9 @@ static void RunCC ( const Combo & c, CMeasure & m, CSimulatedSensor & sensor, CC
 		CColor aColor = Meas(sensor, GenColors[j], 1.0);
 		CColor refColor;
 		m.GetRefCC24Sat(j, refColor);
+		ConvCheck(m, aColor, refColor, YWhite, 11, j + 1, kSatSize, convStat, "patch", j);
 		if ( cfg->m_GammaOffsetType == 5 )
-			ScaleXYZ(refColor, (ccMode >= MASCIOR50 && ccMode <= CCMAXHDR) ? 100. : 105.95640);	// UpdateGrid ~4221-4231
+			ScaleXYZ(refColor, (ccMode >= MASCIOR50 && ccMode <= CCMAXHDR) ? 100. : m.GetHDRRefScale());	// UpdateGrid ~4296-4307
 		double dE = GridColorDE(m, aColor, refColor, YWhite, 11, j + 1, kSatSize);
 		stat.Add(dE, "patch %d (%.2f/%.2f/%.2f%%)", j, GenColors[j][0], GenColors[j][1], GenColors[j][2]);
 	}
@@ -739,6 +824,12 @@ static void RunCC ( const Combo & c, CMeasure & m, CSimulatedSensor & sensor, CC
 
 static double TolFor ( const Combo & c, int fam )
 {
+	// Matched pane/viewer conventions agree to machine precision (identical
+	// GetDeltaE arguments), while the legacy 105.95640 pane convention reads
+	// 0.015-0.023 under 300-nit tone mapping - the default 0.05 would let a
+	// convention regression back in.
+	if ( fam == FAM_CONV )
+		return 0.005;
 	if ( c.intensity < 0.999 )
 	{
 		// Dimmed combos verify the Intensity CANCELLATION, which is exact
@@ -795,10 +886,10 @@ static void RunCombo ( const Combo & c )
 	// primaries set PrimeWhite (the sat/CC dE normalizer).
 	RunGray(c, m, sensor, stats[FAM_GRAY]);
 	RunPrimaries(c, m, sensor, stats[FAM_PRIM]);
-	RunSats(c, m, sensor, 1.0, stats[FAM_SAT100]);
-	RunSats(c, m, sensor, 0.75, stats[FAM_SAT75]);
-	RunCC(c, m, sensor, GCD, 24, stats[FAM_CC_GCD]);
-	RunCC(c, m, sensor, AXIS, 71, stats[FAM_CC_AXIS]);
+	RunSats(c, m, sensor, 1.0, stats[FAM_SAT100], stats[FAM_CONV]);
+	RunSats(c, m, sensor, 0.75, stats[FAM_SAT75], stats[FAM_CONV]);
+	RunCC(c, m, sensor, GCD, 24, stats[FAM_CC_GCD], stats[FAM_CONV]);
+	RunCC(c, m, sensor, AXIS, 71, stats[FAM_CC_AXIS], stats[FAM_CONV]);
 
 	// Evaluate
 	char line[512];
@@ -902,11 +993,13 @@ int RunAccuracyTest ( const char * pReportPath )
 	fprintf(s_fReport, "ColorHCFR /accuracytest - reference == wire == sensor-model matrix\n");
 	fprintf(s_fReport, "Columns are the worst dE per patch family; '*' = over tolerance (FAIL),\n");
 	fprintf(s_fReport, "'#' = over tolerance but documented KNOWN-FAIL (see detail below).\n");
-	fprintf(s_fReport, "Tolerance: 0.05; Intensity-90%% combos: 0.9 (power law) / 1.5 (other EOTFs)\n");
-	fprintf(s_fReport, "dE settings: dE_form=3 (CIE2000), dE_gray=1 (gamma-predicted gray target), gw_Weight=0\n\n");
-	fprintf(s_fReport, "%-8s %-10s %-6s %-8s %-5s %8s %7s %7s %7s %7s %7s  %s\n",
+	fprintf(s_fReport, "Tolerance: 0.05; Intensity-90%% combos: 0.9 (power law) / 1.5 (other EOTFs); convPV: 0.005\n");
+	fprintf(s_fReport, "dE settings: dE_form=3 (CIE2000), dE_gray=1 (gamma-predicted gray target), gw_Weight=0\n");
+	fprintf(s_fReport, "convPV: |grid dE - 3D-viewer dE| for a perturbed patch (PQ mode-5 combos only;\n");
+	fprintf(s_fReport, "-1.000 = family not run) - locks the unified HDR reference-rescale convention\n\n");
+	fprintf(s_fReport, "%-8s %-10s %-6s %-8s %-5s %8s %7s %7s %7s %7s %7s %7s  %s\n",
 			"space", "eotf", "white", "grid", "inten",
-			"gray", "prim", "sat100", "sat75", "ccGCD", "ccAXIS", "result");
+			"gray", "prim", "sat100", "sat75", "ccGCD", "ccAXIS", "convPV", "result");
 
 	int iSpace, iEotf, iWhite, iGrid, iInt;
 	for ( iSpace = 0 ; iSpace < (int)(sizeof(kSpaces)/sizeof(kSpaces[0])) ; iSpace ++ )

--- a/Controls/RGBLevelWnd.cpp
+++ b/Controls/RGBLevelWnd.cpp
@@ -228,6 +228,12 @@ void CRGBLevelWnd::Refresh(int minCol, int m_displayMode, int nSize)
     	int nCount = m_pDocument -> GetMeasure () -> GetGrayScaleSize ();
         double YWhite = white.GetY();
 		double tmWhite = TmDiffuseWhiteNits(noDataColor, noDataColor);
+		// The DVD branches below REASSIGN tmWhite to the manual-generator 0.50-code
+		// white (~92.25). The unified paths (mode 13) pair with a reference scaled
+		// by GetHDRRefScale(), which is built on the true tone-mapped diffuse
+		// white - so they must normalize by THAT, whichever branch ran first.
+		// Clamped exactly like GetHDRRefScale: this value is used as a divisor.
+		const double tmWhiteRef = ( tmWhite > 0.0 ) ? tmWhite : 94.37844;
 
 			if ( (GetConfig()->m_GammaOffsetType == 5 && (m_displayMode <=11 && m_displayMode >= 5 || m_displayMode == 13)) )
 			{
@@ -239,9 +245,15 @@ void CRGBLevelWnd::Refresh(int minCol, int m_displayMode, int nSize)
 				}
 				else
 				{
-					aReference.SetX((aReference.GetX() * 105.95640));
-					aReference.SetY((aReference.GetY() * 105.95640));
-					aReference.SetZ((aReference.GetZ() * 105.95640));
+					// Unified HDR rescale (matches UpdateGrid ~4294 and the 3D
+					// viewer): GetHDRRefScale, = 105.95640 with tone mapping off.
+					// The manual generator (DVD) keeps the legacy fixed scale;
+					// profile mode 13 is always unified.
+					double s = ( DVD && m_displayMode != 13 ) ? 105.95640
+							 : m_pDocument->GetMeasure()->GetHDRRefScale();
+					aReference.SetX((aReference.GetX() * s));
+					aReference.SetY((aReference.GetY() * s));
+					aReference.SetZ((aReference.GetZ() * s));
 				}
 			}
 
@@ -366,6 +378,10 @@ void CRGBLevelWnd::Refresh(int minCol, int m_displayMode, int nSize)
 						{
 							if ( ( (GetColorReference().m_standard == UHDTV2 && minCol == satsize) || GetColorReference().m_standard == HDTV || GetColorReference().m_standard == UHDTV) && m_displayMode != 11 && m_displayMode != 13)// && !shiftDiffuse) //&& nCol == (satsize)
 								white.SetY(92.25496);
+							else if (m_displayMode == 13)
+								// profile mode is always on the unified GetHDRRefScale
+								// convention, even with the manual generator
+								white.SetY(tmWhiteRef);
 							else
 								white.SetY(94.37844);
 						}
@@ -381,7 +397,11 @@ void CRGBLevelWnd::Refresh(int minCol, int m_displayMode, int nSize)
 							if ((GetConfig()->m_CCMode >= MASCIOR50 && GetConfig()->m_CCMode <= CCMAXHDR) && m_displayMode == 11)
 								white.SetY(m_pDocument->GetMeasure()->GetGray((m_pDocument->GetMeasure()->GetGrayScaleSize()-1)).GetY());
 							else
-								white.SetY(94.37844);
+								// Unified convention: the reference above is
+								// GetHDRRefScale-scaled (1.0 = tone-mapped diffuse
+								// white), so normalize the measurement by the same
+								// white (identical with tone mapping off).
+								white.SetY(tmWhiteRef);
 					}
 				}
 				aColor[0]=aColor[0]/white.GetY();
@@ -441,6 +461,13 @@ void CRGBLevelWnd::Refresh(int minCol, int m_displayMode, int nSize)
 			{
 				if ( ((cRef.m_standard == UHDTV2 && minCol == satsize ) || cRef.m_standard == HDTV || cRef.m_standard == UHDTV)  && m_displayMode != 11 && m_displayMode != 13)// && !shiftDiffuse) //fixes skin && nCol == satsize
 					RefWhite = YWhite / (tmWhite);
+				else if (m_displayMode == 13)
+					// profile mode: unified convention even with the manual
+					// generator (reference is GetHDRRefScale-scaled), measured
+					// white unrescaled. tmWhiteRef, NOT tmWhite: the DVD branch
+					// above clobbered tmWhite with the 0.50-code white, which
+					// would leave a fixed ~2.3% bias against the reference.
+					RefWhite = YWhite / (tmWhiteRef);
 				else
 				{
 					RefWhite = YWhite / (tmWhite) ;
@@ -456,7 +483,7 @@ void CRGBLevelWnd::Refresh(int minCol, int m_displayMode, int nSize)
 					RefWhite = YWhite / (tmWhite) ;
 				else
 				{
-					RefWhite = YWhite / (tmWhite) ;					
+					RefWhite = YWhite / (tmWhite) ;
 					YWhite = YWhite * 94.37844 / (tmWhite) ;
 				}
 			}
@@ -466,8 +493,11 @@ void CRGBLevelWnd::Refresh(int minCol, int m_displayMode, int nSize)
 					YWhite = m_pDocument->GetMeasure()->GetGray((m_pDocument->GetMeasure()->GetGrayScaleSize()-1)).GetY() ;
 				else
 				{
+					// Unified HDR convention (matches the measures grid and the
+					// 3D viewer): the reference is GetHDRRefScale-scaled, so the
+					// measured white stays unrescaled - no 94.37844/tmWhite
+					// adjust (identical with tone mapping off).
 					RefWhite = YWhite / (tmWhite) ;
-					YWhite = YWhite * 94.37844 / (tmWhite) ;
 				}
 			}
 			}

--- a/Export.cpp
+++ b/Export.cpp
@@ -798,8 +798,14 @@ bool CExport::SavePDF()
 			YWhite = m_pDoc->GetMeasure()->GetGray((m_pDoc->GetMeasure()->GetGrayScaleSize()-1)).GetY() ;
 		else
 		{
+			// Unified HDR convention (matches the measures grid): references are
+			// GetHDRRefScale-scaled below, measured white unrescaled. The manual
+			// generator keeps the legacy pair, because the grid does too
+			// (UpdateGrid/InitGrid gate the scale on enumManual) - the export must
+			// reproduce the on-screen numbers.
 			RefWhite = YWhite / (tmWhite) ;
-			YWhite = YWhite * 94.37844 / (tmWhite) ;
+			if (GetConfig()->GetGeneratorType() == CColorHCFRConfig::enumManual)
+				YWhite = YWhite * 94.37844 / (tmWhite) ;
 		}
 	}
 
@@ -862,12 +868,13 @@ bool CExport::SavePDF()
 				}
 				else
 				{
-					aReference.SetX(aReference.GetX() * 105.95640);
-					aReference.SetY(aReference.GetY() * 105.95640);
-					aReference.SetZ(aReference.GetZ() * 105.95640);
-					aRef[0] = aRef[0] * 105.95640;
-					aRef[1] = aRef[1] * 105.95640;
-					aRef[2] = aRef[2] * 105.95640;
+					double s = ( GetConfig()->GetGeneratorType() == CColorHCFRConfig::enumManual ) ? 105.95640 : m_pDoc->GetMeasure()->GetHDRRefScale();
+					aReference.SetX(aReference.GetX() * s);
+					aReference.SetY(aReference.GetY() * s);
+					aReference.SetZ(aReference.GetZ() * s);
+					aRef[0] = aRef[0] * s;
+					aRef[1] = aRef[1] * s;
+					aRef[2] = aRef[2] * s;
 				}
 			}
 			aMeasure[0]=pow((tmp.GetRGBValue(bRef)[0]), 1.0/2.22);
@@ -1375,8 +1382,13 @@ bool CExport::SavePDF()
 				YWhite = m_pDoc->GetMeasure()->GetGray((m_pDoc->GetMeasure()->GetGrayScaleSize()-1)).GetY() ;
 			else
 			{
+				// Unified HDR convention: references are GetHDRRefScale-scaled
+				// below, measured white unrescaled. The manual generator keeps
+				// the legacy pair so the export reproduces the on-screen grid,
+				// which gates its own scale on enumManual.
 				RefWhite = YWhite / (tmWhite) ;
-				YWhite = YWhite * 94.37844 / (tmWhite) ;
+				if (GetConfig()->GetGeneratorType() == CColorHCFRConfig::enumManual)
+					YWhite = YWhite * 94.37844 / (tmWhite) ;
 			}
 		}
 		ri = 6;
@@ -1430,12 +1442,13 @@ bool CExport::SavePDF()
 				}
 				else
 				{
-					aReference.SetX(aReference.GetX() * 105.95640);
-					aReference.SetY(aReference.GetY() * 105.95640);
-					aReference.SetZ(aReference.GetZ() * 105.95640);
-					aRef[0] = aRef[0] * 105.95640;
-					aRef[1] = aRef[1] * 105.95640;
-					aRef[2] = aRef[2] * 105.95640;
+					double s = ( GetConfig()->GetGeneratorType() == CColorHCFRConfig::enumManual ) ? 105.95640 : pDataRef->GetMeasure()->GetHDRRefScale();
+					aReference.SetX(aReference.GetX() * s);
+					aReference.SetY(aReference.GetY() * s);
+					aReference.SetZ(aReference.GetZ() * s);
+					aRef[0] = aRef[0] * s;
+					aRef[1] = aRef[1] * s;
+					aRef[2] = aRef[2] * s;
 				}
 			}
 			if (aColor.isValid())
@@ -2390,8 +2403,13 @@ bool CExport::SaveCCSheet()
 				YWhite = m_pDoc->GetMeasure()->GetGray((m_pDoc->GetMeasure()->GetGrayScaleSize()-1)).GetY() ;
 			else
 			{
+				// Unified HDR convention: references are GetHDRRefScale-scaled
+				// below, measured white unrescaled. The manual generator keeps
+				// the legacy pair so the export reproduces the on-screen grid,
+				// which gates its own scale on enumManual.
 				RefWhite = YWhite / (tmWhite) ;
-				YWhite = YWhite * 94.37844 / (tmWhite) ;
+				if (GetConfig()->GetGeneratorType() == CColorHCFRConfig::enumManual)
+					YWhite = YWhite * 94.37844 / (tmWhite) ;
 			}
 		}
 
@@ -2407,9 +2425,10 @@ bool CExport::SaveCCSheet()
 			}
 			else
 			{
-				aReference.SetX(aReference.GetX() * 105.95640);
-				aReference.SetY(aReference.GetY() * 105.95640);
-				aReference.SetZ(aReference.GetZ() * 105.95640);
+				double s = ( GetConfig()->GetGeneratorType() == CColorHCFRConfig::enumManual ) ? 105.95640 : m_pDoc->GetMeasure()->GetHDRRefScale();
+				aReference.SetX(aReference.GetX() * s);
+				aReference.SetY(aReference.GetY() * s);
+				aReference.SetZ(aReference.GetZ() * s);
 			}
 		}
 

--- a/Measure.cpp
+++ b/Measure.cpp
@@ -1179,17 +1179,22 @@ double CMeasure::ComputeProfileDE(const CColor & c, int i)
 	double YWhite = ywForDE, RefWhite = 1.0;
 	if ( mode == 5 )	// PQ HDR: match the grid's absolute-nits bridge
 	{
-		// Same chain as the grid's CC24 dE (GetItemText): snapped tone-mapped
-		// diffuse white via the shared TmDiffuseWhiteNits helper, reference
-		// rescaled from the 1.0 = 10000 nits convention.
+		// Same chain as the grid's CC24 dE (GetItemText): reference rescaled
+		// from the 1.0 = 10000 nits convention by GetHDRRefScale (the unified,
+		// tone-map-aware form the 3D viewer also uses; = 105.95640 with tone
+		// mapping off), measurement anchored to the measured white as-is.
 		double tmWhite = TmDiffuseWhiteNits( GetOnOffWhite(), GetOnOffBlack() );
 		if ( tmWhite > 0.0 )
 		{
-			refC.SetX( refC.GetX() * 105.95640 );
-			refC.SetY( refC.GetY() * 105.95640 );
-			refC.SetZ( refC.GetZ() * 105.95640 );
+			// 10000/tmWhite IS GetHDRRefScale() here (mode-5 getL_EOTF ignores
+			// White/Black), and the guard above already covers its <= 0 case -
+			// calling it would re-run the PQ + BT.2390 chain on every patch, and
+			// this is per-patch code (a 21-cube is 9261 of them).
+			double s = 10000. / tmWhite;
+			refC.SetX( refC.GetX() * s );
+			refC.SetY( refC.GetY() * s );
+			refC.SetZ( refC.GetZ() * s );
 			RefWhite = YWhite / tmWhite;
-			YWhite   = YWhite * 94.37844 / tmWhite;
 		}
 	}
 
@@ -7448,6 +7453,48 @@ double CMeasure::GetHDRRefScale() const
 	if ( tmWhite <= 0.0 )
 		tmWhite = 94.37844;
 	return 10000. / tmWhite;
+}
+
+// The white the measures grid normalises saturation / color-checker dE by
+// (UpdateGrid's YWhite source + GetItemText's HDR block): the MEASURED prime
+// white, the ON/OFF white for the special 75%/plasma standards, or the
+// grayscale top for the Mascior-style HDR CC sets. The <90% fallback (a
+// primaries run made at reduced stimulus) is SDR- and COLOR-CHECKER-only in
+// the grid, hence bCC.
+//
+// Consumers must normalise dE by THIS white, not by the theoretical
+// TmDiffuseWhiteNits: both are self-consistent (a perfect measurement reads
+// dE 0 either way, which is why the /accuracytest invariant cannot tell them
+// apart), but they diverge as soon as the display's white misses its target -
+// dE scales roughly with (YWhite / tmWhite)^(1/3), so a 3.5%-low white shifted
+// the 3D viewer ~1% away from the grid before this was shared.
+double CMeasure::GetColorDEWhiteY(bool bSpecial, bool bCC, bool bMasciorCC) const
+{
+	BOOL isHDR = ( GetConfig()->m_GammaOffsetType == 5 );
+
+	if ( isHDR && bCC && bMasciorCC )
+	{
+		int n = GetGrayScaleSize();
+		if ( n > 0 && GetGray(n - 1).isValid() )
+			return GetGray(n - 1).GetY();
+	}
+
+	CColor prime = GetPrimeWhite();
+	CColor onoff = GetOnOffWhite();
+	double yPrime = prime.isValid() ? prime.GetY() : 0.0;
+	double yOnOff = onoff.isValid() ? onoff.GetY() : 0.0;
+
+	// UpdateGrid's chain: prime white, falling back to on/off white, then to
+	// m_TargetMaxL when neither was measured (MainView.cpp ~3708-3722). The
+	// special standards read the on/off white directly and do NOT fall back to
+	// prime - the grid goes straight from a missing on/off white to TargetMaxL.
+	double y = bSpecial ? yOnOff : ( yPrime > 0.0 ? yPrime : yOnOff );
+	if ( bCC && onoff.isValid() && !isHDR && yOnOff > 0.0 && yPrime / yOnOff < 0.9 )
+		y = yOnOff;
+
+	if ( y <= 0.0 )
+		y = GetConfig()->m_TargetMaxL;
+	return y;
 }
 
 CColor CMeasure::GetMeasurement(int i) const 

--- a/Measure.h
+++ b/Measure.h
@@ -241,6 +241,7 @@ public:
 	ColorRGBDisplay GetProfilePatchRGB(int i);		// patch stimulus, regenerated from metadata (cached)
 	void GetRefProfileSat(int i, CColor & ccRef);	// theoretical reference for patch i (grid conventions)
 	double ComputeProfileDE(const CColor & measured, int i);	// dE for profile patch i, matching the measures grid (SDR + PQ HDR); -1 to skip
+	double GetColorDEWhiteY(bool bSpecial, bool bCC, bool bMasciorCC) const;	// the white the grid normalises sat/CC dE by (measured, NOT the theoretical tmWhite)
 	// Live profile-capture state (not serialized): the profiling pane pauses/observes through these
 	volatile BOOL m_bProfilePause;
 	double m_profileCurrentDrift;	// last anchor's drift factor minus 1.0

--- a/Views/CIEChartView.cpp
+++ b/Views/CIEChartView.cpp
@@ -576,7 +576,13 @@ void CCIEChartGrapher::DrawAlphaBitmap(CDC *pDC, const CCIEGraphPoint& aGraphPoi
 
 			CColor inColor = aGraphPoint.GetNormalizedColor();
 
-			if (GetConfig()->m_GammaOffsetType == 5 && (GetConfig()->m_colorStandard == UHDTV3 || GetConfig()->m_colorStandard == UHDTV4 || isSat) ) //check for primaries/secondaries page
+			// Saturation-page points are already normalized on the unified
+			// convention (ref by YWhite/10000 via the GetHDRRefScale-form
+			// YWhiteRef, measurement by YWhite), which now matches the measures
+			// grid - no further white adjustment. The legacy 94.37844/tmWhite
+			// adjust remains only for the UHDTV3/4 primaries page (out of the
+			// unified sat/CC scope). Identical with tone mapping off.
+			if (GetConfig()->m_GammaOffsetType == 5 && (GetConfig()->m_colorStandard == UHDTV3 || GetConfig()->m_colorStandard == UHDTV4) && !isSat ) //check for primaries/secondaries page
 			{
 				RefWhite = 94.37844 / tmWhite;
 				YWhite = YWhite * 94.37844 / tmWhite ;

--- a/Views/Color3DView.cpp
+++ b/Views/Color3DView.cpp
@@ -283,8 +283,16 @@ void C3DColorView::AppendMeasure(const CColor & c, double whiteY, CColorReferenc
 		// pass a precomputed dE (ComputeProfileDE) so the viewer, the summary pane
 		// and the RGB-levels widget can never disagree.
 		int gw = ( GetConfig()->m_GammaOffsetType == 5 ) ? 3 : GetConfig()->gw_Weight;
+		// dE evaluation space, mirroring the grid: the COLOR families run in the
+		// transport space for the UHDTV3/4 pseudo-spaces (GetItemText's bRef),
+		// while the grayscale families use the active reference (its grayscale
+		// branch passes GetColorReference()). HDTVa/b/CC6 are forced to Rec.709
+		// inside GetDeltaE itself, so they need no branch here.
+		CColorReference dERef = ref;
+		if ( !isGS && ( ref.m_standard == UHDTV3 || ref.m_standard == UHDTV4 ) )
+			dERef = ContainerTransportReference( ref );
 		p.dE = ( dEOverride >= 0.0 ) ? (float)dEOverride
-									 : (float)c.GetDeltaE( ywForDE, dETarget, 1.0, ref, GetConfig()->m_dE_form, isGS, gw );
+									 : (float)c.GetDeltaE( ywForDE, dETarget, 1.0, dERef, GetConfig()->m_dE_form, isGS, gw );
 		if ( !( p.dE == p.dE ) || p.dE < 0.0f )   // NaN / negative: no usable dE
 		{
 			m_points.push_back( p );
@@ -475,6 +483,21 @@ void C3DColorView::BuildScene()
 	const bool hdr10Refs = ( GetConfig()->m_GammaOffsetType == 5 );
 	const double hdrRefScale = hdr10Refs ? pMeasure->GetHDRRefScale() : 1.0;
 	const bool satSpecial = ( ref.m_standard == HDTVa || ref.m_standard == HDTVb );
+
+	// dE normalisation, separate from the marker geometry above. The grid
+	// normalises sat/CC dE by the MEASURED white (CMeasure::GetColorDEWhiteY)
+	// and expresses the reference relative to it (RefWhite = YWhite / tmWhite);
+	// scaling the reference by 10000 / that white is the same thing with
+	// YWhiteRef 1.0, which is what AppendMeasure passes. Normalising by the
+	// theoretical tmWhite instead (what SceneDiffuseWhiteY returns in HDR, and
+	// what this used to pass) reads ~1% off the grid whenever the display's
+	// white misses target. Marker geometry keeps hdrRefScale: refC * (10000 /
+	// tmWhite) * tmWhite is absolute nits, so a perfect patch draws no tail.
+	// (whiteY fallback: with no measured white at all the helper returns 0,
+	// which AppendMeasure would read as "blackish" and drop the dE entirely.)
+	double satDEWhiteRaw = pMeasure->GetColorDEWhiteY( satSpecial, false, false );
+	const double satDEWhite = ( satDEWhiteRaw > 0.0 ) ? satDEWhiteRaw : whiteY;
+	const double satDEScale = ( hdr10Refs && satDEWhite > 0.0 ) ? 10000. / satDEWhite : 1.0;
 	static const wchar_t * hueName[6] = { L"Red", L"Green", L"Blue", L"Yellow", L"Cyan", L"Magenta" };
 	int nSatLevels = pMeasure->GetSatLevelCount();
 	for ( int L = 0; L < nSatLevels; L++ )
@@ -492,15 +515,19 @@ void C3DColorView::BuildScene()
 				if ( i >= (int) set.sat[h].size() )
 					continue;
 				CColor refC = pMeasure->GetRefSat( h, satRatio, satSpecial, stim );
+				CColor refMark = refC, refDE = refC;
 				if ( hdr10Refs && refC.isValid() )
 				{
-					refC.SetX( refC.GetX() * hdrRefScale );
-					refC.SetY( refC.GetY() * hdrRefScale );
-					refC.SetZ( refC.GetZ() * hdrRefScale );
+					refMark.SetX( refC.GetX() * hdrRefScale );
+					refMark.SetY( refC.GetY() * hdrRefScale );
+					refMark.SetZ( refC.GetZ() * hdrRefScale );
+					refDE.SetX( refC.GetX() * satDEScale );
+					refDE.SetY( refC.GetY() * satDEScale );
+					refDE.SetZ( refC.GetZ() * satDEScale );
 				}
 				wchar_t lbl[64];
 				swprintf( lbl, 64, L"%s %d%% sat @ %d%% stim", hueName[h], (int)( satRatio * 100.0 + 0.5 ), stimPct );
-				AppendMeasure( set.sat[h][i], whiteY, ref, refC, refC, false, whiteY, lbl, SRC_SAT, i, h, L );
+				AppendMeasure( set.sat[h][i], whiteY, ref, refDE, refMark, false, satDEWhite, lbl, SRC_SAT, i, h, L );
 			}
 		}
 	}
@@ -512,6 +539,18 @@ void C3DColorView::BuildScene()
 	if ( n > MAX_USER_CC_PATCH_SIZE )
 		n = MAX_USER_CC_PATCH_SIZE;   // the measure arrays are allocated to this;
 									  // GetCC24Sat indexes unchecked past it
+	// Loop-invariant: hoisted like the saturation block above. GetColorDEWhiteY
+	// returns CColor copies internally, so calling it per patch would allocate
+	// on every one of the 71 AXIS iterations. SDR is included because the grid
+	// falls back to the ON/OFF white for CC when the primaries run was made
+	// below 90% stimulus, which whiteY does not model.
+	const bool ccMascior = ( GetConfig()->m_CCMode >= MASCIOR50 && GetConfig()->m_CCMode <= CCMAXHDR );
+	double ccDEWhiteRaw = pMeasure->GetColorDEWhiteY( satSpecial, true, ccMascior );
+	const double ccDEWhite = ( ccDEWhiteRaw > 0.0 ) ? ccDEWhiteRaw : whiteY;
+	// Mascior-style HDR CC sets keep their own convention (* 100 against the
+	// grayscale top, RefWhite 1.0) on both sides - see the grid.
+	const double ccMarkScale = ccMascior ? 100. : hdrRefScale;
+	const double ccDEScale   = ccMascior ? 100. : ( 10000. / ccDEWhite );
 	for ( i = 0; i < n; i++ )
 	{
 		CColor c = pMeasure->GetCC24Sat( i );
@@ -519,16 +558,19 @@ void C3DColorView::BuildScene()
 			continue;
 		CColor refC;
 		pMeasure->GetRefCC24Sat( i, refC );
+		CColor refMark = refC, refDE = refC;
 		if ( hdr10Refs && refC.isValid() )
 		{
-			double s = ( GetConfig()->m_CCMode >= MASCIOR50 && GetConfig()->m_CCMode <= CCMAXHDR ) ? 100. : hdrRefScale;
-			refC.SetX( refC.GetX() * s );
-			refC.SetY( refC.GetY() * s );
-			refC.SetZ( refC.GetZ() * s );
+			refMark.SetX( refC.GetX() * ccMarkScale );
+			refMark.SetY( refC.GetY() * ccMarkScale );
+			refMark.SetZ( refC.GetZ() * ccMarkScale );
+			refDE.SetX( refC.GetX() * ccDEScale );
+			refDE.SetY( refC.GetY() * ccDEScale );
+			refDE.SetZ( refC.GetZ() * ccDEScale );
 		}
 		wchar_t lbl[48];
 		swprintf( lbl, 48, L"Color checker #%d", i + 1 );
-		AppendMeasure( c, whiteY, ref, refC, refC, false, whiteY, lbl, SRC_CC24, i );
+		AppendMeasure( c, whiteY, ref, refDE, refMark, false, ccDEWhite, lbl, SRC_CC24, i );
 	}
 
 	// Free measures. Shared with the incremental UPD_FREEMEASUREAPPENDED path.

--- a/Views/MainView.cpp
+++ b/Views/MainView.cpp
@@ -1544,6 +1544,13 @@ void CMainView::RefreshSelection(bool b_minCol, bool inMeasure)
 		CColor Black = GetDocument()->GetMeasure()->GetOnOffBlack();
 		int mode = GetConfig()->m_GammaOffsetType;
 		double tmWhite = TmDiffuseWhiteNits(noDataColor, noDataColor) / 94.37844;
+		// Manual generator (DVD) keeps the legacy 105.95640/94.37844 conventions
+		// upstream (UpdateGrid/GetItemText), so its comparator math stays legacy.
+		BOOL bManualGen = (GetConfig()->GetGeneratorType() == CColorHCFRConfig::enumManual);
+		// Mascior-style HDR CC sets keep the legacy * 100 reference scale upstream
+		// (UpdateGrid / InitGrid / GetItemText), so the comparator must keep the
+		// legacy tmWhite factor for them too.
+		BOOL bMasciorCC = ( m_displayMode == 11 && GetConfig()->m_CCMode >= MASCIOR50 && GetConfig()->m_CCMode <= CCMAXHDR );
 
 		double m_meas_rd, m_meas_gd, m_meas_bd, m_ref_rd, m_ref_gd, m_ref_bd;
 
@@ -1557,7 +1564,22 @@ void CMainView::RefreshSelection(bool b_minCol, bool inMeasure)
 			ref = ColorRGB(m_RefColor.GetRGBValue(bRef));
 			if (mode == 5)
 			{
-				double Yref = ((m_displayMode==0||m_displayMode==3||m_displayMode==4||m_displayMode==12)?(GetConfig()->m_useToneMap?((GetConfig()->m_DiffuseL/94.37844) /(GetConfig()->m_TargetMaxL/10000.)):tmWhite/(GetConfig()->m_TargetMaxL/10000.)):(m_displayMode == 1 && !(GetConfig()->m_colorStandard==UHDTV2||GetConfig()->m_colorStandard==UHDTV3||GetConfig()->m_colorStandard==UHDTV4))?(m_RefWhite * 10000./94.37844):(m_RefWhite * 10000./94.37844*tmWhite));
+				double Yref;
+				if (m_displayMode==0||m_displayMode==3||m_displayMode==4||m_displayMode==12)
+					Yref = GetConfig()->m_useToneMap?((GetConfig()->m_DiffuseL/94.37844) /(GetConfig()->m_TargetMaxL/10000.)):tmWhite/(GetConfig()->m_TargetMaxL/10000.);
+				else if (m_displayMode == 1 && !(GetConfig()->m_colorStandard==UHDTV2||GetConfig()->m_colorStandard==UHDTV3||GetConfig()->m_colorStandard==UHDTV4))
+					Yref = m_RefWhite * 10000./94.37844;
+				else if ((!bManualGen && m_displayMode >= 5 && m_displayMode <= 11 && !bMasciorCC) || m_displayMode == 13)
+					// sat/CC/profile references are GetHDRRefScale-scaled (1.0 =
+					// tone-mapped diffuse white); without the legacy tmWhite factor
+					// this reproduces exactly the code the 105.95640-scaled
+					// references displayed (identical with tone mapping off).
+					// The Mascior HDR CC sets are excluded: their reference still
+					// gets the legacy * 100 upstream (UpdateGrid/InitGrid), so the
+					// tmWhite factor must stay for them.
+					Yref = m_RefWhite * 10000./94.37844;
+				else
+					Yref = m_RefWhite * 10000./94.37844*tmWhite;
 				m_ref_rd = min(max(ref[0]/Yref,0),1);
 				m_ref_gd = min(max(ref[1]/Yref,0),1);
 				m_ref_bd = min(max(ref[2]/Yref,0),1);
@@ -1625,7 +1647,21 @@ void CMainView::RefreshSelection(bool b_minCol, bool inMeasure)
 
 				if (mode == 5)
 				{
-					double Yref = ((m_displayMode==0||m_displayMode==3||m_displayMode==4||m_displayMode==12)?(GetConfig()->m_useToneMap?10000.*(GetConfig()->m_DiffuseL/94.37844):tmWhite*10000.):(m_displayMode == 1 && !(GetConfig()->m_colorStandard==UHDTV2||GetConfig()->m_colorStandard==UHDTV3||GetConfig()->m_colorStandard==UHDTV4))?(m_YWhite * 10000./94.37844):(m_YWhite * 10000./94.37844*tmWhite));
+					double Yref;
+					if (m_displayMode==0||m_displayMode==3||m_displayMode==4||m_displayMode==12)
+						Yref = GetConfig()->m_useToneMap?10000.*(GetConfig()->m_DiffuseL/94.37844):tmWhite*10000.;
+					else if (m_displayMode == 1 && !(GetConfig()->m_colorStandard==UHDTV2||GetConfig()->m_colorStandard==UHDTV3||GetConfig()->m_colorStandard==UHDTV4))
+						Yref = m_YWhite * 10000./94.37844;
+					else if ((!bManualGen && m_displayMode >= 5 && m_displayMode <= 11 && !bMasciorCC) || m_displayMode == 13)
+						// m_YWhite is the unrescaled measured white under the unified
+						// convention. The legacy pair was m_YWhite_old * K * tmWhite
+						// with m_YWhite_old = m_YWhite / tmWhite, so the faithful
+						// replacement simply DROPS the tmWhite factor - dividing by
+						// it instead would over-correct by tmWhite^2. Mascior CC is
+						// excluded for the same reason as the reference side above.
+						Yref = m_YWhite * 10000./94.37844;
+					else
+						Yref = m_YWhite * 10000./94.37844*tmWhite;
 					m_meas_r = min(max(meas[0]/Yref,0),1);
 					m_meas_g = min(max(meas[1]/Yref,0),1);
 					m_meas_b = min(max(meas[2]/Yref,0),1);
@@ -2227,10 +2263,13 @@ void CMainView::InitGrid(bool sizeGrid)
 				GetDocument()->GetMeasure()->GetRefCC24Sat(i, s_clr);
 				if (GetConfig()->m_GammaOffsetType == 5 && GetConfig()->m_bHDR100 )
 				{
-					// Match the dE path's scale (4219/4225): *100 for the
-					// Mascior-style HDR CC sets, *105.95640 otherwise - so the
+					// Match the dE path's scale (UpdateGrid ~4294): *100 for the
+					// Mascior-style HDR CC sets, GetHDRRefScale otherwise (fixed
+					// 105.95640 for the legacy manual-generator path) - so the
 					// swatch luminance represents the same reference the dE uses.
-					double s = ( GetConfig()->m_CCMode >= MASCIOR50 && GetConfig()->m_CCMode <= CCMAXHDR ) ? 100. : 105.95640;
+					double s = ( GetConfig()->m_CCMode >= MASCIOR50 && GetConfig()->m_CCMode <= CCMAXHDR ) ? 100.
+							 : ( GetConfig()->GetGeneratorType() == CColorHCFRConfig::enumManual ) ? 105.95640
+							 : GetDocument()->GetMeasure()->GetHDRRefScale();
 					s_clr.SetX(s_clr.GetX()*s);
 					s_clr.SetY(s_clr.GetY()*s);
 					s_clr.SetZ(s_clr.GetZ()*s);
@@ -2699,14 +2738,13 @@ void CMainView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 					// is on the 1.0 = 10000 nits scale; without this the LIVE
 					// comparator showed a ~106x-off reference during capture that
 					// then "corrected itself" when the patch was clicked afterward.
+					// Unified convention: GetHDRRefScale, measured white unrescaled.
 					if ( GetConfig()->m_GammaOffsetType == 5 )
 					{
-						m_RefColor.SetX( m_RefColor.GetX() * 105.95640 );
-						m_RefColor.SetY( m_RefColor.GetY() * 105.95640 );
-						m_RefColor.SetZ( m_RefColor.GetZ() * 105.95640 );
-						double tmWhite = TmDiffuseWhiteNits( noDataColor, noDataColor );
-						if ( tmWhite > 0.0 )
-							m_YWhite = m_YWhite * 94.37844 / tmWhite;
+						double s = pProfMeasure->GetHDRRefScale();
+						m_RefColor.SetX( m_RefColor.GetX() * s );
+						m_RefColor.SetY( m_RefColor.GetY() * s );
+						m_RefColor.SetZ( m_RefColor.GetZ() * s );
 					}
 					m_RGBLevels.Refresh ( done + 1, 13, nProfSize );
 					m_Target.Refresh ( GetDocument()->GetGenerator()->m_b16_235, done + 1, nProfSize, 13, GetDocument(), CTargetWnd::TARGET_TARGET );
@@ -3104,8 +3142,12 @@ CString CMainView::GetItemText(CColor & aMeasure, double YWhite, CColor & aRefer
 									YWhite = GetDocument()->GetMeasure()->GetGray((GetDocument()->GetMeasure()->GetGrayScaleSize()-1)).GetY() ;
 								else
 								{
+									// Unified HDR convention: the reference is scaled by
+									// GetHDRRefScale (UpdateGrid ~4294), so the measurement
+									// stays anchored to the measured white as-is - no
+									// 94.37844/tmWhite rescale (matches the 3D viewer;
+									// identical with tone mapping off).
 									RefWhite = YWhite / (tmWhite) ;
-									YWhite = YWhite * 94.37844 / (tmWhite) ;
 								}
 							}
 						}
@@ -3262,45 +3304,18 @@ CString CMainView::GetItemText(CColor & aMeasure, double YWhite, CColor & aRefer
 						RefLuma [ 5 ] = GetDocument()->GetMeasure()->GetRefSecondary(2).GetLuminance();
 						RefLuma [ 6 ] = 1.0;
 						break ;
+					// The six saturation sweeps differ only in the GetRefSat hue
+					// index (displayMode 5..10 -> hue 0..5); one arm keeps the HDR
+					// scale in a single place instead of six copies to keep in sync.
 					case 5:
-						satcolor = GetDocument()->GetMeasure()->GetRefSat(0, sat, (GetConfig()->m_colorStandard==HDTVa||GetConfig()->m_colorStandard==HDTVb));
-						if (GetConfig()->m_GammaOffsetType == 5)
-		                    RefLuma [nCol - 1] = satcolor.GetLuminance() * 105.95640;
-						else
-		                    RefLuma [nCol - 1] = satcolor.GetLuminance();
-						break;
 					case 6:
-                        satcolor = GetDocument()->GetMeasure()->GetRefSat(1, sat, (GetConfig()->m_colorStandard==HDTVa||GetConfig()->m_colorStandard==HDTVb));
-						if (GetConfig()->m_GammaOffsetType == 5)
-		                    RefLuma [nCol - 1] = satcolor.GetLuminance() * 105.95640;
-						else
-		                    RefLuma [nCol - 1] = satcolor.GetLuminance();
-						break;
-					case 7:                                                
-                        satcolor = GetDocument()->GetMeasure()->GetRefSat(2, sat, (GetConfig()->m_colorStandard==HDTVa||GetConfig()->m_colorStandard==HDTVb));
-						if (GetConfig()->m_GammaOffsetType == 5)
-		                    RefLuma [nCol - 1] = satcolor.GetLuminance() * 105.95640;
-						else
-		                    RefLuma [nCol - 1] = satcolor.GetLuminance();
-						break;
+					case 7:
 					case 8:
-                        satcolor = GetDocument()->GetMeasure()->GetRefSat(3, sat, (GetConfig()->m_colorStandard==HDTVa||GetConfig()->m_colorStandard==HDTVb));
-						if (GetConfig()->m_GammaOffsetType == 5)
-		                    RefLuma [nCol - 1] = satcolor.GetLuminance() * 105.95640;
-						else
-		                    RefLuma [nCol - 1] = satcolor.GetLuminance();
-						break;
 					case 9:
-                        satcolor = GetDocument()->GetMeasure()->GetRefSat(4, sat, (GetConfig()->m_colorStandard==HDTVa||GetConfig()->m_colorStandard==HDTVb));
-						if (GetConfig()->m_GammaOffsetType == 5)
-		                    RefLuma [nCol - 1] = satcolor.GetLuminance() * 105.95640;
-						else
-		                    RefLuma [nCol - 1] = satcolor.GetLuminance();
-						break;
 					case 10:
-                        satcolor = GetDocument()->GetMeasure()->GetRefSat(5, sat, (GetConfig()->m_colorStandard==HDTVa||GetConfig()->m_colorStandard==HDTVb));
+						satcolor = GetDocument()->GetMeasure()->GetRefSat(m_displayMode - 5, sat, (GetConfig()->m_colorStandard==HDTVa||GetConfig()->m_colorStandard==HDTVb));
 						if (GetConfig()->m_GammaOffsetType == 5)
-		                    RefLuma [nCol - 1] = satcolor.GetLuminance() * 105.95640;
+		                    RefLuma [nCol - 1] = satcolor.GetLuminance() * (DVD ? 105.95640 : GetDocument()->GetMeasure()->GetHDRRefScale());
 						else
 		                    RefLuma [nCol - 1] = satcolor.GetLuminance();
 						break;
@@ -3358,7 +3373,11 @@ CString CMainView::GetItemText(CColor & aMeasure, double YWhite, CColor & aRefer
 							if ((GetConfig()->m_CCMode >= MASCIOR50 && GetConfig()->m_CCMode <= CCMAXHDR) && m_displayMode == 11)
 								white.SetY(GetDocument()->GetMeasure()->GetGray((GetDocument()->GetMeasure()->GetGrayScaleSize()-1)).GetY());
 							else
-								white.SetY(94.37844);
+								// Unified convention: references are GetHDRRefScale-scaled
+								// (1.0 = tone-mapped diffuse white), so normalize the
+								// measurement by the same white. The delta-luminance ratio
+								// is unchanged (both sides reduce to meas / (ref * 10000)).
+								white.SetY(tmWhite);
 					}
 				}
 
@@ -4301,9 +4320,15 @@ void CMainView::UpdateGrid()
 				}
 				else
 				{
-					refColor.SetX((refColor.GetX() * 105.95640));
-					refColor.SetY((refColor.GetY() * 105.95640));
-					refColor.SetZ((refColor.GetZ() * 105.95640));
+					// Unified HDR rescale: GetHDRRefScale (tone-map aware, matches
+					// the 3D viewer; = 105.95640 with tone mapping off). The manual
+					// generator (DVD) keeps the legacy fixed scale - its GetItemText
+					// white terms still use the 94.37844/tmWhite conventions.
+					double s = ( GetConfig()->GetGeneratorType() == CColorHCFRConfig::enumManual )
+							 ? 105.95640 : GetDocument()->GetMeasure()->GetHDRRefScale();
+					refColor.SetX((refColor.GetX() * s));
+					refColor.SetY((refColor.GetY() * s));
+					refColor.SetZ((refColor.GetZ() * s));
 				}
 			}
 
@@ -6713,18 +6738,16 @@ void CMainView::SelectProfilePatch(int idx)
 	m_YWhite = ( w.isValid () && w.GetY () > 0.0 ) ? w.GetY () : 1.0;
 
 	// PQ HDR: GetRefProfileSat produces the internal HDR-10 scale (1.0 = 10000
-	// nits). The grid applies * 105.95640 (10000 / 94.37844) to CC/sat refs
-	// before handing them to the comparator widgets (GetItemText, ~line 4280);
-	// mode 13 bypasses the grid, so apply the same bridge here, including the
-	// tone-mapped YWhite adjust the CC24 path uses.
+	// nits). The grid applies GetHDRRefScale (= 105.95640 with tone mapping
+	// off) to CC/sat refs before handing them to the comparator widgets
+	// (UpdateGrid, ~line 4294); mode 13 bypasses the grid, so apply the same
+	// bridge here. Unified convention: the measured white stays unrescaled.
 	if ( GetConfig()->m_GammaOffsetType == 5 )
 	{
-		m_RefColor.SetX( m_RefColor.GetX() * 105.95640 );
-		m_RefColor.SetY( m_RefColor.GetY() * 105.95640 );
-		m_RefColor.SetZ( m_RefColor.GetZ() * 105.95640 );
-		double tmWhite = TmDiffuseWhiteNits( noDataColor, noDataColor );
-		if ( tmWhite > 0.0 )
-			m_YWhite = m_YWhite * 94.37844 / tmWhite;
+		double s = pMeasure->GetHDRRefScale();
+		m_RefColor.SetX( m_RefColor.GetX() * s );
+		m_RefColor.SetY( m_RefColor.GetY() * s );
+		m_RefColor.SetZ( m_RefColor.GetZ() * s );
 	}
 
 	if ( sel.isValid () )

--- a/Views/SatLumShiftView.cpp
+++ b/Views/SatLumShiftView.cpp
@@ -616,15 +616,18 @@ void CSatLumShiftGrapher::GetSatShift ( double & satshift, double & deltaE, cons
 
 	if (GetConfig()->m_GammaOffsetType == 5)
 	{
+		// Unified HDR convention (matches the measures grid and the 3D viewer):
+		// references scaled by GetHDRRefScale (= 105.95640 with tone mapping
+		// off), measured white unrescaled.
 		double tmWhite = TmDiffuseWhiteNits(White, Black);
-		aColor.SetX(aColor.GetX() * 105.95640);
-		aColor.SetY(aColor.GetY() * 105.95640);
-		aColor.SetZ(aColor.GetZ() * 105.95640);
-		aColore.SetX(aColore.GetX() * 105.95640);
-		aColore.SetY(aColore.GetY() * 105.95640);
-		aColore.SetZ(aColore.GetZ() * 105.95640);
+		double s = pDoc->GetMeasure()->GetHDRRefScale();
+		aColor.SetX(aColor.GetX() * s);
+		aColor.SetY(aColor.GetY() * s);
+		aColor.SetZ(aColor.GetZ() * s);
+		aColore.SetX(aColore.GetX() * s);
+		aColore.SetY(aColore.GetY() * s);
+		aColore.SetZ(aColore.GetZ() * s);
 		RefWhite = YWhite / (tmWhite) ;
-		YWhite = YWhite * 94.37844 / (tmWhite);
 	}
 	
 	deltaE = SatColor.GetDeltaE(YWhite, aColore, RefWhite, isSpecial?CColorReference(HDTV, D65):(GetColorReference().m_standard==UHDTV3||GetColorReference().m_standard == UHDTV4)?CColorReference(UHDTV2):GetColorReference() , GetConfig()->m_dE_form, false, GetConfig()->gw_Weight );

--- a/tests/ACCURACYTEST.md
+++ b/tests/ACCURACYTEST.md
@@ -7,8 +7,8 @@ app's **references** (CMeasure `GetRefPrimary` / `GetRefSecondary` /
 (the exact patch codes the generators emit) exactly, by pushing those codes
 through `CSimulatedSensor` (error injection off) and asserting dE ~ 0 with the
 **same normalization the measures grid uses** (`CMainView::UpdateGrid` +
-`GetItemText`: the HDR `105.95640` / `GetHDRRefScale` rescales, the
-`tmWhite`-based `RefWhite`, the `YWhite * 94.37844 / tmWhite` rescale, the
+`GetItemText`: the unified HDR `GetHDRRefScale` reference rescale
+(= `105.95640` with tone mapping off), the `tmWhite`-based `RefWhite`, the
 per-view YWhite source — gray-ramp top, PrimeWhite, or OnOff white).
 
 ## Relation to `tests\ColorMathTest`
@@ -88,6 +88,38 @@ measured gray top as White; then primaries, which set PrimeWhite):
   indices 0..70) via `GenerateCC24Colors`. AXIS covers the clipped-ramp-top
   cases in PQ: patches above `m_TargetMaxL` must STILL read dE ~ 0 because
   the reference models the same per-channel clip.
+- `convPV` — pane-vs-viewer dE **convention equality** (PQ mode-5 combos
+  only; `-1.000` = not run). The wire-model families read dE ~ 0 under *any*
+  self-consistent normalization, so they cannot see a convention split. This
+  family perturbs each sat/CC measurement (fixed asymmetric XYZ gains, a few
+  dE of luminance + chroma error) and asserts the measures-grid formula and
+  the 3D-viewer formula produce the **same** dE. It guards three axes that
+  drifted apart historically: the HDR reference **rescale**, the **white**
+  the dE normalizes by (`CMeasure::GetColorDEWhiteY` — the measured white, not
+  the theoretical `TmDiffuseWhiteNits`), and the **dE evaluation space**
+  (transport space for the UHDTV3/4 pseudo-spaces). Because it also
+  recomputes the white through the shared helper, it fails if that helper
+  drifts from the grid's own YWhite selection. The ideal sensor's prime white equals
+  `TmDiffuseWhiteNits` exactly, so matched conventions agree to machine
+  precision — hence a dedicated **0.005** tolerance: the legacy fixed
+  `105.95640` pane rescale reads 0.015–0.023 here (small in absolute dE
+  because a common normalizer shift largely cancels inside a dE
+  difference), which the default 0.05 would let back in.
+  **Known blind spot:** the ideal sensor's measured white lands exactly on
+  `TmDiffuseWhiteNits`, so a *white-source* divergence is invisible to this
+  harness — the viewer's old theoretical-white normalization passed convPV
+  while reading ~1% off the grid on a real display whose white missed target
+  by 3.5% (found by hand, grid 8.80 vs viewer 8.72). The guard against that
+  class is structural, not numerical: both sides now call
+  `CMeasure::GetColorDEWhiteY`, so there is one definition to drift.
+  Tone-map-ON combos run at `TargetMaxL = 300` nits — BT.2390's
+  knee (`KS = 1.5*PQ(Lmax) - 0.5`) then falls below the 50.23%
+  diffuse-white code, so tone mapping actually compresses diffuse white and
+  a convention split becomes visible (at 700 nits the knee sits ~245 nits
+  and diffuse white passes through untouched). HDTVa/b are excluded: the
+  grid normalizes their sat/CC dE to the measured ON/OFF (peak) white while
+  the viewer uses the tone-mapped diffuse white — a separate legacy
+  divergence.
 
 ## Reading the report
 
@@ -172,6 +204,61 @@ run is reported as STALE. Current entries (expected, pre-existing):
   full-range re-snap to 255/1023 is unmodeled (≤ ~0.4 dE, worst at the PQ
   8-bit knee). Fixing requires a range parameter through libHCFR, which
   moves ColorMathTest T2/T3 goldens — out of scope here.
+
+## Coverage gaps — what this harness structurally cannot see
+
+Known-fails above are *modeling* gaps the harness detects and tolerates. The
+gaps below are different and more dangerous: configurations and code paths the
+harness never reaches, so a real dE bug in them reads **green**. Every dE bug
+found by hand during the 2026-07 HDR rescale unification lived in one of these.
+
+**The root limitation.** The core assertion is "a perfect display measures its
+own reference, dE ~ 0". That invariant holds under *any* self-consistent
+normalization, so it cannot distinguish two conventions that disagree — it only
+catches a reference that stops modeling the wire. The `convPV` family exists to
+cover exactly that hole (perturb the measurement, require two formulas to
+agree), and the gaps below are mostly places `convPV`'s reach stops.
+
+1. **The ideal sensor's white is exactly `TmDiffuseWhiteNits`.** The 50.22831%
+   wire code and the helper's snapped `0.5022283` land on the same grid code, so
+   measured white == theoretical white *by construction*. Any divergence in
+   which white a consumer normalizes by is therefore invisible. This is how the
+   3D viewer shipped a ~1% dE offset vs the grid that only appears on a display
+   whose white misses target (found by hand: grid 8.80 vs viewer 8.72).
+   *Needs:* a combo axis that perturbs the measured white away from the
+   theoretical one (a gain error injected into the white patches only).
+2. **The manual generator (DVD) is never configured.** `RunAccuracyTest` sets
+   `enumAutomatic` unconditionally, so every `if (DVD)` carve-out — in
+   `GetItemText`, `UpdateGrid`, `InitGrid`, `RGBLevelWnd`, and the Export
+   blocks — is untested. Two real bugs hid there.
+3. **Mascior HDR CC sets are never run.** `RunCC` is only called with `GCD` and
+   `AXIS`; the whole `m_CCMode in [MASCIOR50..CCMAXHDR]` family (its `* 100`
+   reference scale and grayscale-top white) has zero coverage in the harness,
+   in `GetColorDEWhiteY`, and in the viewer.
+4. **`bSpecial` (HDTVa/HDTVb) is excluded from `convPV`.** The exclusion
+   predates the white unification and its stated rationale is now stale — the
+   viewer passes `satSpecial` today, so these could be covered.
+5. **Whites are always present.** The run order is always gray → primaries →
+   sat/CC, so `PrimeWhite`/`OnOffWhite` are always valid and the grid's
+   `m_TargetMaxL` fallback path is never exercised.
+6. **The display/comparator layer is not modeled at all.** `CMainView::OnUpdate`'s
+   `Yref` formulas, the RGB-levels bars and the target widget do dE-adjacent
+   math on `m_RefColor`/`m_RefWhite`/`m_YWhite`. A wrong factor there is
+   user-visible (swatches disagree while dE reads 0) and completely invisible
+   here.
+7. **`convPV` compares two harness-local copies.** It *emulates* the viewer's
+   formula rather than calling it, so changing `C3DColorView::BuildScene`
+   without editing `AccuracyTest.cpp` still reads 0.000. Only the white is
+   genuinely shared (`CMeasure::GetColorDEWhiteY`); the reference scale and the
+   dE evaluation space are re-derived. Extracting the whole normalization into
+   one `CMeasure` helper that the grid, the viewer and the harness all call
+   would make the lock real.
+8. **Export is never exercised.** The PDF/CSV/spreadsheet dE paths duplicate the
+   grid's normalization and have already drifted from it.
+9. **Hard-clip coverage is tone-map-OFF only.** Tone-map-ON combos run at
+   `TargetMaxL = 300`, where BT.2390 rolls off instead of clipping, so the
+   "clipped patches still read dE ~ 0" invariant is only checked on the
+   tone-map-OFF half of the matrix.
 
 Reference result (2026-07-13, first full run after the fixes):
 `708 combos: 311 pass, 0 FAIL, 397 known-fail`, ColorMathTest verify green


### PR DESCRIPTION
## What

ColorHCFR had two conventions for rescaling PQ-HDR (mode 5) references:

1. **Grid/pane** — a fixed `*105.95640`, with tone mapping folded into the `GetDeltaE` white terms (`YWhite = YWhite*94.37844/tmWhite`).
2. **3D viewer** — `CMeasure::GetHDRRefScale()` = `10000 / tone-mapped diffuse white`.

They are identical with tone mapping **off** and diverge with it **on**, so profile tails were not proportional to the pane's dE, and sat/CC viewer dE could disagree with the grid for the same patch.

This converges everything on `GetHDRRefScale()`, per the direction settled in the PR #154 review.

## The transformation

At each GDI-wire site: scale the reference by `GetHDRRefScale()`, **keep** `RefWhite = YWhite / tmWhite`, and **delete** the paired `YWhite = YWhite * 94.37844 / tmWhite`. That is algebraically a no-op with tone mapping off — both forms reduce to comparing `ref*10000/YWhite` against `meas/YWhite` — which the harness confirms bit-identical on the limited-range grids.

Migrated: the measures-grid CC24/sat dE and reference rescale, the delta-luminance row, the CC swatch, the `OnUpdate` comparator formulas, `SelectProfilePatch` and the live mode-13 comparator, `ComputeProfileDE`, `RGBLevelWnd`, `SatLumShiftView`, three `Export` CC blocks, and the CIE-chart sat tooltip.

**Deliberately left legacy:** the manual-generator (DVD) branches and their 92.25/0.50-anchor quirks, the `displayMode == 1` primaries branches, and the Mascior HDR CC sets' `*100`.

## Two more splits, found by hand

Hand testing an HDR10 capture surfaced two further pane-vs-viewer divergences that the harness could not see. Both are fixed here:

- **dE white normalizer.** The viewer normalized sat/CC dE by the *theoretical* tone-mapped white while the grid uses the *measured* white. dE scales as `(YWhite/tmWhite)^(1/3)`, so a display 3.5% off target read **grid 8.80 vs viewer 8.72**. Adds the shared `CMeasure::GetColorDEWhiteY()` and moves the viewer onto it. Marker geometry still uses `GetHDRRefScale`, so a perfect patch draws no tail. Worth noting SDR already used the measured white — the HDR branch was the outlier.
- **dE evaluation space.** The viewer evaluated color dE in the pseudo-space for UHDTV3/4 where the grid uses the transport space. Now matched, gated on `!isGS` so grayscale keeps the active reference like the grid's grayscale branch. (Numerically a no-op today — `ContainerTransportReference` preserves the active white and `ColorLab` only reads the white — but it stops the two from drifting.)

## Harness

A 7th `convPV` family asserts **pane dE == viewer dE** on a perturbed patch (tolerance 0.005, PQ only), guarding the reference rescale, the dE white, and the dE evaluation space. Tone-map-ON combos run at `TargetMaxL = 300`, because BT.2390's knee only compresses diffuse white below ~316 nits — at 700 the conventions coincide and the check proves nothing.

`ACCURACYTEST.md` gains a **"Coverage gaps"** section. The honest limitation: the harness asserts `dE ~ 0`, which holds under *any* self-consistent normalization, so it cannot tell two conventions apart — and the ideal sensor's white equals `TmDiffuseWhiteNits` by construction, which is exactly why the white-normalizer bug passed. The guard there is structural (one shared helper), not numerical.

## Review fixes

An xhigh multi-agent review of this change set found 15 issues; 13 are fixed here, including six bugs introduced by the change itself:

- a spurious `/tmWhite` on the measured-side comparator `Yref` (three independent angles caught it)
- the Mascior CC sets swallowed by the new comparator branch
- mode-13 dE dividing by the DVD-clobbered `tmWhite`
- the Export CC blocks losing the manual-generator carve-out the grid keeps
- an unguarded `TmDiffuseWhiteNits` divisor in `RGBLevelWnd`
- two harness defects (ConvCheck's pane side omitting the Mascior scale; an unguarded white reaching `GetDeltaE`)

Two skipped as needing their own validation: unifying `ComputeProfileDE`'s duplicate white selection (changes profile dE for HDTVa/b and standalone captures), and restoring hard-clip coverage under tone mapping (needs tone-map-ON combos at both 300 and 700).

## Validation

- `/accuracytest`: **708 combos: 311 pass, 0 FAIL, 397 known-fail** — unchanged from main. `convPV` 0.000 across the matrix.
- `ColorMathTest verify`: **ALL TESTS PASSED**, no golden movement.
- Legacy-vs-unified report diff: known-fail magnitudes move by at most ±0.03 dE; tone-map-off rows bit-identical on the limited-range grids.
- Manual HDR10 tone-mapped capture (Rec.2020, 82-nit tone-mapped diffuse white): CC reads all zeros on the simulated sensor, and pane and 3D viewer now report the same dE for the same patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
