### PR TITLE
/accuracytest: close the coverage gaps a green matrix could not see

### DIFF
--- a/AccuracyTest.cpp
+++ b/AccuracyTest.cpp
@@ -214,6 +214,7 @@ struct KnownFail
 #define GRID_ANY   0xF
 #define GRID_8LIM  0x1	// kGrids[0]
 #define GRID_FULL  0xA	// kGrids[1] (8b-full) | kGrids[3] (10b-full)
+#define GRID_LIM   0x5	// kGrids[0] (8b-lim) | kGrids[2] (10b-lim)
 
 // The `ceiling` on each entry bounds the known gap: a matching combo is only
 // downgraded to KNOWN-FAIL while its worst dE stays <= ceiling; a larger dE is
@@ -297,15 +298,24 @@ static const KnownFail kKnownFails[] =
 	// measured white alone, so the full 105.95640-vs-10000/92.254965 reference
 	// offset - 2.25% - survives: observed 0.49-0.70. Branch B additionally
 	// rescales YWhite by 94.37844/tmWhite, which very nearly cancels it:
-	// observed 0.02-0.07. Split ceilings so a regression in the near-cancelling
-	// half cannot hide under the other half's headroom.
-	{ HDTV,   -1, 5, -1, GRID_ANY, 1, 1.5, "manual generator: grid keeps the legacy DVD HDR conventions, the 3D viewer has no DVD branch (GetItemText ~3103 vs Color3DView BuildScene)" },
-	{ UHDTV,  -1, 5, -1, GRID_ANY, 1, 1.5, "manual generator: grid keeps the legacy DVD HDR conventions, the 3D viewer has no DVD branch (GetItemText ~3103 vs Color3DView BuildScene)" },
-	{ UHDTV2, -1, 5, -1, GRID_ANY, 1, 1.5, "manual generator: grid keeps the legacy DVD HDR conventions, the 3D viewer has no DVD branch (GetItemText ~3103 vs Color3DView BuildScene)" },
-	{ UHDTV3, -1, 5, -1, GRID_ANY, 1, 0.3, "manual generator: DVD YWhite * 94.37844/tmWhite rescale nearly cancels the fixed 105.95640, the 3D viewer applies neither" },
-	{ UHDTV4, -1, 5, -1, GRID_ANY, 1, 0.3, "manual generator: DVD YWhite * 94.37844/tmWhite rescale nearly cancels the fixed 105.95640, the 3D viewer applies neither" },
-	{ HDTVa,  -1, 5, -1, GRID_ANY, 1, 0.3, "manual generator: DVD YWhite * 94.37844/tmWhite rescale nearly cancels the fixed 105.95640, the 3D viewer applies neither" },
-	{ HDTVb,  -1, 5, -1, GRID_ANY, 1, 0.3, "manual generator: DVD YWhite * 94.37844/tmWhite rescale nearly cancels the fixed 105.95640, the 3D viewer applies neither" },
+	// observed 0.02-0.07.
+	//
+	// LIMITATION, deliberately recorded rather than papered over: these ceilings
+	// are keyed on color SPACE, but the two sub-branches are selected by
+	// displayMode - and RunSats and RunCC both accumulate into the SAME
+	// stats[FAM_CONV]/[FAM_CONVW], which keeps only the worst. So for
+	// HDTV/UHDTV/UHDTV2, where branch A reaches ~0.70, a branch-B (color
+	// checker) regression is hidden until it exceeds 1.5. Separating them needs
+	// per-displayMode FamStats, which is a bigger change than this entry table.
+	// The four spaces that only ever take branch B get the tight 0.3 ceiling and
+	// are fully protected.
+	{ HDTV,   -1, 5, -1, GRID_LIM, 1, 1.5, "manual generator: grid keeps the legacy DVD HDR conventions, the 3D viewer has no DVD branch (GetItemText ~3103 vs Color3DView BuildScene)" },
+	{ UHDTV,  -1, 5, -1, GRID_LIM, 1, 1.5, "manual generator: grid keeps the legacy DVD HDR conventions, the 3D viewer has no DVD branch (GetItemText ~3103 vs Color3DView BuildScene)" },
+	{ UHDTV2, -1, 5, -1, GRID_LIM, 1, 1.5, "manual generator: grid keeps the legacy DVD HDR conventions, the 3D viewer has no DVD branch (GetItemText ~3103 vs Color3DView BuildScene)" },
+	{ UHDTV3, -1, 5, -1, GRID_LIM, 1, 0.3, "manual generator: DVD YWhite * 94.37844/tmWhite rescale nearly cancels the fixed 105.95640, the 3D viewer applies neither" },
+	{ UHDTV4, -1, 5, -1, GRID_LIM, 1, 0.3, "manual generator: DVD YWhite * 94.37844/tmWhite rescale nearly cancels the fixed 105.95640, the 3D viewer applies neither" },
+	{ HDTVa,  -1, 5, -1, GRID_LIM, 1, 0.3, "manual generator: DVD YWhite * 94.37844/tmWhite rescale nearly cancels the fixed 105.95640, the 3D viewer applies neither" },
+	{ HDTVb,  -1, 5, -1, GRID_LIM, 1, 0.3, "manual generator: DVD YWhite * 94.37844/tmWhite rescale nearly cancels the fixed 105.95640, the 3D viewer applies neither" },
 };
 
 static bool s_knownFailFired[sizeof(kKnownFails)/sizeof(kKnownFails[0])] = { false };
