### PR TITLE
3D viewer: sync selection from the measures grid

### DIFF
--- a/Views/Color3DView.cpp
+++ b/Views/Color3DView.cpp
@@ -181,6 +181,7 @@ C3DColorView::C3DColorView()
 	, m_pointColor(PTCOLOR_DE), m_deFilter(0), m_showTails(true), m_showProfilePts(true)
 	, m_bDragging(false)
 	, m_selected(-1)
+	, m_reqType(-1), m_reqA(0), m_reqB(0), m_reqC(0)
 	, m_orbKernelR(-1)
 	, m_memDC(NULL), m_memBmp(NULL), m_oldBmp(NULL), m_bits(NULL), m_bw(0), m_bh(0)
 	, m_cx(0), m_cyc(0), m_scale(0), m_ry(1), m_rsy(0), m_rp(1), m_rsp(0)
@@ -1280,6 +1281,7 @@ void C3DColorView::Render(const CRect& rc)
 	{
 		BuildScene();
 		m_sceneDirty = false;
+		ResolvePendingSelection();   // BuildScene cleared m_selected and renumbered m_points
 	}
 
 	// Clear colour + depth: at fullscreen this touches ~2M pixels per buffer per
@@ -1730,23 +1732,86 @@ void C3DColorView::AppendNewProfileMeasures()
 	m_profileInScene = lastAppended;
 }
 
-void C3DColorView::SelectProfilePoint(int patchIdx)
+// Consume a pending selection request: find the point matching the requested
+// identity in the CURRENT scene, or clear the selection if it has no point.
+// One-shot by design -- see the m_reqType comment in the header.
+void C3DColorView::ResolvePendingSelection()
 {
-	m_showProfilePts = true;   // an explicit inspect un-hides the layer so the halo is visible
+	if ( m_reqType < 0 )
+		return;
+
+	// A point the user cannot click is a point the grid cannot halo either:
+	// same visibility rules as the hit test in OnLButtonUp, so a filtered-out
+	// point never gets a halo ring with no orb under it.
+	double deThr = -1.0;
+	if ( m_deFilter > 0 )
+	{
+		double good, warn;
+		GetConfig()->GetDEThresholds( good, warn );
+		deThr = ( m_deFilter == 1 ) ? good : warn;
+	}
+
+	m_selected = -1;
 	for ( size_t i = 0; i < m_points.size(); i++ )
 	{
-		if ( m_points[i].srcType == SRC_PROFILE && m_points[i].srcA == patchIdx )
-		{
-			m_selected = (int)i;
-			if ( ::IsWindow( m_hWnd ) )
-				Invalidate( FALSE );
-			return;
-		}
+		const ScenePoint & P = m_points[i];
+		if ( P.srcType != (BYTE)m_reqType || P.srcA != (short)m_reqA
+		  || P.srcB != (short)m_reqB || P.srcC != (short)m_reqC )
+			continue;
+		if ( !m_showProfilePts && P.srcType == SRC_PROFILE )
+			break;   // hidden layer
+		if ( deThr >= 0.0 && P.hasTarget && P.dE < deThr )
+			break;   // hidden by the dE filter
+		m_selected = (int)i;
+		break;
 	}
+	m_reqType = -1;   // consumed
+}
+
+// Halo the point matching a measurement's identity: the grid -> viewer half of
+// the selection sync, driven by CMainView::OnGrayScaleGridEndSelChange.
+// srcType < 0 clears. Resolving is deferred when the scene is stale, so a
+// selection made before the rebuild still lands at the next paint.
+void C3DColorView::SelectMeasurePoint(int srcType, int srcA, int srcB, int srcC)
+{
+	if ( srcType == SRC_PROFILE )
+		m_showProfilePts = true;   // an explicit inspect un-hides the layer so the halo is visible
+
+	if ( srcType < 0 )
+	{
+		m_selected = -1;           // an explicit clear needs no scene
+		m_reqType  = -1;
+	}
+	else
+	{
+		m_reqType = srcType;
+		m_reqA    = srcA;
+		m_reqB    = srcB;
+		m_reqC    = srcC;
+		// m_sceneDirty starts TRUE, so this alone means "the scene is current".
+		// Deliberately NOT also gated on m_points being non-empty: a request
+		// left pending against an up-to-date empty scene would sit there and
+		// fire at some later unrelated rebuild, haloing a measurement the user
+		// never picked. An up-to-date scene without the point means "no point".
+		if ( !m_sceneDirty )
+			ResolvePendingSelection();   // otherwise the pending rebuild consumes it
+	}
+	if ( ::IsWindow( m_hWnd ) )
+		Invalidate( FALSE );
+}
+
+void C3DColorView::SelectProfilePoint(int patchIdx)
+{
+	SelectMeasurePoint( SRC_PROFILE, patchIdx );
 }
 
 void C3DColorView::OnUpdate(CView* /*pSender*/, LPARAM lHint, CObject* /*pHint*/)
 {
+	if ( lHint == UPD_SELECTEDCOLOR )
+		return;   // selection-only hint: no measurement changed, so a rebuild here
+				  // would only throw away the halo the grid just asked for. (The
+				  // dE_gray toggles that also send it broadcast UPD_GRAYSCALE first,
+				  // so a real data change still dirties the scene.)
 	if ( lHint == UPD_FREEMEASUREAPPENDED && !m_sceneDirty && !m_points.empty() )
 	{
 		AppendNewFreeMeasures();
@@ -1871,6 +1936,7 @@ void C3DColorView::OnLButtonUp(UINT nFlags, CPoint point)
 					best     = (int)k;
 				}
 			}