@@ -413,6 +423,30 @@ static CColor Meas ( CSimulatedSensor & sensor, const ColorRGBDisplay & rgb, dou
 static CColorReference *	s_pGridDERef = NULL;	// GetItemText's bRef
 static CColorReference *	s_pViewDERef = NULL;	// AppendMeasure's dERef
 
+// UpdateGrid's sat/CC YWhite selection, whole chain (MainView.cpp ~3686-3706
+// then ~3814-3826): the special standards read the ON/OFF white, everyone else
+// the prime white - but prime falls back to ON/OFF when it was never measured,
+// and both fall back to m_TargetMaxL. Reading GetPrimeWhite().GetY() directly
+// (as this used to) skips both fallbacks and would return FX_NODATA (-99999.99)
+// for the common "contrast run done, primaries not run, sweep measured" state,
+// while the viewer's GetColorDEWhiteY handles it - a phantom divergence.
+static double GridYWhite ( const CMeasure & m, bool bSpecial, bool bCC )
+{
+	CColor prime = m.GetPrimeWhite();
+	CColor onoff = m.GetOnOffWhite();
+	double yOnOff = onoff.isValid() ? onoff.GetY() : -1.0;
+	double yPrime = prime.isValid() ? prime.GetY() : yOnOff;
+	double y = bSpecial ? yOnOff : yPrime;
+	if ( y == -1.0 )
+		y = GetConfig()->m_TargetMaxL;
+	// CC only, SDR only: a primaries run made below 90% stimulus (UpdateGrid
+	// ~3819-3826).
+	if ( bCC && onoff.isValid() && GetConfig()->m_GammaOffsetType != 5
+		 && yOnOff > 0 && yPrime / yOnOff < 0.9 )
+		y = yOnOff;
+	return y;
+}
+
 // UpdateGrid's mode-5 sat/CC reference rescale (MainView.cpp ~4313-4333):
 // * 100 for the Mascior-style HDR CC sets, the legacy fixed 105.95640 for the
 // manual generator, the tone-map-aware GetHDRRefScale otherwise.
@@ -437,8 +471,8 @@ static double GridColorDE ( const CMeasure & m, const CColor & aMeasure, const C
 	{
 		CColor White = m.GetOnOffWhite();
 		CColor Black = m.GetOnOffBlack();
-		double tmWhite = TmDiffuseWhiteNits(White, Black);
 		BOOL DVD = ( cfg->GetGeneratorType() == CColorHCFRConfig::enumManual );
+		double tmWhite;
 		if ( DVD )
 		{
 			// The Mascior disc redefines white as its level-502 (50.0%) patch =
@@ -472,6 +506,7 @@ static double GridColorDE ( const CMeasure & m, const CColor & aMeasure, const C
 		}
 		else if ( displayMode == 1 )
 		{
+			tmWhite = TmDiffuseWhiteNits(White, Black);
 			if ( cRef.m_standard == UHDTV2 || cRef.m_standard == HDTV || cRef.m_standard == UHDTV || cRef.m_standard == UHDTV3 || cRef.m_standard == UHDTV4 || nCol == 7 )
 				RefWhite = YWhite / tmWhite;
 			else
@@ -488,6 +523,7 @@ static double GridColorDE ( const CMeasure & m, const CColor & aMeasure, const C
 			{
 				// Unified convention (GetItemText sat/CC, non-DVD): reference is
 				// GetHDRRefScale-scaled, measured white stays unrescaled.
+				tmWhite = TmDiffuseWhiteNits(White, Black);
 				RefWhite = YWhite / tmWhite;
 			}
 		}
@@ -559,9 +595,14 @@ static void ConvCheck ( const CMeasure & m, const CColor & aColor, const CColor 
 	// reference rescale, a white source, or a dE space - shows up here.
 	if ( wDE <= 0.0 )
 	{
-		// GetDeltaE would divide by this; a NaN here surfaces as a bogus 999
-		// convention failure whose real cause is a missing white.
-		stat.Add(0.0, "%s %d (no white; convention check skipped)", name, idx);
+		// Unreachable while GetColorDEWhiteY ends in its m_TargetMaxL fallback,
+		// and it must FAIL loudly if that ever stops being true: the grid would
+		// keep printing numbers off m_TargetMaxL while the viewer's
+		// AppendMeasure treats ywForDE <= 0 as "blackish" and drops the dE
+		// entirely - a real two-consumer divergence. Recording 0.0 here (which
+		// this used to do) promoted the family from the -1.0 "not run" sentinel
+		// to a 0.000 PASS: it failed OPEN on exactly the state convNW exists for.
+		stat.Add(999.0, "%s %d (no dE white: GetColorDEWhiteY returned %.3f)", name, idx, wDE);
 		return;
 	}
 	CColor refView = refRaw;
@@ -586,7 +627,7 @@ struct ConvSample
 	const char *	name;
 	int				idx;
 };
-static const int kMaxConvSamples = 256;
+static const int kMaxConvSamples = 48;	// high-water mark is 36 (30 sat + 6 stratified CC)
 static ConvSample	s_convSamples[kMaxConvSamples];
 static int			s_nConvSamples = 0;
 
@@ -657,7 +698,13 @@ static void ApplyComboConfig ( const Combo & c )
 	// Setting it after the flags below would silently reset every combo to the
 	// ini's 8-bit-limited default - which is exactly what it did until a
 	// half-code known-fail started firing on all four grids instead of one.
-	cfg->SetGeneratorType(c.dvd ? CColorHCFRConfig::enumManual : CColorHCFRConfig::enumAutomatic);
+	// Guarded because SetGeneratorType also does a WriteProfileString (a full
+	// ini rewrite) plus several reads whose results the flags below overwrite:
+	// unguarded, that is ~876 file rewrites per run for ~168 real changes.
+	CColorHCFRConfig::GeneratorType wantGen = c.dvd ? CColorHCFRConfig::enumManual
+													: CColorHCFRConfig::enumAutomatic;
+	if ( cfg->GetGeneratorType() != wantGen )
+		cfg->SetGeneratorType(wantGen);
 
 	// Grid flags: set the CACHED flags directly (RefreshUse10bitLevels would
 	// re-derive them from the scratch ini's generator keys).
@@ -682,10 +729,14 @@ static void ApplyComboConfig ( const Combo & c )
 	// Rec.709 for the special standards, the active reference otherwise.
 	// AppendMeasure's dERef: transport for the pseudo-spaces, active otherwise
 	// (HDTVa/b need no branch - GetDeltaE forces Rec.709 for them internally).
+	// NULL between the delete and the new: if a CColorReference construction
+	// throws (its ctor inverts a matrix), the next call must not free a stale
+	// pointer, and GridColorDE/ConvCheck must fault on a NULL rather than on
+	// freed memory.
 	const CColorReference & aRef = GetColorReference();
 	bool pseudo = ( aRef.m_standard == UHDTV3 || aRef.m_standard == UHDTV4 );
-	delete s_pGridDERef;
-	delete s_pViewDERef;
+	delete s_pGridDERef;	s_pGridDERef = NULL;
+	delete s_pViewDERef;	s_pViewDERef = NULL;
 	s_pGridDERef = new CColorReference( pseudo ? ContainerTransportReference(aRef)
 						 : ( aRef.m_standard == HDTVa || aRef.m_standard == HDTVb ) ? CColorReference(HDTV) : aRef );
 	s_pViewDERef = new CColorReference( pseudo ? ContainerTransportReference(aRef) : aRef );
@@ -924,7 +975,7 @@ static void RunSats ( const Combo & c, CMeasure & m, CSimulatedSensor & sensor, 
 
 	m.SetSaturationSize(kSatSize);
 	// Loop invariants, hoisted exactly as C3DColorView::BuildScene hoists them.
-	double YWhite = special ? m.GetOnOffWhite().GetY() : m.GetPrimeWhite().GetY();
+	double YWhite = GridYWhite(m, special, false);
 	double wDE = m.GetColorDEWhiteY(special, false, false);
 	for ( int s = 0 ; s < 6 ; s ++ )
 	{
@@ -964,19 +1015,12 @@ static void RunCC ( const Combo & c, CMeasure & m, CSimulatedSensor & sensor, CC
 		return;
 	}
 
-	// UpdateGrid default-case YWhite (MainView.cpp ~3720): OnOffWhite for the
-	// special standards (HDTVa/b), else PrimeWhite - falling back to OnOffWhite
-	// when the primaries run was dimmed (<90%) and not HDR. RunSats uses the
-	// same special?OnOffWhite:PrimeWhite selection; omitting it here would
-	// normalize HDTVa/b CC dE by the 75% PrimeWhite instead of peak white and
-	// diverge from the grid.
+	// UpdateGrid's default-case YWhite, including the CC-only sub-90%-stimulus
+	// fallback - see GridYWhite. Omitting the special-standard selection here
+	// would normalize HDTVa/b CC dE by the 75% PrimeWhite instead of peak white
+	// and diverge from the grid.
 	bool special = ( cfg->m_colorStandard == HDTVa || cfg->m_colorStandard == HDTVb );
-	double YWhitePrime = m.GetPrimeWhite().GetY();
-	double YWhiteOnOff = m.GetOnOffWhite().GetY();
-	double YWhite = special ? YWhiteOnOff : YWhitePrime;
-	BOOL isHDR = ( cfg->m_GammaOffsetType == 5 );
-	if ( m.GetOnOffWhite().isValid() && !isHDR && YWhiteOnOff > 0 && (YWhitePrime / YWhiteOnOff < 0.9) )
-		YWhite = YWhiteOnOff;
+	double YWhite = GridYWhite(m, special, true);
 	bool mascior = ( ccMode >= MASCIOR50 && ccMode <= CCMAXHDR );
 	double wDE = m.GetColorDEWhiteY(special, true, mascior);
 
@@ -1025,42 +1069,38 @@ static void RunCC ( const Combo & c, CMeasure & m, CSimulatedSensor & sensor, CC
 //
 // The gains are otherwise arbitrary; 0.965 on prime white reproduces the
 // 3.5%-low display that surfaced the original bug.
+// Only two whites are perturbed. A third gain on the grayscale TOP was
+// dropped: that white is read only through GetColorDEWhiteY's Mascior branch,
+// and RunCC restores m_CCMode = GCD before this runs, so it was inert - it
+// changed no computed value and gave the false impression that this family
+// locks the Mascior white source. Covering that source needs a Mascior CC set
+// in the matrix (ACCURACYTEST.md coverage gap 3).
 static const double kPrimeWhiteGain = 0.965;
 static const double kOnOffWhiteGain = 0.982;
-static const double kGrayTopGain    = 0.973;
 
-static void RunConvWhite ( const Combo & c, CMeasure & m, FamStat & stat )
+static void RunConvWhite ( CMeasure & m, FamStat & stat )
 {
 	CColorHCFRConfig * cfg = GetConfig();
 	bool special = ( cfg->m_colorStandard == HDTVa || cfg->m_colorStandard == HDTVb );
-	int gs = m.GetGrayScaleSize();
-	if ( gs <= 0 || s_nConvSamples == 0 )
+	if ( s_nConvSamples == 0 )
 		return;
 
 	CColor savePrime = m.GetPrimeWhite();
 	CColor saveOnOff = m.GetOnOffWhite();
-	CColor saveTop   = m.GetGray(gs - 1);
 
 	CColor p = savePrime; ScaleXYZ(p, kPrimeWhiteGain); m.SetPrimeWhite(p);
 	CColor o = saveOnOff; ScaleXYZ(o, kOnOffWhiteGain); m.SetOnOffWhite(o);
-	CColor t = saveTop;   ScaleXYZ(t, kGrayTopGain);    m.SetGray(gs - 1, t);
 
 	// Deliberately NO RefreshHdrTargets here: leaving m_TargetMaxL (and with it
 	// tmWhite / GetHDRRefScale) at its converged value is what DECOUPLES the
 	// measured white from the theoretical one. Refreshing would drag the
 	// theoretical white along and restore the accidental equality.
-	double YWhitePrime = m.GetPrimeWhite().GetY();
-	double YWhiteOnOff = m.GetOnOffWhite().GetY();
-	BOOL isHDR = ( cfg->m_GammaOffsetType == 5 );
 	bool mascior = ( cfg->m_CCMode >= MASCIOR50 && cfg->m_CCMode <= CCMAXHDR );
 
-	// UpdateGrid's default-case YWhite (MainView.cpp ~3814-3826) recomputed from
-	// the PERTURBED state, plus the matching shared white - one pair for the
-	// saturation samples, one for the color-checker samples.
-	double YWhiteSat = special ? YWhiteOnOff : YWhitePrime;
-	double YWhiteCC  = YWhiteSat;
-	if ( m.GetOnOffWhite().isValid() && !isHDR && YWhiteOnOff > 0 && (YWhitePrime / YWhiteOnOff < 0.9) )
-		YWhiteCC = YWhiteOnOff;
+	// UpdateGrid's YWhite recomputed from the PERTURBED state, plus the matching
+	// shared white - one pair for saturation samples, one for CC samples.
+	double YWhiteSat = GridYWhite(m, special, false);
+	double YWhiteCC  = GridYWhite(m, special, true);
 	double wDESat = m.GetColorDEWhiteY(special, false, false);
 	double wDECC  = m.GetColorDEWhiteY(special, true, mascior);
 
@@ -1074,7 +1114,6 @@ static void RunConvWhite ( const Combo & c, CMeasure & m, FamStat & stat )
 
 	m.SetPrimeWhite(savePrime);
 	m.SetOnOffWhite(saveOnOff);
-	m.SetGray(gs - 1, saveTop);
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -1099,13 +1138,26 @@ static void RunConvNoWhite ( const Combo & c, CSimulatedSensor & sensor, FamStat
 		{ true,true,false }, { false,true,true }, { true,false,true },
 	};
 
-	// A pristine CMeasure: no gray array, no primaries, no on/off pair.
+	// A default-constructed CMeasure is NOT white-less: the constructor
+	// pre-loads m_PrimeWhite, m_OnOffWhite and the grayscale top to plausible
+	// display values at Y = m_TargetMaxL (Measure.cpp ~203, ~223-225), and
+	// isValid() only rejects components <= -1.0 - so all three read as
+	// measured. Invalidating the two whites explicitly is what actually
+	// reaches the missing-white path; without it this family silently tested
+	// nothing, because the ctor's Y happens to equal the m_TargetMaxL the pane
+	// side falls back to, so both sides agreed for the wrong reason.
+	// The gray array is deliberately left alone: GetRefSat indexes
+	// GetGray(GetGrayScaleSize()-1) unguarded.
 	CMeasure m;
 	m.SetSaturationSize(kSatSize);
+	m.SetPrimeWhite(noDataColor);
+	m.SetOnOffWhite(noDataColor);
 
-	// Both whites are invalid, so the grid falls all the way through to
-	// m_TargetMaxL - the value ApplyComboConfig set, since no measurement ever
-	// refreshed it. GetColorDEWhiteY must land on the same fallback.
+	// Both whites are now invalid, so UpdateGrid falls all the way through to
+	// m_TargetMaxL (MainView.cpp ~3699-3706) and GetColorDEWhiteY must land on
+	// the same fallback. Note m_TargetMaxL is whatever RefreshHdrTargets left
+	// after RunGray (the measured on/off white on HDR combos), NOT the value
+	// ApplyComboConfig set - which is fine, both sides read the same config.
 	double YWhite = cfg->m_TargetMaxL;
 	double wDE = m.GetColorDEWhiteY(special, false, false);
 
@@ -1203,7 +1255,7 @@ static void RunCombo ( const Combo & c )
 	// White-source coverage, last: RunConvWhite mutates the stored whites (and
 	// restores them), RunConvNoWhite builds its own empty CMeasure. Neither
 	// must run before the wire-model families above.
-	RunConvWhite(c, m, stats[FAM_CONVW]);
+	RunConvWhite(m, stats[FAM_CONVW]);
 	RunConvNoWhite(c, sensor, stats[FAM_CONVNW]);
 
 	// Manual generator: reference == wire is NOT testable. HCFR generates no
@@ -1221,11 +1273,18 @@ static void RunCombo ( const Combo & c )
 				stats[f].worst = -1.0;
 	}
 
-	// Evaluate
+	// Evaluate. MSVC's _snprintf returns NEGATIVE on truncation and does not
+	// NUL-terminate, and the remaining-space argument is size_t - so a raw
+	// `n += _snprintf(line+n, sizeof(line)-1-n, ...)` would write before the
+	// buffer AND widen its own bound the moment it overflowed. Clamp n after
+	// every append and terminate explicitly.
 	char line[512];
-	int n = _snprintf(line, sizeof(line)-1, "%-8s %-10s %-6s %-8s %3.0f%% %-4s ",
+	const int kLineMax = (int)sizeof(line) - 1;
+	int n = _snprintf(line, kLineMax, "%-8s %-10s %-6s %-8s %3.0f%%  %-4s ",
 					  c.stdName, c.eotfName, c.whiteName, c.gridName, c.intensity * 100.,
 					  c.dvd ? "DVD" : "GDI");
+	if ( n < 0 || n > kLineMax ) n = kLineMax;
+	line[n] = 0;
 	BOOL bFail = FALSE, bKnown = FALSE;
 	for ( int fam = 0 ; fam < FAM_COUNT ; fam ++ )
 	{
@@ -1237,7 +1296,9 @@ static void RunCombo ( const Combo & c )
 		// entry's documented ceiling; beyond that, the known issue has grown
 		// = a real regression, so treat it as a hard FAIL.
 		BOOL absorbed = ( iKnown >= 0 && w <= kKnownFails[iKnown].ceiling );
-		n += _snprintf(line + n, sizeof(line)-1-n, "%7.3f%c", w, over ? (absorbed ? '#' : '*') : ' ');
+		int nAdd = _snprintf(line + n, kLineMax - n, "%7.3f%c", w, over ? (absorbed ? '#' : '*') : ' ');
+		n = ( nAdd < 0 || n + nAdd > kLineMax ) ? kLineMax : n + nAdd;
+		line[n] = 0;
 		if ( over )
 		{
 			if ( absorbed )
@@ -1387,7 +1448,13 @@ int RunAccuracyTest ( const char * pReportPath )
 						// diffuse-white CONSTANT, not the chromaticity), so
 						// D65 covers them - running all three whites would
 						// triple the cost for identical branches.
-						if ( eotf == 5 && kWhites[iWhite].wt == D65 && iInt == 0 )
+						// LIMITED-RANGE grids only: RefreshUse10bitLevels
+						// forces m_bRGB16_235 = TRUE for the manual generator
+						// ("consumer disc video is 16-235 by definition"), so a
+						// full-range DVD combo models a wire the app cannot
+						// emit - and would calibrate the DVD known-fail
+						// ceilings on unreachable rows.
+						if ( eotf == 5 && kWhites[iWhite].wt == D65 && iInt == 0 && kGrids[iGrid].lim )
 						{
 							c.dvd = true;
 							RunCombo(c);

--- a/AccuracyTest.cpp
+++ b/AccuracyTest.cpp
@@ -184,6 +184,7 @@ struct Combo
 	bool			lim;
 	int				gridIdx;	// index into kGrids
 	double			intensity;	// 1.0 or 0.9 (GDI window Intensity fraction)
+	bool			dvd;		// manual generator (enumManual)
 	const char *	eotfName;
 	const char *	whiteName;
 	const char *	gridName;
@@ -205,6 +206,7 @@ struct KnownFail
 	int				eotf;		// -1 = any / 57 = HDR (5 or 7)
 	int				family;		// Family, or -1 = any
 	int				grids;		// bitmask over kGrids indices (0xF = any)
+	int				dvd;		// -1 = any generator, 0 = GDI only, 1 = manual only
 	double			ceiling;	// dE above which this is a REAL fail, not the known gap
 	const char *	reason;
 };
@@ -228,35 +230,35 @@ static const KnownFail kKnownFails[] =
 	// GetRefPrimary/GetRefSecondary for these pseudo-spaces route through
 	// GetRefSat(i, 1.0), so the primaries family inherits the same skew.
 	// (observed worst ~8 dE)
-	{ UHDTV3, 999, -1, FAM_PRIM,   GRID_ANY, 15.0, "hardcoded D65 endpoint xy tables in GetRefSat (p3Ref/p3sRef)" },
-	{ UHDTV3, 999, -1, FAM_SAT100, GRID_ANY, 15.0, "hardcoded D65 endpoint xy tables in GetRefSat (p3Ref/p3sRef)" },
-	{ UHDTV3, 999, -1, FAM_SAT75,  GRID_ANY, 15.0, "hardcoded D65 endpoint xy tables in GetRefSat (p3Ref/p3sRef)" },
-	{ UHDTV4, 999, -1, FAM_PRIM,   GRID_ANY, 15.0, "hardcoded D65 endpoint xy tables in GetRefSat (rRef/rsRef)" },
-	{ UHDTV4, 999, -1, FAM_SAT100, GRID_ANY, 15.0, "hardcoded D65 endpoint xy tables in GetRefSat (rRef/rsRef)" },
-	{ UHDTV4, 999, -1, FAM_SAT75,  GRID_ANY, 15.0, "hardcoded D65 endpoint xy tables in GetRefSat (rRef/rsRef)" },
+	{ UHDTV3, 999, -1, FAM_PRIM,   GRID_ANY, -1, 15.0, "hardcoded D65 endpoint xy tables in GetRefSat (p3Ref/p3sRef)" },
+	{ UHDTV3, 999, -1, FAM_SAT100, GRID_ANY, -1, 15.0, "hardcoded D65 endpoint xy tables in GetRefSat (p3Ref/p3sRef)" },
+	{ UHDTV3, 999, -1, FAM_SAT75,  GRID_ANY, -1, 15.0, "hardcoded D65 endpoint xy tables in GetRefSat (p3Ref/p3sRef)" },
+	{ UHDTV4, 999, -1, FAM_PRIM,   GRID_ANY, -1, 15.0, "hardcoded D65 endpoint xy tables in GetRefSat (rRef/rsRef)" },
+	{ UHDTV4, 999, -1, FAM_SAT100, GRID_ANY, -1, 15.0, "hardcoded D65 endpoint xy tables in GetRefSat (rRef/rsRef)" },
+	{ UHDTV4, 999, -1, FAM_SAT75,  GRID_ANY, -1, 15.0, "hardcoded D65 endpoint xy tables in GetRefSat (rRef/rsRef)" },
 	// HDTVa/HDTVb under custom whites: the wire tables, the pRef/sRef
 	// reference endpoints, the simulated sensor's decode space and the dE
 	// space are all fixed Rec.709/D65 constructions, while the gray/sat
 	// reference targets follow the active custom white - custom whites are
 	// outside the special modes' model by design (CC passes because both
 	// sides share the same decode chain). (observed worst: gray ~12, sat ~14)
-	{ HDTVa, 999, -1, FAM_GRAY,   GRID_ANY, 20.0, "special modes are fixed Rec.709/D65: gray targets follow the custom white, the wire cannot" },
-	{ HDTVb, 999, -1, FAM_GRAY,   GRID_ANY, 20.0, "special modes are fixed Rec.709/D65: gray targets follow the custom white, the wire cannot" },
-	{ HDTVa, 999, -1, FAM_SAT100, GRID_ANY, 20.0, "75%-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
-	{ HDTVa, 999, -1, FAM_SAT75,  GRID_ANY, 20.0, "75%-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
-	{ HDTVb, 999, -1, FAM_SAT100, GRID_ANY, 20.0, "plasma-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
-	{ HDTVb, 999, -1, FAM_SAT75,  GRID_ANY, 20.0, "plasma-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
+	{ HDTVa, 999, -1, FAM_GRAY,   GRID_ANY, -1, 20.0, "special modes are fixed Rec.709/D65: gray targets follow the custom white, the wire cannot" },
+	{ HDTVb, 999, -1, FAM_GRAY,   GRID_ANY, -1, 20.0, "special modes are fixed Rec.709/D65: gray targets follow the custom white, the wire cannot" },
+	{ HDTVa, 999, -1, FAM_SAT100, GRID_ANY, -1, 20.0, "75%-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
+	{ HDTVa, 999, -1, FAM_SAT75,  GRID_ANY, -1, 20.0, "75%-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
+	{ HDTVb, 999, -1, FAM_SAT100, GRID_ANY, -1, 20.0, "plasma-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
+	{ HDTVb, 999, -1, FAM_SAT75,  GRID_ANY, -1, 20.0, "plasma-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
 	// HDTVa/b custom-white primaries overlap the HDR-analog gap below when
 	// the EOTF is PQ/HLG, so this entry (which matches first) must clear the
 	// same ~70 dE. (observed worst ~68 dE)
-	{ HDTVa, 999, -1, FAM_PRIM,   GRID_ANY, 90.0, "75%-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
-	{ HDTVb, 999, -1, FAM_PRIM,   GRID_ANY, 90.0, "plasma-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
+	{ HDTVa, 999, -1, FAM_PRIM,   GRID_ANY, -1, 90.0, "75%-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
+	{ HDTVb, 999, -1, FAM_PRIM,   GRID_ANY, -1, 90.0, "plasma-mode wire tables and pRef/sRef references are fixed Rec.709/D65 constructions" },
 	// HDTVa/b primaries under PQ/HLG: WireModeledPrimaryReference
 	// deliberately returns the ANALOG color for modes 5/7 (legacy behavior,
 	// see its header comment) while the wire re-encodes the 75% tables with
 	// the active EOTF - the two conventions are far apart (dE ~70 on blue).
-	{ HDTVa, -1, 57, FAM_PRIM, GRID_ANY, 90.0, "legacy analog primaries reference under HDR (WireModeledPrimaryReference modes 5/7 early-out)" },
-	{ HDTVb, -1, 57, FAM_PRIM, GRID_ANY, 90.0, "legacy analog primaries reference under HDR (WireModeledPrimaryReference modes 5/7 early-out)" },
+	{ HDTVa, -1, 57, FAM_PRIM, GRID_ANY, -1, 90.0, "legacy analog primaries reference under HDR (WireModeledPrimaryReference modes 5/7 early-out)" },
+	{ HDTVb, -1, 57, FAM_PRIM, GRID_ANY, -1, 90.0, "legacy analog primaries reference under HDR (WireModeledPrimaryReference modes 5/7 early-out)" },
 	// HDTVa/b PQ reduced-stim 100%-saturation point, 8-bit limited grid
 	// only: the PQ 50% anchor is exactly code 110/219, so 0.75 stim lands
 	// the encoded signal on an exact half-code (82.5). The generator and
@@ -264,8 +266,8 @@ static const KnownFail kKnownFails[] =
 	// whose sub-1e-9 dust falls on opposite sides of the tie -> a one-code
 	// split on two channels (constant dE 0.74 at yellow). No other
 	// grid/level combination lands on a half-code. (observed worst 0.74)
-	{ HDTVa, -1, 5, FAM_SAT75, GRID_8LIM, 2.0, "PQ 50% anchor (code 110/219) x 0.75 stim = exact half-code tie; generator/reference dust splits it" },
-	{ HDTVb, -1, 5, FAM_SAT75, GRID_8LIM, 2.0, "PQ 50% anchor (code 110/219) x 0.75 stim = exact half-code tie; generator/reference dust splits it" },
+	{ HDTVa, -1, 5, FAM_SAT75, GRID_8LIM, -1, 2.0, "PQ 50% anchor (code 110/219) x 0.75 stim = exact half-code tie; generator/reference dust splits it" },
+	{ HDTVb, -1, 5, FAM_SAT75, GRID_8LIM, -1, 2.0, "PQ 50% anchor (code 110/219) x 0.75 stim = exact half-code tie; generator/reference dust splits it" },
 	// Grayscale on the FULL-range grids: the whole gray pipeline
 	// (GetGrayPercent, ArrayIndexToGrayLevel, GrayLevelToGrayProp) has no
 	// range parameter - ramp codes and references live on the 219/876
@@ -275,7 +277,35 @@ static const KnownFail kKnownFails[] =
 	// T2/T3 goldens - out of scope for this harness. Tight ceiling: this
 	// entry is broad (any space/white/eotf), so it must NOT swallow a real
 	// grayscale/EOTF regression that pushes dE past ~2. (observed worst 0.39)
-	{ -1, -1, -1, FAM_GRAY, GRID_FULL, 2.0, "gray ramp codes/references are limited-grid only (no range parameter in GetGrayPercent/GrayLevelToGrayProp)" },
+	{ -1, -1, -1, FAM_GRAY, GRID_FULL, -1, 2.0, "gray ramp codes/references are limited-grid only (no range parameter in GetGrayPercent/GrayLevelToGrayProp)" },
+	// MANUAL GENERATOR: the measures grid and the 3D viewer genuinely disagree.
+	// GetItemText keeps the legacy DVD conventions for mode 5 - the Mascior
+	// disc's 92.254965-nit white in place of TmDiffuseWhiteNits, the fixed
+	// 105.95640 reference rescale in place of GetHDRRefScale, and (in its
+	// second sub-branch) the extra YWhite * 94.37844 / tmWhite measured-white
+	// rescale - while C3DColorView::BuildScene has NO manual-generator branch
+	// at all and always uses the unified GetHDRRefScale/GetColorDEWhiteY pair.
+	// So the same patch reports one dE in the pane and another in the 3D
+	// viewer whenever the user is measuring from a disc. This is the same class
+	// of bug the 2026-07 unification fixed for the GDI wire; DVD was
+	// deliberately left legacy there, and closing it means deciding WHICH
+	// convention wins (a user-visible number change on a legacy path), so it is
+	// recorded rather than silently changed.
+	//
+	// Two magnitudes, matching GetItemText's two sub-branches. Branch A (sat
+	// modes for HDTV/UHDTV, and UHDTV2's last saturation column) leaves the
+	// measured white alone, so the full 105.95640-vs-10000/92.254965 reference
+	// offset - 2.25% - survives: observed 0.49-0.70. Branch B additionally
+	// rescales YWhite by 94.37844/tmWhite, which very nearly cancels it:
+	// observed 0.02-0.07. Split ceilings so a regression in the near-cancelling
+	// half cannot hide under the other half's headroom.
+	{ HDTV,   -1, 5, -1, GRID_ANY, 1, 1.5, "manual generator: grid keeps the legacy DVD HDR conventions, the 3D viewer has no DVD branch (GetItemText ~3103 vs Color3DView BuildScene)" },
+	{ UHDTV,  -1, 5, -1, GRID_ANY, 1, 1.5, "manual generator: grid keeps the legacy DVD HDR conventions, the 3D viewer has no DVD branch (GetItemText ~3103 vs Color3DView BuildScene)" },
+	{ UHDTV2, -1, 5, -1, GRID_ANY, 1, 1.5, "manual generator: grid keeps the legacy DVD HDR conventions, the 3D viewer has no DVD branch (GetItemText ~3103 vs Color3DView BuildScene)" },
+	{ UHDTV3, -1, 5, -1, GRID_ANY, 1, 0.3, "manual generator: DVD YWhite * 94.37844/tmWhite rescale nearly cancels the fixed 105.95640, the 3D viewer applies neither" },
+	{ UHDTV4, -1, 5, -1, GRID_ANY, 1, 0.3, "manual generator: DVD YWhite * 94.37844/tmWhite rescale nearly cancels the fixed 105.95640, the 3D viewer applies neither" },
+	{ HDTVa,  -1, 5, -1, GRID_ANY, 1, 0.3, "manual generator: DVD YWhite * 94.37844/tmWhite rescale nearly cancels the fixed 105.95640, the 3D viewer applies neither" },
+	{ HDTVb,  -1, 5, -1, GRID_ANY, 1, 0.3, "manual generator: DVD YWhite * 94.37844/tmWhite rescale nearly cancels the fixed 105.95640, the 3D viewer applies neither" },
 };
 
 static bool s_knownFailFired[sizeof(kKnownFails)/sizeof(kKnownFails[0])] = { false };
@@ -372,15 +402,28 @@ static CColor Meas ( CSimulatedSensor & sensor, const ColorRGBDisplay & rgb, dou
 // common normalizer shift largely cancels inside a dE difference, hence
 // FAM_CONV's dedicated 0.005 tolerance in TolFor).
 // Replicates CMainView::GetItemText's color-mode dE (MainView.cpp
-// ~2985-3047) for the non-grayscale families. displayMode: 1 = primaries,
-// 5..10 = saturation sweeps, 11 = color checker. DVD (manual generator) is
-// FALSE here - the harness models the GDI-family wire.
+// ~3097-3154) for the non-grayscale families. displayMode: 1 = primaries,
+// 5..10 = saturation sweeps, 11 = color checker. Both generator branches are
+// modeled: the manual-generator (DVD) side keeps its own 92.254965 white and
+// 94.37844/tmWhite measured-white rescale.
 // The dE evaluation spaces, rebuilt once per combo by ApplyComboConfig.
 // Constructing a CColorReference is not cheap (matrix inversion + secondary
 // derivation) and these appear in the innermost dE loops; ContainerTransportReference
 // in particular builds a whole new reference on every call.
 static CColorReference *	s_pGridDERef = NULL;	// GetItemText's bRef
 static CColorReference *	s_pViewDERef = NULL;	// AppendMeasure's dERef
+
+// UpdateGrid's mode-5 sat/CC reference rescale (MainView.cpp ~4313-4333):
+// * 100 for the Mascior-style HDR CC sets, the legacy fixed 105.95640 for the
+// manual generator, the tone-map-aware GetHDRRefScale otherwise.
+static double PaneRefScale ( const CMeasure & m, bool mascior )
+{
+	if ( mascior )
+		return 100.;
+	if ( GetConfig()->GetGeneratorType() == CColorHCFRConfig::enumManual )
+		return 105.95640;
+	return m.GetHDRRefScale();
+}
 
 static double GridColorDE ( const CMeasure & m, const CColor & aMeasure, const CColor & aReference,
 							double YWhiteIn, int displayMode, int nCol, int satsize )
@@ -395,7 +438,39 @@ static double GridColorDE ( const CMeasure & m, const CColor & aMeasure, const C
 		CColor White = m.GetOnOffWhite();
 		CColor Black = m.GetOnOffBlack();
 		double tmWhite = TmDiffuseWhiteNits(White, Black);
-		if ( displayMode == 1 )
+		BOOL DVD = ( cfg->GetGeneratorType() == CColorHCFRConfig::enumManual );
+		if ( DVD )
+		{
+			// The Mascior disc redefines white as its level-502 (50.0%) patch =
+			// 92.254965 nits, un-snapped, instead of the GDI wire's 50.22831%
+			// code -> TmDiffuseWhiteNits. (MainView.cpp ~3103-3126.)
+			bool shiftDiffuse = ( fabs(cfg->m_DiffuseL - 94.0) > 0.5 );
+			tmWhite = getL_EOTF(0.50, White, Black, cfg->m_GammaRel, cfg->m_Split, 5, cfg->m_DiffuseL,
+								cfg->m_MasterMinL, cfg->m_MasterMaxL, cfg->m_TargetMinL, cfg->m_TargetMaxL,
+								cfg->m_useToneMap, FALSE, cfg->m_TargetSysGamma,
+								cfg->m_BT2390_BS, cfg->m_BT2390_WS, cfg->m_BT2390_WS1) * 100.0;
+			if ( displayMode == 1 )
+			{
+				if ( cRef.m_standard == UHDTV2 || cRef.m_standard == HDTV || cRef.m_standard == UHDTV || cRef.m_standard == UHDTV3 || cRef.m_standard == UHDTV4 || nCol == 7 )
+					RefWhite = YWhite / ( !shiftDiffuse ? 92.254965 : tmWhite );
+				else
+				{
+					RefWhite = YWhite / tmWhite;
+					YWhite = YWhite * 94.37844 / tmWhite;
+				}
+			}
+			else
+			{
+				if ( ( (cRef.m_standard == UHDTV2 && nCol == satsize) || cRef.m_standard == HDTV || cRef.m_standard == UHDTV ) && displayMode != 11 )
+					RefWhite = YWhite / tmWhite;
+				else
+				{
+					RefWhite = YWhite / tmWhite;
+					YWhite = YWhite * 94.37844 / tmWhite;
+				}
+			}
+		}
+		else if ( displayMode == 1 )
 		{
 			if ( cRef.m_standard == UHDTV2 || cRef.m_standard == HDTV || cRef.m_standard == UHDTV || cRef.m_standard == UHDTV3 || cRef.m_standard == UHDTV4 || nCol == 7 )
 				RefWhite = YWhite / tmWhite;
@@ -473,7 +548,7 @@ static void ConvCheck ( const CMeasure & m, const CColor & aColor, const CColor 
 	// rescale block and the viewer's hdr10Refs are both mode-5 gated).
 	CColor refPane = refRaw;
 	if ( isHDR )
-		ScaleXYZ(refPane, mascior ? 100. : m.GetHDRRefScale());
+		ScaleXYZ(refPane, PaneRefScale(m, mascior));
 	double dEpane = GridColorDE(m, pert, refPane, YWhite, displayMode, nCol, satsize);
 
 	// Viewer side, as C3DColorView::BuildScene builds it: the reference scaled
@@ -576,6 +651,13 @@ static void ApplyComboConfig ( const Combo & c )
 	cfg->m_TargetMinL = 0.0;
 	cfg->m_bOverRideTargs = FALSE;
 	cfg->m_userBlack = FALSE;
+
+	// Generator FIRST: SetGeneratorType calls RefreshUse10bitLevels(), which
+	// re-derives the cached grid flags from the scratch ini's generator keys.
+	// Setting it after the flags below would silently reset every combo to the
+	// ini's 8-bit-limited default - which is exactly what it did until a
+	// half-code known-fail started firing on all four grids instead of one.
+	cfg->SetGeneratorType(c.dvd ? CColorHCFRConfig::enumManual : CColorHCFRConfig::enumAutomatic);
 
 	// Grid flags: set the CACHED flags directly (RefreshUse10bitLevels would
 	// re-derive them from the scratch ini's generator keys).
@@ -861,7 +943,7 @@ static void RunSats ( const Combo & c, CMeasure & m, CSimulatedSensor & sensor, 
 			if ( stim >= 1.0 )
 				KeepConvSample(aColor, refColor, 5 + s, j + 1, names[s], j);
 			if ( cfg->m_GammaOffsetType == 5 )
-				ScaleXYZ(refColor, m.GetHDRRefScale());	// UpdateGrid ~4294
+				ScaleXYZ(refColor, PaneRefScale(m, false));	// UpdateGrid ~4313
 			double dE = GridColorDE(m, aColor, refColor, YWhite, 5 + s, j + 1, kSatSize);
 			stat.Add(dE, "%s sat %d%% stim %.0f%%", names[s], j * 25, stim * 100.);
 		}
@@ -912,7 +994,7 @@ static void RunCC ( const Combo & c, CMeasure & m, CSimulatedSensor & sensor, CC
 		if ( ccMode == GCD && (j % 4) == 0 )
 			KeepConvSample(aColor, refColor, 11, j + 1, "patch", j);
 		if ( cfg->m_GammaOffsetType == 5 )
-			ScaleXYZ(refColor, mascior ? 100. : m.GetHDRRefScale());	// UpdateGrid ~4296-4307
+			ScaleXYZ(refColor, PaneRefScale(m, mascior));	// UpdateGrid ~4313-4333
 		double dE = GridColorDE(m, aColor, refColor, YWhite, 11, j + 1, kSatSize);
 		stat.Add(dE, "patch %d (%.2f/%.2f/%.2f%%)", j, GenColors[j][0], GenColors[j][1], GenColors[j][2]);
 	}
@@ -1085,6 +1167,7 @@ static int MatchKnownFail ( const Combo & c, int fam )	// index into kKnownFails
 		else if ( k.eotf != -1 && k.eotf != c.eotf ) continue;
 		if ( k.family != -1 && k.family != fam ) continue;
 		if ( !( k.grids & (1 << c.gridIdx) ) ) continue;
+		if ( k.dvd != -1 && (k.dvd != 0) != c.dvd ) continue;
 		return i;
 	}
 	return -1;
@@ -1123,10 +1206,26 @@ static void RunCombo ( const Combo & c )
 	RunConvWhite(c, m, stats[FAM_CONVW]);
 	RunConvNoWhite(c, sensor, stats[FAM_CONVNW]);
 
+	// Manual generator: reference == wire is NOT testable. HCFR generates no
+	// patches at all in this mode - the "wire" is the disc the user plays, and
+	// the DVD conventions are built for the Mascior disc's 50.0% / 92.254965-nit
+	// white, not for the 50.22831% code the simulated sensor is fed. The
+	// wire-model families still RUN (they bootstrap the measured whites and
+	// collect the convention samples) but their result is not scored; what the
+	// DVD combos exist to check is the convention families, which compare two
+	// consumers reading the same state.
+	if ( c.dvd )
+	{
+		for ( int f = 0 ; f < FAM_COUNT ; f ++ )
+			if ( !IsConvFamily(f) )
+				stats[f].worst = -1.0;
+	}
+
 	// Evaluate
 	char line[512];
-	int n = _snprintf(line, sizeof(line)-1, "%-8s %-10s %-6s %-8s %3.0f%%  ",
-					  c.stdName, c.eotfName, c.whiteName, c.gridName, c.intensity * 100.);
+	int n = _snprintf(line, sizeof(line)-1, "%-8s %-10s %-6s %-8s %3.0f%% %-4s ",
+					  c.stdName, c.eotfName, c.whiteName, c.gridName, c.intensity * 100.,
+					  c.dvd ? "DVD" : "GDI");
 	BOOL bFail = FALSE, bKnown = FALSE;
 	for ( int fam = 0 ; fam < FAM_COUNT ; fam ++ )
 	{
@@ -1145,22 +1244,22 @@ static void RunCombo ( const Combo & c )
 			{
 				bKnown = TRUE;
 				s_knownFailFired[iKnown] = true;
-				Detail("KNOWN-FAIL  %s %s %s %s %.0f%% [%s]: worst dE %.3f at %s\n            reason: %s\n",
-					   c.stdName, c.eotfName, c.whiteName, c.gridName, c.intensity * 100.,
+				Detail("KNOWN-FAIL  %s %s %s %s %.0f%% %s [%s]: worst dE %.3f at %s\n            reason: %s\n",
+					   c.stdName, c.eotfName, c.whiteName, c.gridName, c.intensity * 100., c.dvd ? "DVD" : "GDI",
 					   kFamilyName[fam], w, stats[fam].desc, kKnownFails[iKnown].reason);
 			}
 			else if ( iKnown >= 0 )
 			{
 				bFail = TRUE;
-				Detail("FAIL(>ceil) %s %s %s %s %.0f%% [%s]: worst dE %.3f exceeds known-fail ceiling %.2f at %s\n            the known gap GREW - likely a regression: %s\n",
-					   c.stdName, c.eotfName, c.whiteName, c.gridName, c.intensity * 100.,
+				Detail("FAIL(>ceil) %s %s %s %s %.0f%% %s [%s]: worst dE %.3f exceeds known-fail ceiling %.2f at %s\n            the known gap GREW - likely a regression: %s\n",
+					   c.stdName, c.eotfName, c.whiteName, c.gridName, c.intensity * 100., c.dvd ? "DVD" : "GDI",
 					   kFamilyName[fam], w, kKnownFails[iKnown].ceiling, stats[fam].desc, kKnownFails[iKnown].reason);
 			}
 			else
 			{
 				bFail = TRUE;
-				Detail("FAIL        %s %s %s %s %.0f%% [%s]: worst dE %.3f (tol %.3f) at %s\n",
-					   c.stdName, c.eotfName, c.whiteName, c.gridName, c.intensity * 100.,
+				Detail("FAIL        %s %s %s %s %.0f%% %s [%s]: worst dE %.3f (tol %.3f) at %s\n",
+					   c.stdName, c.eotfName, c.whiteName, c.gridName, c.intensity * 100., c.dvd ? "DVD" : "GDI",
 					   kFamilyName[fam], w, tol, stats[fam].desc);
 			}
 		}
@@ -1229,9 +1328,12 @@ int RunAccuracyTest ( const char * pReportPath )
 	fprintf(s_fReport, "dE settings: dE_form=3 (CIE2000), dE_gray=1 (gamma-predicted gray target), gw_Weight=0\n");
 	fprintf(s_fReport, "conv* families are DIFFERENTIAL: |grid dE - 3D-viewer dE| for a perturbed patch\n");
 	fprintf(s_fReport, "(-1.000 = family not run). convPV = nominal whites; convPVw = the three stored\n");
-	fprintf(s_fReport, "whites pulled off target and off each other; convNW = no white measured at all.\n\n");
-	fprintf(s_fReport, "%-8s %-10s %-6s %-8s %-5s %8s %7s %7s %7s %7s %7s %7s %7s %7s  %s\n",
-			"space", "eotf", "white", "grid", "inten",
+	fprintf(s_fReport, "whites pulled off target and off each other; convNW = no white measured at all.\n");
+	fprintf(s_fReport, "gen: GDI = automatic generator, DVD = manual generator. DVD combos score ONLY the\n");
+	fprintf(s_fReport, "conv* columns - HCFR emits no patches in that mode, so reference == wire has no\n");
+	fprintf(s_fReport, "meaning; what they check is that the grid's DVD conventions and the viewer agree.\n\n");
+	fprintf(s_fReport, "%-8s %-10s %-6s %-8s %-5s %-4s %8s %7s %7s %7s %7s %7s %7s %7s %7s  %s\n",
+			"space", "eotf", "white", "grid", "inten", "gen",
 			"gray", "prim", "sat100", "sat75", "ccGCD", "ccAXIS", "convPV", "convPVw", "convNW", "result");
 
 	int iSpace, iEotf, iWhite, iGrid, iInt;
@@ -1271,11 +1373,25 @@ int RunAccuracyTest ( const char * pReportPath )
 						c.lim = kGrids[iGrid].lim;
 						c.gridIdx = iGrid;
 						c.intensity = iInt ? 0.9 : 1.0;
+						c.dvd = false;
 						c.eotfName = ( sp.cs == sRGB ) ? "sRGB" : e.name;
 						c.whiteName = kWhites[iWhite].name;
 						c.gridName = kGrids[iGrid].name;
 						c.stdName = sp.name;
 						RunCombo(c);
+
+						// Manual-generator pass. Every DVD carve-out in
+						// GetItemText / UpdateGrid sits inside the mode-5 HDR
+						// block, so only PQ combos differ at all; and the
+						// carve-outs are white-independent (they swap the
+						// diffuse-white CONSTANT, not the chromaticity), so
+						// D65 covers them - running all three whites would
+						// triple the cost for identical branches.
+						if ( eotf == 5 && kWhites[iWhite].wt == D65 && iInt == 0 )
+						{
+							c.dvd = true;
+							RunCombo(c);
+						}
 					}
 				}
 			}

--- a/AccuracyTest.cpp
+++ b/AccuracyTest.cpp
@@ -23,6 +23,20 @@
 // models the wire for that combination - exactly the class of regression a
 // color-math change can introduce.
 //
+// ...AND WHAT THE dE ~ 0 INVARIANT CANNOT VERIFY
+// ----------------------------------------------
+// That invariant holds under ANY self-consistent normalization, so it cannot
+// tell two CONSUMERS apart when they disagree about a convention - it only
+// catches a reference that stopped modeling the wire. Every dE bug that
+// reached a user during the 2026-07 HDR rescale unification was of the first
+// kind and left all 708 combos green.
+//
+// The conv* families close that hole with a DIFFERENTIAL check: perturb the
+// measurement, then require the measures grid's formula and the 3D viewer's
+// formula to produce the SAME dE. convPV runs it at nominal whites, convPVw
+// with the stored whites pushed off target and off each other, and convNW with
+// no white measured at all. See ConvCheck and tests\ACCURACYTEST.md.
+//
 // RELATION TO tests\ColorMathTest
 // -------------------------------
 // ColorMathTest.exe verify   covers the pure libHCFR layer (patch generators,
@@ -85,7 +99,7 @@ namespace
 // Matrix dimensions
 
 struct SpaceDef  { ColorStandard cs; const char * name; };
-struct EotfDef   { int mode; BOOL toneMap; const char * name; };
+struct EotfDef   { int mode; BOOL toneMap; double maxL; const char * name; };	// maxL 0 = default rule
 struct WhiteDef  { WhiteTarget wt; const char * name; };
 struct GridDef   { bool b10; bool lim; const char * name; };
 
@@ -108,14 +122,23 @@ static const SpaceDef kSpaces[] =
 // sRGB-the-EOTF is exercised through the sRGB color space (every consumer
 // forces mode 99 when m_colorStandard == sRGB), so the sRGB space runs a
 // single EOTF entry.
+// maxL overrides m_TargetMaxL for the entry (0 = the default rule in
+// ApplyComboConfig: 700 for HDR, 300 for tone-mapped HDR, 120 for SDR).
+// Tone mapping runs at BOTH knee positions: 300 nits puts BT.2390's knee BELOW
+// diffuse white (so the HDR reference-rescale / white-anchor conventions get
+// real coverage - see ApplyComboConfig), while 700 nits leaves diffuse white
+// untouched and moves the roll-off up among the AXIS patches that CLIP with
+// tone mapping off. Without the 700 row the "patches above m_TargetMaxL still
+// read dE ~ 0" invariant was only ever checked with tone mapping off.
 static const EotfDef kEotfs[] =
 {
-	{ 0, FALSE, "Power2.2"  },
-	{ 4, FALSE, "BT.1886"   },
-	{ 6, FALSE, "L-star"    },
-	{ 5, FALSE, "PQ"        },
-	{ 5, TRUE,  "PQ+BT2390" },
-	{ 7, FALSE, "HLG"       },
+	{ 0, FALSE,   0.0, "Power2.2"  },
+	{ 4, FALSE,   0.0, "BT.1886"   },
+	{ 6, FALSE,   0.0, "L-star"    },
+	{ 5, FALSE,   0.0, "PQ"        },
+	{ 5, TRUE,    0.0, "PQ+TM300"  },
+	{ 5, TRUE,  700.0, "PQ+TM700"  },
+	{ 7, FALSE,   0.0, "HLG"       },
 };
 
 // D65 plus two custom whites that were never hand-tested: DCI white and a
@@ -138,14 +161,24 @@ static const GridDef kGrids[] =
 	{ true,  false, "10b-full"},	// 1023
 };
 
-enum Family { FAM_GRAY = 0, FAM_PRIM, FAM_SAT100, FAM_SAT75, FAM_CC_GCD, FAM_CC_AXIS, FAM_CONV, FAM_COUNT };
-static const char * kFamilyName[FAM_COUNT] = { "gray", "prim", "sat100", "sat75", "ccGCD", "ccAXIS", "convPV" };
+enum Family { FAM_GRAY = 0, FAM_PRIM, FAM_SAT100, FAM_SAT75, FAM_CC_GCD, FAM_CC_AXIS,
+			  FAM_CONV, FAM_CONVW, FAM_CONVNW, FAM_COUNT };
+static const char * kFamilyName[FAM_COUNT] =
+	{ "gray", "prim", "sat100", "sat75", "ccGCD", "ccAXIS", "convPV", "convPVw", "convNW" };
+
+// The three convention families are DIFFERENTIAL (|grid dE - viewer dE|), not
+// dE ~ 0 invariants - see ConvCheck.
+static bool IsConvFamily ( int fam )
+{
+	return ( fam == FAM_CONV || fam == FAM_CONVW || fam == FAM_CONVNW );
+}
 
 struct Combo
 {
 	ColorStandard	std;
 	int				eotf;		// m_GammaOffsetType for the combo
 	BOOL			toneMap;
+	double			maxL;		// m_TargetMaxL override, 0 = default rule
 	WhiteTarget		white;
 	bool			b10;
 	bool			lim;
@@ -342,13 +375,20 @@ static CColor Meas ( CSimulatedSensor & sensor, const ColorRGBDisplay & rgb, dou
 // ~2985-3047) for the non-grayscale families. displayMode: 1 = primaries,
 // 5..10 = saturation sweeps, 11 = color checker. DVD (manual generator) is
 // FALSE here - the harness models the GDI-family wire.
+// The dE evaluation spaces, rebuilt once per combo by ApplyComboConfig.
+// Constructing a CColorReference is not cheap (matrix inversion + secondary
+// derivation) and these appear in the innermost dE loops; ContainerTransportReference
+// in particular builds a whole new reference on every call.
+static CColorReference *	s_pGridDERef = NULL;	// GetItemText's bRef
+static CColorReference *	s_pViewDERef = NULL;	// AppendMeasure's dERef
+
 static double GridColorDE ( const CMeasure & m, const CColor & aMeasure, const CColor & aReference,
 							double YWhiteIn, int displayMode, int nCol, int satsize )
 {
 	CColorHCFRConfig * cfg = GetConfig();
 	BOOL isHDR = ( cfg->m_GammaOffsetType == 5 && (displayMode == 1 || (displayMode >= 5 && displayMode <= 11)) );
 	double YWhite = YWhiteIn, RefWhite = 1.0;
-	CColorReference cRef = GetColorReference();
+	const CColorReference & cRef = GetColorReference();
 
 	if ( isHDR )
 	{
@@ -378,42 +418,47 @@ static double GridColorDE ( const CMeasure & m, const CColor & aMeasure, const C
 		}
 	}
 
-	CColorReference bRef = ((cRef.m_standard == UHDTV3 || cRef.m_standard == UHDTV4) ? ContainerTransportReference(cRef)
-						  : (cRef.m_standard == HDTVa || cRef.m_standard == HDTVb) ? CColorReference(HDTV) : cRef);
-
-	return aMeasure.GetDeltaE(YWhite, aReference, RefWhite, bRef, cfg->m_dE_form, false,
+	return aMeasure.GetDeltaE(YWhite, aReference, RefWhite, *s_pGridDERef, cfg->m_dE_form, false,
 							  cfg->m_GammaOffsetType == 5 ? 3 : cfg->gw_Weight);
 }
 
 /////////////////////////////////////////////////////////////////////////////
-// FAM_CONV: pane-vs-viewer dE convention equality (PQ HDR, mode 5 only).
+// The convention families: pane-vs-viewer dE equality.
 //
 // The 3D viewer computes sat/CC dE as
-//   measured.GetDeltaE( tmWhite, ref * GetHDRRefScale(), 1.0, ... , gw = 3 )
-// (Color3DView SceneDiffuseWhiteY + AppendMeasure). The measures grid uses
-// the GridColorDE chain above with the GetHDRRefScale reference rescale.
-// With the ideal sensor a perfect patch reads dE ~ 0 under EITHER convention,
-// so the wire-model families cannot see a convention mismatch. This check
-// perturbs the measured color (fixed asymmetric XYZ gains -> a few dE of
-// luminance + chroma error) and requires both formulas to yield the SAME dE.
-// The ideal sensor's prime white equals TmDiffuseWhiteNits exactly (the
-// 50.22831% wire code and the helper's 0.5022283 snap to the same grid code
-// on all four grids), so matched conventions agree to machine precision;
-// tone mapping ON exposes any 105.95640-vs-GetHDRRefScale divergence.
+//   measured.GetDeltaE( GetColorDEWhiteY(), ref * (10000/that white), 1.0, ... )
+// (Color3DView BuildScene + AppendMeasure). The measures grid uses the
+// GridColorDE chain above with the GetHDRRefScale reference rescale. With the
+// ideal sensor a perfect patch reads dE ~ 0 under EITHER convention, so the
+// wire-model families cannot see a convention mismatch. This check perturbs
+// the measured color (fixed asymmetric XYZ gains -> a few dE of luminance +
+// chroma error) and requires both formulas to yield the SAME dE.
 //
-// HDTVa/b are excluded: the grid normalizes their sat/CC dE to the measured
-// ON/OFF (peak) white while the viewer always uses the tone-mapped diffuse
-// white - a real, separate legacy divergence outside this check's scope.
+// What is genuinely SHARED with production here is the dE white: the viewer
+// side calls CMeasure::GetColorDEWhiteY, while the pane side is fed the
+// harness's own UpdateGrid emulation. So the check also locks "UpdateGrid's
+// YWhite selection == GetColorDEWhiteY", which is what the white-source
+// families below exercise. The reference scale and the dE evaluation space are
+// still re-derived on both sides - see ACCURACYTEST.md coverage gap 7.
+//
+// Three families run this same comparison under different measured state:
+//   convPV   nominal whites (the ideal sensor's prime white lands exactly on
+//            TmDiffuseWhiteNits, so the white SOURCE cannot be told apart)
+//   convPVw  the three stored whites pulled apart and off target (RunConvWhite)
+//   convNW   no white measured at all (RunConvNoWhite)
+// wDE is CMeasure::GetColorDEWhiteY for this family, passed in rather than
+// re-read per patch: the helper returns CColor copies internally, and
+// C3DColorView::BuildScene hoists it out of its patch loops for exactly that
+// reason - so hoisting here also keeps the emulation faithful.
 static void ConvCheck ( const CMeasure & m, const CColor & aColor, const CColor & refRaw,
-						double YWhite, int displayMode, int nCol, int satsize,
+						double YWhite, double wDE, int displayMode, int nCol, int satsize,
 						FamStat & stat, const char * name, int idx )
 {
 	CColorHCFRConfig * cfg = GetConfig();
-	if ( cfg->m_GammaOffsetType != 5 || !aColor.isValid() || !refRaw.isValid() )
-		return;
-	if ( cfg->m_colorStandard == HDTVa || cfg->m_colorStandard == HDTVb )
+	if ( !aColor.isValid() || !refRaw.isValid() )
 		return;
 
+	bool isHDR = ( cfg->m_GammaOffsetType == 5 );
 	bool bCC = ( displayMode == 11 );
 	bool mascior = ( bCC && cfg->m_CCMode >= MASCIOR50 && cfg->m_CCMode <= CCMAXHDR );
 
@@ -424,9 +469,11 @@ static void ConvCheck ( const CMeasure & m, const CColor & aColor, const CColor 
 
 	// Pane side: the Mascior HDR CC sets keep their * 100 convention on BOTH
 	// sides (RunCC applies it too) - scaling only the viewer side here would
-	// report a ~1.06x phantom mismatch the moment a Mascior set joins kSpaces.
+	// report a ~1.06x phantom mismatch. SDR rescales neither side (UpdateGrid's
+	// rescale block and the viewer's hdr10Refs are both mode-5 gated).
 	CColor refPane = refRaw;
-	ScaleXYZ(refPane, mascior ? 100. : m.GetHDRRefScale());
+	if ( isHDR )
+		ScaleXYZ(refPane, mascior ? 100. : m.GetHDRRefScale());
 	double dEpane = GridColorDE(m, pert, refPane, YWhite, displayMode, nCol, satsize);
 
 	// Viewer side, as C3DColorView::BuildScene builds it: the reference scaled
@@ -435,7 +482,6 @@ static void ConvCheck ( const CMeasure & m, const CColor & aColor, const CColor 
 	// YWhiteRef 1.0 is algebraically the grid's (ref * GetHDRRefScale(),
 	// RefWhite = YWhite/tmWhite) pair, so any drift between the two - a
 	// reference rescale, a white source, or a dE space - shows up here.
-	double wDE = m.GetColorDEWhiteY(false, bCC, mascior);
 	if ( wDE <= 0.0 )
 	{
 		// GetDeltaE would divide by this; a NaN here surfaces as a bogus 999
@@ -444,12 +490,39 @@ static void ConvCheck ( const CMeasure & m, const CColor & aColor, const CColor 
 		return;
 	}
 	CColor refView = refRaw;
-	ScaleXYZ(refView, mascior ? 100. : 10000. / wDE);
-	CColorReference vRef = ( GetColorReference().m_standard == UHDTV3 || GetColorReference().m_standard == UHDTV4 )
-						 ? ContainerTransportReference(GetColorReference()) : GetColorReference();
-	double dEview = pert.GetDeltaE(wDE, refView, 1.0, vRef, cfg->m_dE_form, false, 3);
+	if ( isHDR )
+		ScaleXYZ(refView, mascior ? 100. : 10000. / wDE);
+	// AppendMeasure's gw: 3 in mode 5, the configured weight otherwise.
+	double dEview = pert.GetDeltaE(wDE, refView, 1.0, *s_pViewDERef, cfg->m_dE_form, false,
+								   isHDR ? 3 : cfg->gw_Weight);
 
 	stat.Add(fabs(dEpane - dEview), "%s %d (pane %.3f vs viewer %.3f)", name, idx, dEpane, dEview);
+}
+
+// Measured patch + raw reference kept from the sat/CC runs so the white-source
+// families can REPLAY the convention comparison under different stored whites
+// without re-measuring (the whites are CMeasure state, not per-patch state).
+struct ConvSample
+{
+	CColor			meas;
+	CColor			ref;
+	int				displayMode;	// 5..10 saturation, 11 color checker
+	int				nCol;
+	const char *	name;
+	int				idx;
+};
+static const int kMaxConvSamples = 256;
+static ConvSample	s_convSamples[kMaxConvSamples];
+static int			s_nConvSamples = 0;
+
+static void KeepConvSample ( const CColor & meas, const CColor & ref, int displayMode,
+							 int nCol, const char * name, int idx )
+{
+	if ( s_nConvSamples >= kMaxConvSamples )
+		return;
+	ConvSample & s = s_convSamples[s_nConvSamples ++];
+	s.meas = meas; s.ref = ref; s.displayMode = displayMode;
+	s.nCol = nCol; s.name = name; s.idx = idx;
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -499,7 +572,7 @@ static void ApplyComboConfig ( const Combo & c )
 	// dE, not a wire-modeling error. (With black 0, BT.1886 degenerates to a
 	// pure 2.4 power - consistent on both sides.)
 	BOOL bHdr = ( c.eotf == 5 || c.eotf == 7 );
-	cfg->m_TargetMaxL = bHdr ? ( c.toneMap ? 300.0 : 700.0 ) : 120.0;
+	cfg->m_TargetMaxL = ( c.maxL > 0.0 ) ? c.maxL : ( bHdr ? ( c.toneMap ? 300.0 : 700.0 ) : 120.0 );
 	cfg->m_TargetMinL = 0.0;
 	cfg->m_bOverRideTargs = FALSE;
 	cfg->m_userBlack = FALSE;
@@ -521,6 +594,19 @@ static void ApplyComboConfig ( const Combo & c )
 	cfg->m_bHDR100 = FALSE;
 
 	RebuildColorReference();
+
+	// Cache the two dE evaluation spaces for the combo (see s_pGridDERef).
+	// GetItemText's bRef: transport space for the UHDTV3/4 pseudo-spaces,
+	// Rec.709 for the special standards, the active reference otherwise.
+	// AppendMeasure's dERef: transport for the pseudo-spaces, active otherwise
+	// (HDTVa/b need no branch - GetDeltaE forces Rec.709 for them internally).
+	const CColorReference & aRef = GetColorReference();
+	bool pseudo = ( aRef.m_standard == UHDTV3 || aRef.m_standard == UHDTV4 );
+	delete s_pGridDERef;
+	delete s_pViewDERef;
+	s_pGridDERef = new CColorReference( pseudo ? ContainerTransportReference(aRef)
+						 : ( aRef.m_standard == HDTVa || aRef.m_standard == HDTVb ) ? CColorReference(HDTV) : aRef );
+	s_pViewDERef = new CColorReference( pseudo ? ContainerTransportReference(aRef) : aRef );
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -755,6 +841,9 @@ static void RunSats ( const Combo & c, CMeasure & m, CSimulatedSensor & sensor, 
 	};
 
 	m.SetSaturationSize(kSatSize);
+	// Loop invariants, hoisted exactly as C3DColorView::BuildScene hoists them.
+	double YWhite = special ? m.GetOnOffWhite().GetY() : m.GetPrimeWhite().GetY();
+	double wDE = m.GetColorDEWhiteY(special, false, false);
 	for ( int s = 0 ; s < 6 ; s ++ )
 	{
 		ColorRGBDisplay GenColors[kSatSize];
@@ -765,8 +854,12 @@ static void RunSats ( const Combo & c, CMeasure & m, CSimulatedSensor & sensor, 
 			// MT_SAT_* patches are Intensity-dimmed on the real wire
 			CColor aColor = Meas(sensor, GenColors[j], c.intensity);
 			CColor refColor = m.GetRefSat(s, (double)j / (double)(kSatSize - 1), special, stim);
-			double YWhite = special ? m.GetOnOffWhite().GetY() : m.GetPrimeWhite().GetY();
-			ConvCheck(m, aColor, refColor, YWhite, 5 + s, j + 1, kSatSize, convStat, names[s], j);
+			ConvCheck(m, aColor, refColor, YWhite, wDE, 5 + s, j + 1, kSatSize, convStat, names[s], j);
+			// Only the 100% sweep feeds the white-source replays: the 75% sweep
+			// exercises the same normalization with a different reference, so
+			// keeping both would double the replay cost for no new convention.
+			if ( stim >= 1.0 )
+				KeepConvSample(aColor, refColor, 5 + s, j + 1, names[s], j);
 			if ( cfg->m_GammaOffsetType == 5 )
 				ScaleXYZ(refColor, m.GetHDRRefScale());	// UpdateGrid ~4294
 			double dE = GridColorDE(m, aColor, refColor, YWhite, 5 + s, j + 1, kSatSize);
@@ -802,6 +895,8 @@ static void RunCC ( const Combo & c, CMeasure & m, CSimulatedSensor & sensor, CC
 	BOOL isHDR = ( cfg->m_GammaOffsetType == 5 );
 	if ( m.GetOnOffWhite().isValid() && !isHDR && YWhiteOnOff > 0 && (YWhitePrime / YWhiteOnOff < 0.9) )
 		YWhite = YWhiteOnOff;
+	bool mascior = ( ccMode >= MASCIOR50 && ccMode <= CCMAXHDR );
+	double wDE = m.GetColorDEWhiteY(special, true, mascior);
 
 	for ( int j = 0 ; j < count ; j ++ )
 	{
@@ -809,14 +904,142 @@ static void RunCC ( const Combo & c, CMeasure & m, CSimulatedSensor & sensor, CC
 		CColor aColor = Meas(sensor, GenColors[j], 1.0);
 		CColor refColor;
 		m.GetRefCC24Sat(j, refColor);
-		ConvCheck(m, aColor, refColor, YWhite, 11, j + 1, kSatSize, convStat, "patch", j);
+		ConvCheck(m, aColor, refColor, YWhite, wDE, 11, j + 1, kSatSize, convStat, "patch", j);
+		// One CC set feeds the replays (the GCD run, which is also the CC mode
+		// left active afterwards - see RunConvWhite), stratified every 4th
+		// patch: a white-source split shows on every patch, so the replay only
+		// needs a spread across the luminance range, not all 24.
+		if ( ccMode == GCD && (j % 4) == 0 )
+			KeepConvSample(aColor, refColor, 11, j + 1, "patch", j);
 		if ( cfg->m_GammaOffsetType == 5 )
-			ScaleXYZ(refColor, (ccMode >= MASCIOR50 && ccMode <= CCMAXHDR) ? 100. : m.GetHDRRefScale());	// UpdateGrid ~4296-4307
+			ScaleXYZ(refColor, mascior ? 100. : m.GetHDRRefScale());	// UpdateGrid ~4296-4307
 		double dE = GridColorDE(m, aColor, refColor, YWhite, 11, j + 1, kSatSize);
 		stat.Add(dE, "patch %d (%.2f/%.2f/%.2f%%)", j, GenColors[j][0], GenColors[j][1], GenColors[j][2]);
 	}
 
 	cfg->m_CCMode = GCD;
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// FAM_CONVW: the same pane-vs-viewer comparison with the measured whites
+// pulled OFF their theoretical values, and off EACH OTHER.
+//
+// This is coverage gap 1. With the ideal sensor the measured prime white lands
+// exactly on TmDiffuseWhiteNits (the 50.22831% wire code and the helper's
+// snapped 0.5022283 reach the same grid code on all four grids), so every
+// candidate white - prime, ON/OFF, grayscale top, theoretical tmWhite - has
+// the SAME value and a consumer normalizing by the wrong one is invisible.
+// That is exactly how the 3D viewer shipped a ~1% dE offset against the grid
+// (grid 8.80 vs viewer 8.72 on a display 3.5% below target).
+//
+// The perturbation is applied to the STORED whites rather than to the sensor:
+// both consumers read the same CMeasure, so a differential check only needs
+// the state to differ, and scaling the three whites by DIFFERENT factors makes
+// them mutually distinguishable - a consumer reading prime where the grid
+// reads ON/OFF (or the theoretical white) cannot hide behind a common factor.
+// A real display cannot have its grayscale top and its ON/OFF white disagree;
+// that is deliberate, and it is why this family asserts only the differential,
+// never dE ~ 0.
+//
+// The gains are otherwise arbitrary; 0.965 on prime white reproduces the
+// 3.5%-low display that surfaced the original bug.
+static const double kPrimeWhiteGain = 0.965;
+static const double kOnOffWhiteGain = 0.982;
+static const double kGrayTopGain    = 0.973;
+
+static void RunConvWhite ( const Combo & c, CMeasure & m, FamStat & stat )
+{
+	CColorHCFRConfig * cfg = GetConfig();
+	bool special = ( cfg->m_colorStandard == HDTVa || cfg->m_colorStandard == HDTVb );
+	int gs = m.GetGrayScaleSize();
+	if ( gs <= 0 || s_nConvSamples == 0 )
+		return;
+
+	CColor savePrime = m.GetPrimeWhite();
+	CColor saveOnOff = m.GetOnOffWhite();
+	CColor saveTop   = m.GetGray(gs - 1);
+
+	CColor p = savePrime; ScaleXYZ(p, kPrimeWhiteGain); m.SetPrimeWhite(p);
+	CColor o = saveOnOff; ScaleXYZ(o, kOnOffWhiteGain); m.SetOnOffWhite(o);
+	CColor t = saveTop;   ScaleXYZ(t, kGrayTopGain);    m.SetGray(gs - 1, t);
+
+	// Deliberately NO RefreshHdrTargets here: leaving m_TargetMaxL (and with it
+	// tmWhite / GetHDRRefScale) at its converged value is what DECOUPLES the
+	// measured white from the theoretical one. Refreshing would drag the
+	// theoretical white along and restore the accidental equality.
+	double YWhitePrime = m.GetPrimeWhite().GetY();
+	double YWhiteOnOff = m.GetOnOffWhite().GetY();
+	BOOL isHDR = ( cfg->m_GammaOffsetType == 5 );
+	bool mascior = ( cfg->m_CCMode >= MASCIOR50 && cfg->m_CCMode <= CCMAXHDR );
+
+	// UpdateGrid's default-case YWhite (MainView.cpp ~3814-3826) recomputed from
+	// the PERTURBED state, plus the matching shared white - one pair for the
+	// saturation samples, one for the color-checker samples.
+	double YWhiteSat = special ? YWhiteOnOff : YWhitePrime;
+	double YWhiteCC  = YWhiteSat;
+	if ( m.GetOnOffWhite().isValid() && !isHDR && YWhiteOnOff > 0 && (YWhitePrime / YWhiteOnOff < 0.9) )
+		YWhiteCC = YWhiteOnOff;
+	double wDESat = m.GetColorDEWhiteY(special, false, false);
+	double wDECC  = m.GetColorDEWhiteY(special, true, mascior);
+
+	for ( int i = 0 ; i < s_nConvSamples ; i ++ )
+	{
+		const ConvSample & s = s_convSamples[i];
+		bool bCC = ( s.displayMode == 11 );
+		ConvCheck(m, s.meas, s.ref, bCC ? YWhiteCC : YWhiteSat, bCC ? wDECC : wDESat,
+				  s.displayMode, s.nCol, kSatSize, stat, s.name, s.idx);
+	}
+
+	m.SetPrimeWhite(savePrime);
+	m.SetOnOffWhite(saveOnOff);
+	m.SetGray(gs - 1, saveTop);
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// FAM_CONVNW: a saturation sweep with NO grayscale and NO primaries run.
+//
+// Coverage gap 5: the matrix always runs gray -> primaries -> sat/CC, so
+// PrimeWhite and OnOffWhite are always valid and neither the grid's
+// m_TargetMaxL fallback (MainView.cpp ~3699-3706) nor GetColorDEWhiteY's
+// matching fallback is ever reached. A user who measures a saturation sweep
+// first hits exactly this state. The wire-model dE is meaningless here (the
+// references are normalized by a white that was never measured), so this
+// family asserts only the pane/viewer agreement - and that nothing produces a
+// NaN, which is what an unguarded divide by a missing white looks like.
+static void RunConvNoWhite ( const Combo & c, CSimulatedSensor & sensor, FamStat & stat )
+{
+	CColorHCFRConfig * cfg = GetConfig();
+	bool special = ( cfg->m_colorStandard == HDTVa || cfg->m_colorStandard == HDTVb );
+	static const char * names[6] = { "red", "green", "blue", "yellow", "cyan", "magenta" };
+	static const bool flags[6][3] =
+	{
+		{ true,false,false }, { false,true,false }, { false,false,true },
+		{ true,true,false }, { false,true,true }, { true,false,true },
+	};
+
+	// A pristine CMeasure: no gray array, no primaries, no on/off pair.
+	CMeasure m;
+	m.SetSaturationSize(kSatSize);
+
+	// Both whites are invalid, so the grid falls all the way through to
+	// m_TargetMaxL - the value ApplyComboConfig set, since no measurement ever
+	// refreshed it. GetColorDEWhiteY must land on the same fallback.
+	double YWhite = cfg->m_TargetMaxL;
+	double wDE = m.GetColorDEWhiteY(special, false, false);
+
+	for ( int s = 0 ; s < 6 ; s ++ )
+	{
+		ColorRGBDisplay GenColors[kSatSize];
+		GenerateSaturationColors(GetColorReference(), GenColors, kSatSize, flags[s][0], flags[s][1], flags[s][2],
+								 cfg->m_GammaOffsetType, 1.0, cfg->GetUse10bitLevels() != FALSE, cfg->GetRGB16_235() != FALSE);
+		for ( int j = 0 ; j < kSatSize ; j ++ )
+		{
+			CColor aColor = Meas(sensor, GenColors[j], c.intensity);
+			CColor refColor = m.GetRefSat(s, (double)j / (double)(kSatSize - 1), special, 1.0);
+			ConvCheck(m, aColor, refColor, YWhite, wDE, 5 + s, j + 1, kSatSize,
+					  stat, names[s], j);
+		}
+	}
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -827,8 +1050,10 @@ static double TolFor ( const Combo & c, int fam )
 	// Matched pane/viewer conventions agree to machine precision (identical
 	// GetDeltaE arguments), while the legacy 105.95640 pane convention reads
 	// 0.015-0.023 under 300-nit tone mapping - the default 0.05 would let a
-	// convention regression back in.
-	if ( fam == FAM_CONV )
+	// convention regression back in. The white-source families need the same
+	// tightness: normalizing by the wrong white moves dE by ~1%, which on a
+	// ~5 dE perturbed patch is ~0.05 - exactly the default tolerance.
+	if ( IsConvFamily(fam) )
 		return 0.005;
 	if ( c.intensity < 0.999 )
 	{
@@ -880,6 +1105,7 @@ static void RunCombo ( const Combo & c )
 	sensor.Init(FALSE);
 
 	FamStat stats[FAM_COUNT];
+	s_nConvSamples = 0;
 
 	// Order matters and mirrors real usage: grayscale bootstraps
 	// OnOffWhite/OnOffBlack (the HLG/BT.1886 reference decode White), then
@@ -890,6 +1116,12 @@ static void RunCombo ( const Combo & c )
 	RunSats(c, m, sensor, 0.75, stats[FAM_SAT75], stats[FAM_CONV]);
 	RunCC(c, m, sensor, GCD, 24, stats[FAM_CC_GCD], stats[FAM_CONV]);
 	RunCC(c, m, sensor, AXIS, 71, stats[FAM_CC_AXIS], stats[FAM_CONV]);
+
+	// White-source coverage, last: RunConvWhite mutates the stored whites (and
+	// restores them), RunConvNoWhite builds its own empty CMeasure. Neither
+	// must run before the wire-model families above.
+	RunConvWhite(c, m, stats[FAM_CONVW]);
+	RunConvNoWhite(c, sensor, stats[FAM_CONVNW]);
 
 	// Evaluate
 	char line[512];
@@ -927,7 +1159,7 @@ static void RunCombo ( const Combo & c )
 			else
 			{
 				bFail = TRUE;
-				Detail("FAIL        %s %s %s %s %.0f%% [%s]: worst dE %.3f (tol %.2f) at %s\n",
+				Detail("FAIL        %s %s %s %s %.0f%% [%s]: worst dE %.3f (tol %.3f) at %s\n",
 					   c.stdName, c.eotfName, c.whiteName, c.gridName, c.intensity * 100.,
 					   kFamilyName[fam], w, tol, stats[fam].desc);
 			}
@@ -993,13 +1225,14 @@ int RunAccuracyTest ( const char * pReportPath )
 	fprintf(s_fReport, "ColorHCFR /accuracytest - reference == wire == sensor-model matrix\n");
 	fprintf(s_fReport, "Columns are the worst dE per patch family; '*' = over tolerance (FAIL),\n");
 	fprintf(s_fReport, "'#' = over tolerance but documented KNOWN-FAIL (see detail below).\n");
-	fprintf(s_fReport, "Tolerance: 0.05; Intensity-90%% combos: 0.9 (power law) / 1.5 (other EOTFs); convPV: 0.005\n");
+	fprintf(s_fReport, "Tolerance: 0.05; Intensity-90%% combos: 0.9 (power law) / 1.5 (other EOTFs); conv*: 0.005\n");
 	fprintf(s_fReport, "dE settings: dE_form=3 (CIE2000), dE_gray=1 (gamma-predicted gray target), gw_Weight=0\n");
-	fprintf(s_fReport, "convPV: |grid dE - 3D-viewer dE| for a perturbed patch (PQ mode-5 combos only;\n");
-	fprintf(s_fReport, "-1.000 = family not run) - locks the unified HDR reference-rescale convention\n\n");
-	fprintf(s_fReport, "%-8s %-10s %-6s %-8s %-5s %8s %7s %7s %7s %7s %7s %7s  %s\n",
+	fprintf(s_fReport, "conv* families are DIFFERENTIAL: |grid dE - 3D-viewer dE| for a perturbed patch\n");
+	fprintf(s_fReport, "(-1.000 = family not run). convPV = nominal whites; convPVw = the three stored\n");
+	fprintf(s_fReport, "whites pulled off target and off each other; convNW = no white measured at all.\n\n");
+	fprintf(s_fReport, "%-8s %-10s %-6s %-8s %-5s %8s %7s %7s %7s %7s %7s %7s %7s %7s  %s\n",
 			"space", "eotf", "white", "grid", "inten",
-			"gray", "prim", "sat100", "sat75", "ccGCD", "ccAXIS", "convPV", "result");
+			"gray", "prim", "sat100", "sat75", "ccGCD", "ccAXIS", "convPV", "convPVw", "convNW", "result");
 
 	int iSpace, iEotf, iWhite, iGrid, iInt;
 	for ( iSpace = 0 ; iSpace < (int)(sizeof(kSpaces)/sizeof(kSpaces[0])) ; iSpace ++ )
@@ -1032,6 +1265,7 @@ int RunAccuracyTest ( const char * pReportPath )
 						c.std = sp.cs;
 						c.eotf = eotf;
 						c.toneMap = ( sp.cs == sRGB ) ? FALSE : e.toneMap;
+						c.maxL = ( sp.cs == sRGB ) ? 0.0 : e.maxL;
 						c.white = kWhites[iWhite].wt;
 						c.b10 = kGrids[iGrid].b10;
 						c.lim = kGrids[iGrid].lim;

--- a/libHCFR/Color.cpp
+++ b/libHCFR/Color.cpp
@@ -1186,9 +1186,20 @@ int ColorXYZ::GetColorTemp(const CColorReference& colorReference) const
 
 }
 
+// Rec.709/D65 - the space the special standards (HDTVa/HDTVb/CC6) are always
+// evaluated in. Built once: a CColorReference constructor derives the RGB->XYZ
+// matrix, inverts it and solves four line intersections for the secondaries,
+// and this value never varies. Both dE entry points used to build one on EVERY
+// call, which dominated their cost (the measures grid alone evaluates them four
+// times per cell per refresh, and /accuracytest a few hundred thousand times).
+static const CColorReference & SpecialModeReference()
+{
+	static const CColorReference s_ref(HDTV, D65, 2.2);
+	return s_ref;
+}
+
 double ColorXYZ::GetDeltaLCH(double YWhite, const ColorXYZ& refColor, double YWhiteRef, const CColorReference & colorReference, int dE_form, bool isGS, int gw_Weight, double &dChrom, double &dHue ) const
 {
-	CColorReference cRef=CColorReference(HDTV, D65, 2.2); //special modes assume rec.709
 	double dLight;
 	if (YWhite <= 0) YWhite = 120.;
 	if (YWhiteRef <= 0) YWhiteRef = 1.0;
@@ -1208,8 +1219,9 @@ double ColorXYZ::GetDeltaLCH(double YWhite, const ColorXYZ& refColor, double YWh
         YWhite = 0.05 * YWhite;
     }
     }
-	if (!(colorReference.m_standard == HDTVb || colorReference.m_standard == CC6 || colorReference.m_standard == HDTVa))
-		cRef=colorReference;
+	const CColorReference & cRef =
+		(colorReference.m_standard == HDTVb || colorReference.m_standard == CC6 || colorReference.m_standard == HDTVa)
+		? SpecialModeReference() : colorReference;	//special modes assume rec.709
 	switch (dE_form)
 	{
 		case 0:
@@ -1714,7 +1726,6 @@ double getL_EOTF ( double valx, CColor White, CColor Black, double g_rel, double
 
 double ColorXYZ::GetDeltaE(double YWhite, const ColorXYZ& refColor, double YWhiteRef, const CColorReference & colorReference, int dE_form, bool isGS, int gw_Weight ) const
 {
-	CColorReference cRef=CColorReference(HDTV, D65, 2.2); //special modes assume rec.709
 	double dE;
 	if (YWhite <= 0) YWhite = 120.;
 	if (YWhiteRef <= 0) YWhiteRef = 1.0;
@@ -1733,8 +1744,9 @@ double ColorXYZ::GetDeltaE(double YWhite, const ColorXYZ& refColor, double YWhit
 			YWhite = 0.05 * YWhite;
 		}
     }
-	if (!(colorReference.m_standard == HDTVb || colorReference.m_standard == CC6 || colorReference.m_standard == HDTVa))
-		cRef=colorReference;
+	const CColorReference & cRef =
+		(colorReference.m_standard == HDTVb || colorReference.m_standard == CC6 || colorReference.m_standard == HDTVa)
+		? SpecialModeReference() : colorReference;	//special modes assume rec.709
 	switch (dE_form)
 	{
 		case 0:

--- a/libHCFR/Color.cpp
+++ b/libHCFR/Color.cpp
@@ -1200,7 +1200,16 @@ static const CColorReference & SpecialModeReference()
 
 double ColorXYZ::GetDeltaLCH(double YWhite, const ColorXYZ& refColor, double YWhiteRef, const CColorReference & colorReference, int dE_form, bool isGS, int gw_Weight, double &dChrom, double &dHue ) const
 {
-	double dLight;
+	// MATH-010: dE_form indexes the switch below, which has no default case, so
+	// an out-of-range value (a corrupt ini, or a formula added to the UI but not
+	// here) fell through every case and returned an UNINITIALIZED double.
+	// Clamped rather than defaulted to 0: a 0 would read as a perfect colour
+	// match, which is a worse failure than an obviously wrong number because it
+	// is plausible. CIE2000 is the standard general-purpose formula, so an
+	// unrecognized index at least yields a defined, comparable value.
+	if ( dE_form < 0 || dE_form > 6 )
+		dE_form = 3;
+	double dLight = 0.0;
 	if (YWhite <= 0) YWhite = 120.;
 	if (YWhiteRef <= 0) YWhiteRef = 1.0;
     //gray world weighted white reference
@@ -1726,7 +1735,11 @@ double getL_EOTF ( double valx, CColor White, CColor Black, double g_rel, double
 
 double ColorXYZ::GetDeltaE(double YWhite, const ColorXYZ& refColor, double YWhiteRef, const CColorReference & colorReference, int dE_form, bool isGS, int gw_Weight ) const
 {
-	double dE;
+	// MATH-010, as in GetDeltaLCH above: no default case, so an out-of-range
+	// dE_form returned an uninitialized double. Clamp to CIE2000.
+	if ( dE_form < 0 || dE_form > 6 )
+		dE_form = 3;
+	double dE = 0.0;
 	if (YWhite <= 0) YWhite = 120.;
 	if (YWhiteRef <= 0) YWhiteRef = 1.0;
     //gray world weighted white reference

--- a/tests/ACCURACYTEST.md
+++ b/tests/ACCURACYTEST.md
@@ -54,7 +54,7 @@ settings-saving teardown.
 
 ## The matrix
 
-Full cross product where meaningful (876 combos):
+Full cross product where meaningful (834 combos):
 
 - **Grid (bit depth x range)**: 8-bit limited (219), 8-bit full (255),
   10-bit limited (876), 10-bit full (1023) — via the cached
@@ -80,10 +80,15 @@ Full cross product where meaningful (876 combos):
   The custom whites were never hand-tested; the known-fail table below
   documents where the references are still D65-bound.
 - **Generator**: automatic (GDI) always; **manual (DVD)** additionally for the
-  three PQ rows at D65. Every `if (DVD)` carve-out in `GetItemText` /
-  `UpdateGrid` sits inside the mode-5 HDR block, and the carve-outs swap a
-  diffuse-white *constant* rather than a chromaticity, so PQ-at-D65 reaches all
-  of them without tripling the matrix.
+  three PQ rows at D65, on the limited-range grids only. Every `if (DVD)`
+  carve-out in `GetItemText` / `UpdateGrid` sits inside the mode-5 HDR block,
+  and the carve-outs swap a diffuse-white *constant* rather than a
+  chromaticity, so PQ-at-D65 reaches all of them without tripling the matrix.
+  Limited-range only because `RefreshUse10bitLevels` forces
+  `m_bRGB16_235 = TRUE` for the manual generator ("consumer disc video is
+  16-235 by definition"), so a full-range DVD combo would model a wire the app
+  cannot emit — and would calibrate the DVD known-fail ceilings on rows that
+  can never occur.
   DVD combos score **only** the `conv*` columns; the wire families print
   `-1.000`. HCFR emits no patches at all with a manual generator — the "wire" is
   the disc the user plays, and the DVD conventions are built for the Mascior
@@ -141,9 +146,9 @@ viewer that no longer exists, and re-enabling it turned out to need only that
 `bSpecial` be threaded through to `GetColorDEWhiteY`.
 
 - `convPV` — nominal measured state.
-- `convPVw` — the same comparison with the three stored whites (prime, ON/OFF,
-  grayscale top) scaled **off target and off each other** (0.965 / 0.982 /
-  0.973). This is the family that would have caught the shipped bug. With the
+- `convPVw` — the same comparison with the two stored whites (prime and ON/OFF)
+  scaled **off target and off each other** (0.965 / 0.982).
+  This is the family that would have caught the shipped bug. With the
   ideal sensor every candidate white — prime, ON/OFF, gray top, theoretical
   `TmDiffuseWhiteNits` — has the *same* value by construction (the 50.22831%
   wire code and the helper's snapped `0.5022283` reach the same grid code on all
@@ -152,14 +157,23 @@ viewer that no longer exists, and re-enabling it turned out to need only that
   a display whose white misses target (found by hand: grid 8.80 vs viewer 8.72).
   The perturbation is applied to the **stored** whites, not to the sensor: both
   consumers read the same `CMeasure`, so a differential check only needs the
-  state to differ, and three *different* factors make the whites mutually
-  distinguishable. A real display cannot have its grayscale top disagree with
-  its ON/OFF white — that is deliberate, and it is why this family asserts only
-  the differential, never dE ~ 0.
-- `convNW` — a saturation sweep on a pristine `CMeasure`: **no** grayscale and
-  **no** primaries, so both whites are invalid and the grid falls through to its
-  `m_TargetMaxL` fallback (MainView.cpp ~3699-3706), which the always-ordered
-  gray → primaries → sat/CC matrix never reaches. A user who measures a
+  state to differ, and two *different* factors make the whites mutually
+  distinguishable. A real display cannot have its prime white and its ON/OFF
+  white disagree by different amounts — that is deliberate, and it is why this
+  family asserts only the differential, never dE ~ 0.
+  The **grayscale-top** white is *not* covered: it is read only through
+  `GetColorDEWhiteY`'s Mascior branch, and no Mascior CC set is in the matrix
+  (gap 3), so perturbing it changed nothing. That third gain was removed rather
+  than left in place looking like coverage.
+- `convNW` — a saturation sweep with the measured whites explicitly
+  invalidated, so the grid falls through to its `m_TargetMaxL` fallback
+  (MainView.cpp ~3699-3706), which the always-ordered gray → primaries → sat/CC
+  matrix never reaches. Note a default-constructed `CMeasure` is **not**
+  white-less: its constructor pre-loads prime, ON/OFF and the grayscale top to
+  plausible display values at `Y = m_TargetMaxL`, and `isValid()` only rejects
+  components ≤ −1.0. Relying on a fresh object alone made this family read
+  0.000 for the wrong reason — both sides landed on `m_TargetMaxL`, one by
+  fallback and one by coincidence — so the whites are now cleared explicitly. A user who measures a
   saturation sweep first lands exactly here. The wire-model dE is meaningless in
   this state (the references are normalized by a white that was never measured),
   so this family also asserts only the differential — and that nothing produces
@@ -266,8 +280,16 @@ run is reported as STALE. Current entries (expected, pre-existing):
   viewer. Two magnitudes, matching the two sub-branches: 0.49–0.70 where the
   measured white is left alone (saturation modes for HDTV/UHDTV, and UHDTV2's
   last saturation column), 0.02–0.07 where the `94.37844/tmWhite` rescale very
-  nearly cancels the reference offset. Ceilings are split (1.5 / 0.3) so a
-  regression in the near-cancelling half cannot hide under the other's headroom.
+  nearly cancels the reference offset. Ceilings are 1.5 / 0.3 by color space.
+  **Known limitation:** the two sub-branches are selected by *displayMode*, but
+  `RunSats` and `RunCC` accumulate into the same `FamStat`, which keeps only the
+  worst — so on HDTV/UHDTV/UHDTV2, where the saturation branch already reaches
+  ~0.70, a color-checker regression stays hidden until it exceeds 1.5. The four
+  spaces that only ever take the near-cancelling branch are fully protected by
+  the 0.3 ceiling. Separating them needs per-displayMode `FamStat`s.
+  Manual-generator combos run on the **limited-range grids only**:
+  `RefreshUse10bitLevels` forces `m_bRGB16_235 = TRUE` for that generator, so a
+  full-range DVD combo would model a wire the app cannot emit.
   Recorded rather than fixed because the 2026-07 unification *deliberately* left
   DVD legacy, and closing it means choosing which convention wins — a
   user-visible number change on a legacy path. The structural fix is coverage
@@ -340,9 +362,10 @@ agree), and the gaps below are mostly places their reach stops.
    is the better fix than an export family: if Export calls it, there is nothing
    left to diverge.
 
-Reference result (2026-07-25): `876 combos: 333 pass, 0 FAIL, 543 known-fail`,
+Reference result (2026-07-26): `834 combos: 333 pass, 0 FAIL, 501 known-fail`,
 ColorMathTest verify green with no golden movement. (Was `708 combos: 311 pass,
 0 FAIL, 397 known-fail` before this work: +84 tone-mapped 700-nit combos and +84
-manual-generator combos, the latter all landing in the new DVD known-fail.
+manual-generator combos (limited-range grids only), the latter all landing in
+the new DVD known-fail.
 On the GDI half the three convention families read 0.000 across the whole
 matrix.)

--- a/tests/ACCURACYTEST.md
+++ b/tests/ACCURACYTEST.md
@@ -54,7 +54,7 @@ settings-saving teardown.
 
 ## The matrix
 
-Full cross product where meaningful (792 combos):
+Full cross product where meaningful (876 combos):
 
 - **Grid (bit depth x range)**: 8-bit limited (219), 8-bit full (255),
   10-bit limited (876), 10-bit full (1023) — via the cached
@@ -79,6 +79,18 @@ Full cross product where meaningful (792 combos):
 - **White point**: D65, DCI white, and manual xy 0.3067/0.3180 (`DCUST`).
   The custom whites were never hand-tested; the known-fail table below
   documents where the references are still D65-bound.
+- **Generator**: automatic (GDI) always; **manual (DVD)** additionally for the
+  three PQ rows at D65. Every `if (DVD)` carve-out in `GetItemText` /
+  `UpdateGrid` sits inside the mode-5 HDR block, and the carve-outs swap a
+  diffuse-white *constant* rather than a chromaticity, so PQ-at-D65 reaches all
+  of them without tripling the matrix.
+  DVD combos score **only** the `conv*` columns; the wire families print
+  `-1.000`. HCFR emits no patches at all with a manual generator — the "wire" is
+  the disc the user plays, and the DVD conventions are built for the Mascior
+  disc's 50.0% / 92.254965-nit white rather than the 50.22831% code the
+  simulated sensor is fed, so `reference == wire` has no meaning there. The
+  families still *run* (they bootstrap the measured whites and collect the
+  convention samples), they are just not scored.
 - **Window intensity**: 100% always; 90% additionally for the SDR transfer
   functions (the generator UI disables Intensity for PQ/HLG). Intensity is
   deliberately NOT modeled by the references — it dims the measured white
@@ -103,6 +115,7 @@ measured gray top as White; then primaries, which set PrimeWhite):
   indices 0..70) via `GenerateCC24Colors`. AXIS covers the clipped-ramp-top
   cases in PQ: patches above `m_TargetMaxL` must STILL read dE ~ 0 because
   the reference models the same per-channel clip.
+
 ### The convention families (`convPV` / `convPVw` / `convNW`)
 
 The wire-model families above read dE ~ 0 under *any* self-consistent
@@ -242,6 +255,25 @@ run is reported as STALE. Current entries (expected, pre-existing):
   exactly code 110/219, so 0.75 stim = an exact half-code (82.5); generator
   and reference reach it through different matrix round trips whose sub-1e-9
   dust splits the tie (constant dE 0.74 at yellow).
+- **Manual generator (DVD), all `conv*` families**: a real, newly-detected
+  **grid-vs-3D-viewer divergence**, not a modeling gap — the first thing the DVD
+  axis found. `GetItemText` keeps the legacy DVD conventions for mode 5 (the
+  Mascior disc's 92.254965-nit white instead of `TmDiffuseWhiteNits`, the fixed
+  `105.95640` rescale instead of `GetHDRRefScale`, and in its second sub-branch
+  an extra `YWhite * 94.37844 / tmWhite`), while `C3DColorView::BuildScene` has
+  **no** manual-generator branch and always uses the unified pair. A user
+  measuring from a disc therefore sees one dE in the pane and another in the 3D
+  viewer. Two magnitudes, matching the two sub-branches: 0.49–0.70 where the
+  measured white is left alone (saturation modes for HDTV/UHDTV, and UHDTV2's
+  last saturation column), 0.02–0.07 where the `94.37844/tmWhite` rescale very
+  nearly cancels the reference offset. Ceilings are split (1.5 / 0.3) so a
+  regression in the near-cancelling half cannot hide under the other's headroom.
+  Recorded rather than fixed because the 2026-07 unification *deliberately* left
+  DVD legacy, and closing it means choosing which convention wins — a
+  user-visible number change on a legacy path. The structural fix is coverage
+  gap 7's shared `CMeasure` normalization helper: if the viewer, Export and
+  RGBLevelWnd all ask `CMeasure` for the normalization, the DVD carve-out lives
+  in exactly one place and this divergence cannot exist.
 - **`gray` on the full-range grids**: the gray pipeline (`GetGrayPercent` /
   `ArrayIndexToGrayLevel` / `GrayLevelToGrayProp`) has no range parameter —
   ramp codes and references live on the 219/876 limited grids and the
@@ -275,17 +307,15 @@ agree), and the gaps below are mostly places their reach stops.
 5. ~~**Whites are always present.**~~ Closed by `convNW`.
 9. ~~**Hard-clip coverage is tone-map-OFF only.**~~ Closed by the second
    tone-mapped EOTF row at `TargetMaxL = 700`.
+2. ~~**The manual generator (DVD) is never configured.**~~ Closed by the
+   generator axis — and it immediately found a real grid-vs-3D-viewer
+   divergence, now the DVD known-fail entry above. The `if (DVD)` carve-outs in
+   `InitGrid`, `RGBLevelWnd` and Export are still not *directly* covered: they
+   duplicate the same normalization, which is gap 7's problem, not a separate
+   axis.
 
 ### Still open
 
-2. **The manual generator (DVD) is never configured.** `RunAccuracyTest` sets
-   `enumAutomatic` unconditionally, so every `if (DVD)` carve-out — in
-   `GetItemText`, `UpdateGrid`, `InitGrid`, `RGBLevelWnd`, and the Export
-   blocks — is untested. Two real bugs hid there. Note the DVD paths use a
-   different white (`getL_EOTF(0.50,…) * 100`, un-snapped) than
-   `TmDiffuseWhiteNits`, so the references have to model that; and the 3D viewer
-   has **no** DVD carve-out at all, so `convPV` under a manual generator is
-   expected to surface a real grid-vs-viewer split rather than read 0.
 3. **Mascior HDR CC sets are never run.** `RunCC` is only called with `GCD` and
    `AXIS`; the whole `m_CCMode in [MASCIOR50..CCMAXHDR]` family (its `* 100`
    reference scale and grayscale-top white) has zero coverage in the harness,
@@ -310,7 +340,9 @@ agree), and the gaps below are mostly places their reach stops.
    is the better fix than an export family: if Export calls it, there is nothing
    left to diverge.
 
-Reference result (2026-07-25): `792 combos: 333 pass, 0 FAIL, 459 known-fail`,
+Reference result (2026-07-25): `876 combos: 333 pass, 0 FAIL, 543 known-fail`,
 ColorMathTest verify green with no golden movement. (Was `708 combos: 311 pass,
-0 FAIL, 397 known-fail` before the 84 tone-mapped 700-nit combos were added;
-the three convention families read 0.000 across the whole matrix.)
+0 FAIL, 397 known-fail` before this work: +84 tone-mapped 700-nit combos and +84
+manual-generator combos, the latter all landing in the new DVD known-fail.
+On the GDI half the three convention families read 0.000 across the whole
+matrix.)

--- a/tests/ACCURACYTEST.md
+++ b/tests/ACCURACYTEST.md
@@ -11,6 +11,11 @@ through `CSimulatedSensor` (error injection off) and asserting dE ~ 0 with the
 (= `105.95640` with tone mapping off), the `tmWhite`-based `RefWhite`, the
 per-view YWhite source — gray-ramp top, PrimeWhite, or OnOff white).
 
+It also runs a second, **differential** kind of check — the `conv*` families —
+that asks whether two *consumers* (the measures grid and the 3D viewer) agree
+about a dE convention. The dE ~ 0 invariant structurally cannot answer that; see
+[The convention families](#the-convention-families-convpv--convpvw--convnw).
+
 ## Relation to `tests\ColorMathTest`
 
 They are complementary layers — run **both** after any color-math change:
@@ -32,10 +37,11 @@ Debug\ColorHCFR.exe /accuracytest [report.txt]
 echo %ERRORLEVEL%     rem 0 = pass, 1 = failures, 2 = cannot write report
 ```
 
-Headless: no windows, no generators, no real measure loops; the run takes
-seconds and writes `accuracytest_report.txt` (or the given path) in the
-current directory. When started from a console it also prints progress and
-the summary line.
+Headless: no windows, no generators, no real measure loops. The run takes a
+few minutes (~5-6 on a current desktop; it evaluates on the order of a million
+`GetDeltaE` calls) and writes `accuracytest_report.txt` (or the given path) in
+the current directory. When started from a console it also prints per-EOTF
+progress and the summary line.
 
 Truly headless and config-safe, so it is safe to run in CI on a fresh machine.
 The hook sets `CColorHCFRConfig::s_bHeadless` **before** constructing the
@@ -48,7 +54,7 @@ settings-saving teardown.
 
 ## The matrix
 
-Full cross product where meaningful (~800 combos):
+Full cross product where meaningful (792 combos):
 
 - **Grid (bit depth x range)**: 8-bit limited (219), 8-bit full (255),
   10-bit limited (876), 10-bit full (1023) — via the cached
@@ -56,11 +62,20 @@ Full cross product where meaningful (~800 combos):
 - **Color space**: HDTV (Rec.709), sRGB, UHDTV (P3), UHDTV2 (BT.2020),
   UHDTV3 (P3-in-2020), UHDTV4 (709-in-2020), HDTVa (75%), HDTVb (plasma).
   CC6 is marked unused in the enum and is not UI-selectable — excluded.
-- **Transfer function**: power 2.2, BT.1886, L*, PQ (tone map OFF and ON /
-  BT.2390), HLG. sRGB-the-EOTF is exercised through the sRGB color space
-  (every consumer forces mode 99 for it), so that space runs one entry.
-  Mode 1 (SDR black compensation) only reshapes the gray target and mode 8
-  is not UI-reachable — excluded.
+- **Transfer function**: power 2.2, BT.1886, L*, PQ, PQ + BT.2390 tone mapping
+  at **two** display targets (`TargetMaxL` 300 and 700 nits), HLG.
+  sRGB-the-EOTF is exercised through the sRGB color space (every consumer
+  forces mode 99 for it), so that space runs one entry. Mode 1 (SDR black
+  compensation) only reshapes the gray target and mode 8 is not UI-reachable —
+  excluded.
+  The two tone-mapped rows sit on opposite sides of BT.2390's knee
+  (`KS = 1.5*PQ(Lmax) - 0.5`): at 300 nits the knee falls **below** the 50.23%
+  diffuse-white code, so tone mapping actually compresses diffuse white and the
+  HDR reference-rescale / white-anchor conventions get real coverage; at 700
+  nits diffuse white passes through untouched and the roll-off instead lands
+  among the AXIS patches that hard-clip with tone mapping off. Before the
+  700-nit row existed, the "patches above `m_TargetMaxL` still read dE ~ 0"
+  invariant was only ever checked with tone mapping **off**.
 - **White point**: D65, DCI white, and manual xy 0.3067/0.3180 (`DCUST`).
   The custom whites were never hand-tested; the known-fail table below
   documents where the references are still D65-bound.
@@ -88,38 +103,66 @@ measured gray top as White; then primaries, which set PrimeWhite):
   indices 0..70) via `GenerateCC24Colors`. AXIS covers the clipped-ramp-top
   cases in PQ: patches above `m_TargetMaxL` must STILL read dE ~ 0 because
   the reference models the same per-channel clip.
-- `convPV` — pane-vs-viewer dE **convention equality** (PQ mode-5 combos
-  only; `-1.000` = not run). The wire-model families read dE ~ 0 under *any*
-  self-consistent normalization, so they cannot see a convention split. This
-  family perturbs each sat/CC measurement (fixed asymmetric XYZ gains, a few
-  dE of luminance + chroma error) and asserts the measures-grid formula and
-  the 3D-viewer formula produce the **same** dE. It guards three axes that
-  drifted apart historically: the HDR reference **rescale**, the **white**
-  the dE normalizes by (`CMeasure::GetColorDEWhiteY` — the measured white, not
-  the theoretical `TmDiffuseWhiteNits`), and the **dE evaluation space**
-  (transport space for the UHDTV3/4 pseudo-spaces). Because it also
-  recomputes the white through the shared helper, it fails if that helper
-  drifts from the grid's own YWhite selection. The ideal sensor's prime white equals
-  `TmDiffuseWhiteNits` exactly, so matched conventions agree to machine
-  precision — hence a dedicated **0.005** tolerance: the legacy fixed
-  `105.95640` pane rescale reads 0.015–0.023 here (small in absolute dE
-  because a common normalizer shift largely cancels inside a dE
-  difference), which the default 0.05 would let back in.
-  **Known blind spot:** the ideal sensor's measured white lands exactly on
-  `TmDiffuseWhiteNits`, so a *white-source* divergence is invisible to this
-  harness — the viewer's old theoretical-white normalization passed convPV
-  while reading ~1% off the grid on a real display whose white missed target
-  by 3.5% (found by hand, grid 8.80 vs viewer 8.72). The guard against that
-  class is structural, not numerical: both sides now call
-  `CMeasure::GetColorDEWhiteY`, so there is one definition to drift.
-  Tone-map-ON combos run at `TargetMaxL = 300` nits — BT.2390's
-  knee (`KS = 1.5*PQ(Lmax) - 0.5`) then falls below the 50.23%
-  diffuse-white code, so tone mapping actually compresses diffuse white and
-  a convention split becomes visible (at 700 nits the knee sits ~245 nits
-  and diffuse white passes through untouched). HDTVa/b are excluded: the
-  grid normalizes their sat/CC dE to the measured ON/OFF (peak) white while
-  the viewer uses the tone-mapped diffuse white — a separate legacy
-  divergence.
+### The convention families (`convPV` / `convPVw` / `convNW`)
+
+The wire-model families above read dE ~ 0 under *any* self-consistent
+normalization, so they cannot see two **consumers** disagreeing about a
+convention — only a reference that stopped modeling the wire. Every dE bug that
+reached a user during the 2026-07 HDR rescale unification was of the first kind
+and left all 708 combos green.
+
+These three families close that hole with a **differential** check instead of a
+zero check: perturb the measurement (fixed asymmetric XYZ gains, a few dE of
+luminance + chroma error), then require the measures-grid formula and the
+3D-viewer formula to produce the **same** dE. They guard the three axes that
+drifted apart historically — the HDR reference **rescale**, the **white** the dE
+normalizes by, and the **dE evaluation space** (transport space for the UHDTV3/4
+pseudo-spaces) — and because the viewer side calls `CMeasure::GetColorDEWhiteY`
+while the grid side is fed the harness's own `UpdateGrid` emulation, they also
+fail if that shared helper drifts from the grid's YWhite selection.
+
+They run on **every** combo, SDR included (in SDR the check reduces to that
+white-selection lock, which is where the CC "primaries run below 90% stimulus"
+fallback lives), and now include HDTVa/HDTVb — the old exclusion described a
+viewer that no longer exists, and re-enabling it turned out to need only that
+`bSpecial` be threaded through to `GetColorDEWhiteY`.
+
+- `convPV` — nominal measured state.
+- `convPVw` — the same comparison with the three stored whites (prime, ON/OFF,
+  grayscale top) scaled **off target and off each other** (0.965 / 0.982 /
+  0.973). This is the family that would have caught the shipped bug. With the
+  ideal sensor every candidate white — prime, ON/OFF, gray top, theoretical
+  `TmDiffuseWhiteNits` — has the *same* value by construction (the 50.22831%
+  wire code and the helper's snapped `0.5022283` reach the same grid code on all
+  four grids), so a consumer normalizing by the wrong one is invisible; that is
+  exactly how the viewer shipped a ~1% offset against the grid, visible only on
+  a display whose white misses target (found by hand: grid 8.80 vs viewer 8.72).
+  The perturbation is applied to the **stored** whites, not to the sensor: both
+  consumers read the same `CMeasure`, so a differential check only needs the
+  state to differ, and three *different* factors make the whites mutually
+  distinguishable. A real display cannot have its grayscale top disagree with
+  its ON/OFF white — that is deliberate, and it is why this family asserts only
+  the differential, never dE ~ 0.
+- `convNW` — a saturation sweep on a pristine `CMeasure`: **no** grayscale and
+  **no** primaries, so both whites are invalid and the grid falls through to its
+  `m_TargetMaxL` fallback (MainView.cpp ~3699-3706), which the always-ordered
+  gray → primaries → sat/CC matrix never reaches. A user who measures a
+  saturation sweep first lands exactly here. The wire-model dE is meaningless in
+  this state (the references are normalized by a white that was never measured),
+  so this family also asserts only the differential — and that nothing produces
+  a NaN, which is what an unguarded divide by a missing white looks like.
+
+All three share a dedicated **0.005** tolerance. Matched conventions agree to
+machine precision (identical `GetDeltaE` arguments), while the divergences they
+exist to catch are small in *absolute* dE because a common normalizer shift
+largely cancels inside a dE difference: the legacy fixed `105.95640` pane
+rescale reads 0.015–0.023, and the pre-unification theoretical-white viewer
+reads 0.046 on `convPVw`. The default 0.05 tolerance would let **both** back in.
+
+Verified non-vacuous by mutation: restoring the pre-unification viewer white
+(`TmDiffuseWhiteNits` instead of `GetColorDEWhiteY`) fails 42 combos on
+`convPVw` and 42 on `convNW`, where `convPV` alone catches only 12 — and 18 of
+those are the HDTVa/b combos the family used to skip entirely.
 
 ## Reading the report
 
@@ -144,7 +187,8 @@ exit) — remove them from `kKnownFails` in `AccuracyTest.cpp`. The exit code is
 nonzero if there is any real FAIL **or** any stale entry.
 
 Tolerances: **0.05** for exact-model combos (SnapToVideoGrid's 1e-9
-tie-breaker means no extra slack is needed). The Intensity-90% combos get
+tie-breaker means no extra slack is needed), **0.005** for the three
+convention families (see above). The Intensity-90% combos get
 **0.9** (power law) / **1.5** (BT.1886, L*, sRGB): the cancellation is exact
 only for an ideal power law — the dimmed code snaps to a different grid point
 than the undimmed one, and non-power EOTFs break the ratio identity — so a
@@ -215,51 +259,58 @@ found by hand during the 2026-07 HDR rescale unification lived in one of these.
 **The root limitation.** The core assertion is "a perfect display measures its
 own reference, dE ~ 0". That invariant holds under *any* self-consistent
 normalization, so it cannot distinguish two conventions that disagree — it only
-catches a reference that stops modeling the wire. The `convPV` family exists to
+catches a reference that stops modeling the wire. The `conv*` families exist to
 cover exactly that hole (perturb the measurement, require two formulas to
-agree), and the gaps below are mostly places `convPV`'s reach stops.
+agree), and the gaps below are mostly places their reach stops.
 
-1. **The ideal sensor's white is exactly `TmDiffuseWhiteNits`.** The 50.22831%
-   wire code and the helper's snapped `0.5022283` land on the same grid code, so
-   measured white == theoretical white *by construction*. Any divergence in
-   which white a consumer normalizes by is therefore invisible. This is how the
-   3D viewer shipped a ~1% dE offset vs the grid that only appears on a display
-   whose white misses target (found by hand: grid 8.80 vs viewer 8.72).
-   *Needs:* a combo axis that perturbs the measured white away from the
-   theoretical one (a gain error injected into the white patches only).
+### Closed
+
+1. ~~**The ideal sensor's white is exactly `TmDiffuseWhiteNits`.**~~ Closed by
+   `convPVw`, which scales the three stored whites off target and off each
+   other. Mutation-verified: the pre-unification viewer white fails 42 combos
+   there that `convPV` alone lets through.
+4. ~~**`bSpecial` (HDTVa/HDTVb) is excluded from `convPV`.**~~ Closed — the
+   exclusion needed only `bSpecial` threaded through to `GetColorDEWhiteY`.
+   Those 18 combos now carry the largest signal in the mutation test (3.4 dE).
+5. ~~**Whites are always present.**~~ Closed by `convNW`.
+9. ~~**Hard-clip coverage is tone-map-OFF only.**~~ Closed by the second
+   tone-mapped EOTF row at `TargetMaxL = 700`.
+
+### Still open
+
 2. **The manual generator (DVD) is never configured.** `RunAccuracyTest` sets
    `enumAutomatic` unconditionally, so every `if (DVD)` carve-out — in
    `GetItemText`, `UpdateGrid`, `InitGrid`, `RGBLevelWnd`, and the Export
-   blocks — is untested. Two real bugs hid there.
+   blocks — is untested. Two real bugs hid there. Note the DVD paths use a
+   different white (`getL_EOTF(0.50,…) * 100`, un-snapped) than
+   `TmDiffuseWhiteNits`, so the references have to model that; and the 3D viewer
+   has **no** DVD carve-out at all, so `convPV` under a manual generator is
+   expected to surface a real grid-vs-viewer split rather than read 0.
 3. **Mascior HDR CC sets are never run.** `RunCC` is only called with `GCD` and
    `AXIS`; the whole `m_CCMode in [MASCIOR50..CCMAXHDR]` family (its `* 100`
    reference scale and grayscale-top white) has zero coverage in the harness,
-   in `GetColorDEWhiteY`, and in the viewer.
-4. **`bSpecial` (HDTVa/HDTVb) is excluded from `convPV`.** The exclusion
-   predates the white unification and its stated rationale is now stale — the
-   viewer passes `satSpecial` today, so these could be covered.
-5. **Whites are always present.** The run order is always gray → primaries →
-   sat/CC, so `PrimeWhite`/`OnOffWhite` are always valid and the grid's
-   `m_TargetMaxL` fallback path is never exercised.
+   in `GetColorDEWhiteY`, and in the viewer. Every set in that range reads its
+   patch list from a CSV in `%APPDATA%\color\`, so any coverage here has to be
+   gated on the file loading and cannot be assumed present in CI.
 6. **The display/comparator layer is not modeled at all.** `CMainView::OnUpdate`'s
    `Yref` formulas, the RGB-levels bars and the target widget do dE-adjacent
    math on `m_RefColor`/`m_RefWhite`/`m_YWhite`. A wrong factor there is
    user-visible (swatches disagree while dE reads 0) and completely invisible
-   here.
-7. **`convPV` compares two harness-local copies.** It *emulates* the viewer's
-   formula rather than calling it, so changing `C3DColorView::BuildScene`
+   here. This is MFC view code; extracting the pure math into a testable
+   function is the prerequisite.
+7. **The `conv*` families compare two harness-local copies.** They *emulate* the
+   viewer's formula rather than calling it, so changing `C3DColorView::BuildScene`
    without editing `AccuracyTest.cpp` still reads 0.000. Only the white is
    genuinely shared (`CMeasure::GetColorDEWhiteY`); the reference scale and the
    dE evaluation space are re-derived. Extracting the whole normalization into
-   one `CMeasure` helper that the grid, the viewer and the harness all call
-   would make the lock real.
+   one `CMeasure` helper that the grid, the viewer, Export and the harness all
+   call would make the lock real.
 8. **Export is never exercised.** The PDF/CSV/spreadsheet dE paths duplicate the
-   grid's normalization and have already drifted from it.
-9. **Hard-clip coverage is tone-map-OFF only.** Tone-map-ON combos run at
-   `TargetMaxL = 300`, where BT.2390 rolls off instead of clipping, so the
-   "clipped patches still read dE ~ 0" invariant is only checked on the
-   tone-map-OFF half of the matrix.
+   grid's normalization and have already drifted from it. Gap 7's shared helper
+   is the better fix than an export family: if Export calls it, there is nothing
+   left to diverge.
 
-Reference result (2026-07-13, first full run after the fixes):
-`708 combos: 311 pass, 0 FAIL, 397 known-fail`, ColorMathTest verify green
-with no golden movement.
+Reference result (2026-07-25): `792 combos: 333 pass, 0 FAIL, 459 known-fail`,
+ColorMathTest verify green with no golden movement. (Was `708 combos: 311 pass,
+0 FAIL, 397 known-fail` before the 84 tone-mapped 700-nit combos were added;
+the three convention families read 0.000 across the whole matrix.)


### PR DESCRIPTION
Extends `/accuracytest` to cover the dE-bug classes it structurally could not
see. Spec: the "Coverage gaps" section of `tests/ACCURACYTEST.md`.


## Why

The core assertion — "a perfect display measures its own reference, dE ~ 0" —
holds under *any* self-consistent normalization, so it cannot detect two
**consumers** disagreeing about a convention; it only catches a reference that
stopped modeling the wire. During the 2026-07 PQ-HDR unification every dE bug
that reached a user was of the first kind, and all 708 combos stayed green
through all of them. The `convPV` pattern (perturb the measurement, require the
grid formula and the viewer formula to agree) is what *does* catch that class.
This extends its reach.

## Coverage gaps closed

| # | Gap | How |
|---|---|---|
| 1 | Measured white == `TmDiffuseWhiteNits` by construction | **`convPVw`**: replays the comparison with the three stored whites scaled off target *and off each other* |
| 2 | Manual generator (DVD) never configured | **generator axis** on the PQ rows at D65 |
| 4 | HDTVa/b excluded from `convPV` | re-enabled; needed only `bSpecial` threaded through |
| 5 | Whites always present | **`convNW`**: saturation sweep on a pristine `CMeasure` |
| 9 | Hard-clip only checked tone-map-OFF | second tone-mapped row at `TargetMaxL` = 700 |

`convPV` also now runs on every combo rather than mode 5 only.

## What the DVD axis found

The measures grid and the 3D viewer **genuinely disagree** under a manual
generator. `GetItemText` keeps the legacy DVD conventions for mode 5, while
`C3DColorView::BuildScene` has no DVD branch at all — so a user measuring from
a disc reads one dE in the pane and another in the viewer, by 0.49–0.70 dE on
the saturation modes.

Recorded as a known-fail with split ceilings rather than fixed: the unification
commit *deliberately* left DVD legacy, and closing this means choosing which
convention wins — a user-visible number change on a legacy path, and your call.
The structural fix is gap 7's shared `CMeasure` normalization helper.

## Verified non-vacuous, not just green

New checks that cannot fail are worse than no checks, so they were
mutation-tested. Restoring the pre-unification viewer white
(`TmDiffuseWhiteNits` instead of `GetColorDEWhiteY`) fails **42** combos on
`convPVw` and 42 on `convNW`, where `convPV` alone catches 12 — 18 of them the
HDTVa/b combos the family used to skip. The 0.005 tolerance is load-bearing:
the divergence reads 0.046, which the default 0.05 would have absorbed.

## Also

- Two pure performance fixes (no numerics change): `ColorXYZ::GetDeltaE` /
  `GetDeltaLCH` built a whole `CColorReference` — matrix inversion plus four
  line intersections — on *every* call; now a shared static. The measures grid
  evaluates them four times per cell per refresh.
- A self-inflicted bug the new axis then caught: `SetGeneratorType()` calls
  `RefreshUse10bitLevels()`, so setting the generator after the per-combo grid
  flags silently reset every combo to 8-bit limited.
- `ACCURACYTEST.md`'s "the run takes seconds" was stale — it was already ~3
  minutes before this change (now ~6).

## Still open

Gaps 3 (Mascior CC sets), 6 (comparator/widget layer), 7 (share the
normalization instead of emulating it) and 8 (Export). Gap 7 is the deep one
and deserves its own PR — it would close 8 and the DVD known-fail above as
side effects.

## Validation

- `/accuracytest`: **876 combos: 333 pass, 0 FAIL, 543 known-fail**, exit 0, no
  stale entries (was 708/311/0/397).
- `ColorMathTest verify`: green, no golden movement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