+			m_reqType  = -1;     // a direct click supersedes any queued grid selection
 			m_selected = best;   // -1 (empty space) clears the selection
 			if ( best >= 0 )
 				PushSelectionToMainView( m_points[best] );

--- a/Views/Color3DView.h
+++ b/Views/Color3DView.h
@@ -64,6 +64,17 @@ public:
 	// 1 = hide points below the "good" threshold, 2 = below "warn"
 	// (thresholds read live from the configured tolerance preset).
 	void SetDEFilter(int filter);
+
+	// Which CMeasure array a point came from (so a click can re-fetch the
+	// original CColor, spectrum included, and push it to the main view).
+	// Public because CMainView maps a selected grid column back to one of
+	// these to drive SelectMeasurePoint.
+	enum PointSource { SRC_GRAY = 0, SRC_NEARBLACK, SRC_NEARWHITE, SRC_PRIMARY,
+					   SRC_SECONDARY, SRC_SAT, SRC_CC24, SRC_FREE, SRC_PROFILE };
+
+	// Halo the point a measurement identity resolves to -- the grid -> viewer
+	// half of the selection sync. srcType < 0 (or no matching point) clears it.
+	void SelectMeasurePoint(int srcType, int srcA, int srcB = 0, int srcC = 0);
 	void SelectProfilePoint(int patchIdx);	// halo a profile patch (summary-pane click)
 
 protected:
@@ -72,11 +83,6 @@ protected:
 	virtual ~C3DColorView();
 
 	// ---- scene: measured points in model space (roughly a unit cube) ----
-	// Which CMeasure array a point came from (so a click can re-fetch the
-	// original CColor, spectrum included, and push it to the main view).
-	enum PointSource { SRC_GRAY = 0, SRC_NEARBLACK, SRC_NEARWHITE, SRC_PRIMARY,
-					   SRC_SECONDARY, SRC_SAT, SRC_CC24, SRC_FREE, SRC_PROFILE };
-
 	struct ScenePoint
 	{
 		float mx, my, mz;     // measured position
@@ -155,6 +161,15 @@ protected:
 	CPoint m_lastMouse;
 	CPoint m_downPos;             // to tell a click (select) from a drag (rotate)
 	int    m_selected;            // index into m_points, -1 = none
+	// One-shot pending selection: the IDENTITY of a point to halo, queued when
+	// an external selector (the measures grid) arrives while the scene is stale,
+	// and consumed by the next build. Deliberately NOT persistent state -- an
+	// identity kept across rebuilds re-attaches to whatever later occupies the
+	// same array index (measurements shift on delete, and the saturation level
+	// store renumbers on insert), haloing data the user never picked.
+	// m_reqType < 0 = nothing pending.
+	int    m_reqType, m_reqA, m_reqB, m_reqC;
+	void   ResolvePendingSelection();
 
 	// ---- backbuffer: a top-down 32-bit DIB section + its memory DC ----
 	HDC     m_memDC;

--- a/Views/MainView.cpp
+++ b/Views/MainView.cpp
@@ -5643,6 +5643,86 @@ void CMainView::OnGrayScaleGridEndSelChange(NMHDR *pNotifyStruct,LRESULT* pResul
 	}
 	GetDocument()->UpdateAllViews(this, UPD_SELECTEDCOLOR);
 //	(CMDIFrameWnd *)AfxGetMainWnd()->SendMessage(WM_COMMAND,IDM_REFRESH_CONTROLS,NULL);	// refresh mainframe controls
+
+	// Grid -> 3D viewer half of the selection sync: map the selected column back
+	// to the scene point's source identity (the inverse of the mapping in
+	// C3DColorView::PushSelectionToMainView) and halo it in any live 3D view.
+	// A multi-column or row-header selection resolves to nothing and clears it.
+	// Nothing below runs without a 3D view: the saturation branch has to sync
+	// the stimulus-level store, which is not work a selection should be doing.
+	BOOL bHas3DView = FALSE;
+	POSITION posFind = GetDocument()->GetFirstViewPosition();
+	while ( posFind != NULL && !bHas3DView )
+	{
+		CView * pView = GetDocument()->GetNextView ( posFind );
+		bHas3DView = ( pView != NULL && pView->IsKindOf ( RUNTIME_CLASS ( C3DColorView ) ) );
+	}
+	if ( !bHas3DView )
+		return;
+
+	int srcType = -1, srcA = 0, srcB = 0, srcC = 0;
+	if ( maxCol == minCol && minCol >= 1 )
+	{
+		switch ( m_displayMode )
+		{
+			case 0:  srcType = C3DColorView::SRC_GRAY;      srcA = minCol - 1; break;
+
+			case 1:  if ( minCol < 4 )
+					 {
+						srcType = C3DColorView::SRC_PRIMARY;
+						srcA = minCol - 1;
+					 }
+					 else if ( minCol < 7 )
+					 {
+						srcType = C3DColorView::SRC_SECONDARY;
+						srcA = minCol - 4;
+					 }
+					 break;	// white (7) and black (8) have no scene point
+
+			case 2:  srcType = C3DColorView::SRC_FREE;      srcA = minCol - 1; break;
+
+			case 3:  srcType = C3DColorView::SRC_NEARBLACK; srcA = minCol - 1; break;
+
+			case 4:  srcType = C3DColorView::SRC_NEARWHITE; srcA = minCol - 1; break;
+
+			case 5: case 6: case 7: case 8: case 9: case 10:
+				 {
+					// The scene holds every measured stimulus level, so the
+					// identity also needs the store index of the bound one.
+					CMeasure * pSatMeasure = GetDocument()->GetMeasure();
+					int nLevels = pSatMeasure->GetSatLevelCount();
+					double activeLevel = pSatMeasure->GetActiveSatLevel();
+					srcType = C3DColorView::SRC_SAT;
+					srcA = minCol - 1;
+					srcB = m_displayMode - 5;	// 0=R 1=G 2=B 3=Y 4=C 5=M
+					srcC = -1;					// matches nothing if the bound level is absent
+					for ( int l = 0 ; l < nLevels ; l ++ )
+					{
+						// 1e-4 is the store's own notion of "same level"
+						// (FindSatLevelIndex); a tighter compare could miss.
+						if ( fabs ( pSatMeasure->GetSatLevelAt ( l ) - activeLevel ) < 1e-4 )
+						{
+							srcC = l;
+							break;
+						}
+					}
+				 }
+				 break;
+
+			case 11: srcType = C3DColorView::SRC_CC24;      srcA = minCol - 1; break;
+
+			// 12 (contrast) has no scene points; 13 (display profile) has no grid --
+			// there the profile pane's inspect drives the viewer (OnProfilePaneAction).
+		}
+	}
+
+	POSITION pos3D = GetDocument()->GetFirstViewPosition();
+	while ( pos3D != NULL )
+	{
+		CView * pView = GetDocument()->GetNextView ( pos3D );
+		if ( pView != NULL && pView->IsKindOf ( RUNTIME_CLASS ( C3DColorView ) ) )
+			( (C3DColorView *) pView )->SelectMeasurePoint ( srcType, srcA, srcB, srcC );
+	}
 }
 
 void CMainView::OnXyzRadio() 


### PR DESCRIPTION
Clicking a point in the 3D viewer already selected the matching measurement and synced the measures grid. The reverse did not exist — selecting a patch in the grid left the viewer untouched. This adds that direction.

## What it does

`CMainView::OnGrayScaleGridEndSelChange` maps the selected column back to a scene point's source identity — the exact inverse of the mapping in `C3DColorView::PushSelectionToMainView` — and pushes it to every live `C3DColorView`, so it works for the info pane and a full 3D tab alike.

| grid mode | scene point |
|---|---|
| 0 / 2 / 3 / 4 | gray / free / near-black / near-white, `srcA = nCol-1` |
| 1 | cols 1-3 primaries, cols 4-6 secondaries (white/black have no point) |
| 5-10 | `SRC_SAT`: step, hue, and the bound stimulus level's store index |
| 11 | `SRC_CC24` patch |
| 12 / 13 | no scene points / no grid — the profile pane drives mode 13 |

## Design notes

**The selection is queued as the point's identity, not its index, and it is one-shot.** `BuildScene()` renumbers `m_points`, and a grid click can land while the scene is stale, so an index is not durable. But persisting the identity across rebuilds is worse: it re-attaches the halo to whatever later occupies the same array index. `CArray::RemoveAt` shifts measurements down on delete, and `StoreActiveSatLevel` inserts into a sorted vector, renumbering the saturation level store — both produced a confident halo and readout sitting on data the user never picked. The request is consumed by the next build and cleared, so `BuildScene`'s clear-on-rebuild stays authoritative.

**Resolving mirrors the hit test in `OnLButtonUp`**, so a point hidden by the dE filter is not selectable from the grid either. Without this the grid drew a halo ring and a readout panel over empty space with no orb under it.

**`C3DColorView::OnUpdate` now ignores `UPD_SELECTEDCOLOR`.** It carries no measurement change, and rebuilding on it threw away the halo the grid had just asked for. The two `dE_gray` togglers that also send it broadcast `UPD_GRAYSCALE` first, so a real data change still dirties the scene. Side benefit: no full scene rebuild on every grid click, which matters for a dense profile cube.

**No feedback loop.** `GVN_SELCHANGED` is emitted only from mouse, keyboard, and Edit→Select All — never from `SetSelectedRange` — so the existing viewer→grid direction cannot bounce back through the new handler.

**Nothing runs when no 3D view is open**, because the saturation branch has to sync the stimulus-level store, and that is not work a selection handler should be doing.

`SelectProfilePoint` now delegates to the new `SelectMeasurePoint`, fixing a latent bug of its own: it searched a stale `m_points` when the scene was dirty, and the rebuild then wiped the index it had just set.

## Testing

Built Debug|Win32, 0 errors, no new warnings. Verified on screen that clicking a near-black column halos the matching point — measured x/y in the viewer readout match the grid cell exactly.

## Not in this PR

Three pre-existing dE bugs surfaced while testing this (the sync makes grid and viewer numbers directly comparable for the first time). All predate this change and are being fixed separately, with `/validate`:

1. Viewer near-black dE is ~100x too large — the near-black block hard-codes the dE target to `Y = 1.0` and ignores `m_dE_gray`, evaluating the chromaticity error as if the patch were full white.
2. Free-measures dE shows ~100 for unrecognised patches — the chromaticity-matching chain has no final `else`, so they fall through to D65 white at `Y = 1.0`.
3. HDR grayscale target markers are plotted at ~1/122 of their true height (`L / 100.0` where `getL_EOTF` already returns nits/100).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
