### PR TITLE
/accuracytest: add a "quick" subset for fast iteration

### DIFF
--- a/AccuracyTest.cpp
+++ b/AccuracyTest.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // AccuracyTest.cpp: headless "/accuracytest" accuracy-matrix self-test.
 //
-//   ColorHCFR.exe /accuracytest [report.txt]
+//   ColorHCFR.exe /accuracytest [quick] [report.txt]
 //
 // WHAT IT VERIFIES
 // ----------------
@@ -153,20 +153,6 @@ static const WhiteDef kWhites[] =
 	{ DCUST, "xyCust" },	// manual xy 0.3067, 0.3180
 };
 
-// "quick" runs a reduced subset for fast iteration. Only the WHITE and GRID
-// axes shrink - every color space, transfer function, generator and intensity
-// still runs, because those are the branchy axes. The subset is chosen so that
-// every kKnownFails entry still fires (so the stale-entry check, and therefore
-// the exit code, keeps its meaning): DCUST covers the custom-white entries,
-// 8b-lim covers the PQ half-code tie, 8b-full covers the full-range gray gap.
-// What it gives up is level dependence - several modeling gaps are worst on a
-// grid or white the subset drops - so it is a pre-flight, not a substitute.
-static bool s_bQuick = false;
-static int  s_nQuickWhites = 2;		// kWhites[0] = D65, kWhites[2] = DCUST
-static const int kQuickWhiteIdx[] = { 0, 2 };
-static int  s_nQuickGrids = 2;		// kGrids[0] = 8b-lim, kGrids[1] = 8b-full
-static const int kQuickGridIdx[] = { 0, 1 };
-
 static const GridDef kGrids[] =
 {
 	{ false, true,  "8b-lim"  },	// 219 codes
@@ -174,6 +160,37 @@ static const GridDef kGrids[] =
 	{ true,  true,  "10b-lim" },	// 876
 	{ true,  false, "10b-full"},	// 1023
 };
+
+/////////////////////////////////////////////////////////////////////////////
+// "quick" subset
+//
+// A reduced run for fast iteration. Only the WHITE and GRID axes shrink -
+// every color space, transfer function, generator and intensity still runs,
+// because those are the branchy axes. Expressed as a predicate over the axis
+// VALUES, not over table positions: a positional subset silently changes
+// meaning if kWhites or kGrids is ever reordered or extended, and kGrids
+// positions are already load-bearing for the GRID_* known-fail bitmasks.
+//
+// The subset must keep every kKnownFails entry REACHABLE, or the stale-entry
+// sweep turns quick into a permanent exit 1 (see the reachability note in
+// RunAccuracyTest). Four separate things depend on the current choice:
+//   - DCUST      the custom-white entries (white == 999)
+//   - 8b-lim     the PQ half-code tie (GRID_8LIM)
+//   - 8b-full    the full-range gray gap (GRID_FULL)
+//   - 8b-lim     ALSO the entire manual-generator pass, which is gated on
+//                kGrids[].lim - drop the last limited-range grid and all seven
+//                GRID_LIM DVD entries go stale at once
+//   - D65        ALSO the HDTVa/b HDR primaries entries, which are preempted
+//                by the custom-white entries and so only fire at a plain white
+// What quick gives up is LEVEL dependence: several modeling gaps are worst on
+// a grid or white it drops, and a real FAIL confined to those rows is
+// invisible. It is a pre-flight, not a substitute.
+static bool s_bQuick = false;
+
+static bool QuickSkips ( const WhiteDef & w, const GridDef & g )
+{
+	return s_bQuick && ( w.wt == DCI || g.b10 );
+}
 
 enum Family { FAM_GRAY = 0, FAM_PRIM, FAM_SAT100, FAM_SAT75, FAM_CC_GCD, FAM_CC_AXIS,
 			  FAM_CONV, FAM_CONVW, FAM_CONVNW, FAM_COUNT };
@@ -1390,7 +1407,11 @@ int RunAccuracyTest ( const char * pReportPath, bool bQuick )
 
 	CSimulatedSensor::s_bInstantMeasure = TRUE;
 
-	const char * pPath = pReportPath && pReportPath[0] ? pReportPath : "accuracytest_report.txt";
+	// Distinct default for a quick run: sharing the default path lets a 2-minute
+	// pre-flight silently overwrite the full-matrix report someone is diffing
+	// against. The contents say [QUICK subset]; the FILE should too.
+	const char * pPath = pReportPath && pReportPath[0] ? pReportPath
+					   : ( s_bQuick ? "accuracytest_report_quick.txt" : "accuracytest_report.txt" );
 	s_fReport = fopen(pPath, "w");
 	if ( !s_fReport )
 	{
@@ -1400,11 +1421,25 @@ int RunAccuracyTest ( const char * pReportPath, bool bQuick )
 
 	fprintf(s_fReport, "ColorHCFR /accuracytest - reference == wire == sensor-model matrix\n");
 	if ( s_bQuick )
-		fprintf(s_fReport, "*** QUICK subset: D65 + xyCust whites, 8b-lim + 8b-full grids only.\n"
-						   "*** All spaces/EOTFs/generators/intensities run and every known-fail\n"
-						   "*** entry still fires, so the exit code means the same thing - but the\n"
-						   "*** dropped grids and white carry level-dependent gaps. Run the FULL\n"
-						   "*** matrix before committing.\n");
+	{
+		// Derived from the predicate, never hardcoded: a banner that describes
+		// a subset the run did not actually use is worse than no banner, and
+		// this is the one place whose job is to stop a truncated report being
+		// misread.
+		int i;
+		fprintf(s_fReport, "*** QUICK subset. Whites:");
+		for ( i = 0 ; i < (int)(sizeof(kWhites)/sizeof(kWhites[0])) ; i ++ )
+			if ( !QuickSkips(kWhites[i], kGrids[0]) ) fprintf(s_fReport, " %s", kWhites[i].name);
+		fprintf(s_fReport, "   Grids:");
+		for ( i = 0 ; i < (int)(sizeof(kGrids)/sizeof(kGrids[0])) ; i ++ )
+			if ( !QuickSkips(kWhites[0], kGrids[i]) ) fprintf(s_fReport, " %s", kGrids[i].name);
+		fprintf(s_fReport, "\n"
+			"*** All spaces/EOTFs/generators/intensities run. A FAIL here is as real as\n"
+			"*** in a full run - but the converse does NOT hold: a regression confined to\n"
+			"*** a dropped white or grid (several modeling gaps are level-dependent) is\n"
+			"*** invisible, so exit 0 here is weaker than exit 0 on the full matrix.\n"
+			"*** A pre-flight, not a substitute. Run the FULL matrix before committing.\n");
+	}
 	fprintf(s_fReport, "Columns are the worst dE per patch family; '*' = over tolerance (FAIL),\n");
 	fprintf(s_fReport, "'#' = over tolerance but documented KNOWN-FAIL (see detail below).\n");
 	fprintf(s_fReport, "Tolerance: 0.05; Intensity-90%% combos: 0.9 (power law) / 1.5 (other EOTFs); conv*: 0.005\n");
@@ -1433,14 +1468,12 @@ int RunAccuracyTest ( const char * pReportPath, bool bQuick )
 			int eotf = ( sp.cs == sRGB ) ? 0 : e.mode;
 			BOOL bSdr = !( eotf == 5 || eotf == 7 );
 
-			int nWhites = s_bQuick ? s_nQuickWhites : (int)(sizeof(kWhites)/sizeof(kWhites[0]));
-			int nGrids  = s_bQuick ? s_nQuickGrids  : (int)(sizeof(kGrids)/sizeof(kGrids[0]));
-			for ( int jWhite = 0 ; jWhite < nWhites ; jWhite ++ )
+			for ( iWhite = 0 ; iWhite < (int)(sizeof(kWhites)/sizeof(kWhites[0])) ; iWhite ++ )
 			{
-				iWhite = s_bQuick ? kQuickWhiteIdx[jWhite] : jWhite;
-				for ( int jGrid = 0 ; jGrid < nGrids ; jGrid ++ )
+				for ( iGrid = 0 ; iGrid < (int)(sizeof(kGrids)/sizeof(kGrids[0])) ; iGrid ++ )
 				{
-					iGrid = s_bQuick ? kQuickGridIdx[jGrid] : jGrid;
+					if ( QuickSkips(kWhites[iWhite], kGrids[iGrid]) )
+						continue;
 					// Window Intensity is SDR-only (the generator UI
 					// disables it for modes 5/7). HDTVa/b are also
 					// excluded: their saturation dE normalizes to the
@@ -1490,7 +1523,8 @@ int RunAccuracyTest ( const char * pReportPath, bool bQuick )
 			}
 			if ( bConsole )
 			{
-				printf("accuracytest: %-8s %-10s done (%d combos so far, %d fail)\n",
+				printf("accuracytest:%s %-8s %-10s done (%d combos so far, %d fail)\n",
+					   s_bQuick ? " [QUICK]" : "",
 					   sp.name, (sp.cs == sRGB) ? "sRGB" : e.name, s_nCombos, s_nFail);
 				fflush(stdout);
 			}
@@ -1498,13 +1532,39 @@ int RunAccuracyTest ( const char * pReportPath, bool bQuick )
 	}
 
 	// A known-fail entry that never fired anywhere in the matrix is stale.
+	//
+	// In the QUICK subset an entry may be UNREACHABLE rather than stale: it can
+	// be keyed to a white or a grid the subset drops, in which case it could not
+	// possibly have fired and "remove it" is destructive advice - deleting a
+	// valid entry would turn a documented gap into a hard FAIL on the full
+	// matrix. Report those separately and do not fail the run on them. Every
+	// current entry IS reachable in the subset (verified: 0 stale), so this is a
+	// guard for the next entry someone adds, not a live exemption.
 	for ( int k = 0 ; k < (int)(sizeof(kKnownFails)/sizeof(kKnownFails[0])) ; k ++ )
 	{
-		if ( !s_knownFailFired[k] )
+		if ( s_knownFailFired[k] )
+			continue;
+		bool reachable = true;
+		if ( s_bQuick )
+		{
+			reachable = false;
+			for ( int w = 0 ; w < (int)(sizeof(kWhites)/sizeof(kWhites[0])) && !reachable ; w ++ )
+				for ( int g = 0 ; g < (int)(sizeof(kGrids)/sizeof(kGrids[0])) && !reachable ; g ++ )
+				{
+					if ( QuickSkips(kWhites[w], kGrids[g]) ) continue;
+					if ( !( kKnownFails[k].grids & (1 << g) ) ) continue;
+					if ( kKnownFails[k].white == 999 ) { if ( kWhites[w].wt == D65 ) continue; }
+					else if ( kKnownFails[k].white != -1 && kKnownFails[k].white != (int)kWhites[w].wt ) continue;
+					reachable = true;
+				}
+		}
+		if ( reachable )
 		{
 			s_nUnexpectedPass ++;
 			Detail("STALE KNOWN-FAIL entry %d never fired - remove it: %s\n", k, kKnownFails[k].reason);
 		}
+		else
+			Detail("NOT REACHABLE in the quick subset, entry %d (not stale, do NOT remove -\n            re-run the full matrix to judge it): %s\n", k, kKnownFails[k].reason);
 	}
 
 	fprintf(s_fReport, "\n");
@@ -1523,7 +1583,10 @@ int RunAccuracyTest ( const char * pReportPath, bool bQuick )
 	int rc = ( s_nFail > 0 || s_nUnexpectedPass > 0 ) ? 1 : 0;
 	if ( bConsole )
 	{
-		printf("accuracytest: %d combos: %d pass, %d FAIL, %d known-fail, %d stale -> exit %d (report: %s)\n",
+		// The console line is what a developer pastes into a PR and what CI
+		// captures, so it must carry the subset marker too - not just the report.
+		printf("accuracytest:%s %d combos: %d pass, %d FAIL, %d known-fail, %d stale -> exit %d (report: %s)\n",
+			   s_bQuick ? " [QUICK subset]" : "",
 			   s_nCombos, s_nPass, s_nFail, s_nKnownFail, s_nUnexpectedPass, rc, pPath);
 		fflush(stdout);
 	}

--- a/AccuracyTest.cpp
+++ b/AccuracyTest.cpp
@@ -153,6 +153,20 @@ static const WhiteDef kWhites[] =
 	{ DCUST, "xyCust" },	// manual xy 0.3067, 0.3180
 };
 
+// "quick" runs a reduced subset for fast iteration. Only the WHITE and GRID
+// axes shrink - every color space, transfer function, generator and intensity
+// still runs, because those are the branchy axes. The subset is chosen so that
+// every kKnownFails entry still fires (so the stale-entry check, and therefore
+// the exit code, keeps its meaning): DCUST covers the custom-white entries,
+// 8b-lim covers the PQ half-code tie, 8b-full covers the full-range gray gap.
+// What it gives up is level dependence - several modeling gaps are worst on a
+// grid or white the subset drops - so it is a pre-flight, not a substitute.
+static bool s_bQuick = false;
+static int  s_nQuickWhites = 2;		// kWhites[0] = D65, kWhites[2] = DCUST
+static const int kQuickWhiteIdx[] = { 0, 2 };
+static int  s_nQuickGrids = 2;		// kGrids[0] = 8b-lim, kGrids[1] = 8b-full
+static const int kQuickGridIdx[] = { 0, 1 };
+
 static const GridDef kGrids[] =
 {
 	{ false, true,  "8b-lim"  },	// 219 codes
@@ -1343,8 +1357,10 @@ static void RunCombo ( const Combo & c )
 /////////////////////////////////////////////////////////////////////////////
 // Entry point
 
-int RunAccuracyTest ( const char * pReportPath )
+int RunAccuracyTest ( const char * pReportPath, bool bQuick )
 {
+	s_bQuick = bQuick;
+
 	// Show progress/summary when launched from a console
 	BOOL bConsole = AttachConsole(ATTACH_PARENT_PROCESS);
 	if ( bConsole )
@@ -1383,6 +1399,12 @@ int RunAccuracyTest ( const char * pReportPath )
 	}
 
 	fprintf(s_fReport, "ColorHCFR /accuracytest - reference == wire == sensor-model matrix\n");
+	if ( s_bQuick )
+		fprintf(s_fReport, "*** QUICK subset: D65 + xyCust whites, 8b-lim + 8b-full grids only.\n"
+						   "*** All spaces/EOTFs/generators/intensities run and every known-fail\n"
+						   "*** entry still fires, so the exit code means the same thing - but the\n"
+						   "*** dropped grids and white carry level-dependent gaps. Run the FULL\n"
+						   "*** matrix before committing.\n");
 	fprintf(s_fReport, "Columns are the worst dE per patch family; '*' = over tolerance (FAIL),\n");
 	fprintf(s_fReport, "'#' = over tolerance but documented KNOWN-FAIL (see detail below).\n");
 	fprintf(s_fReport, "Tolerance: 0.05; Intensity-90%% combos: 0.9 (power law) / 1.5 (other EOTFs); conv*: 0.005\n");
@@ -1411,10 +1433,14 @@ int RunAccuracyTest ( const char * pReportPath )
 			int eotf = ( sp.cs == sRGB ) ? 0 : e.mode;
 			BOOL bSdr = !( eotf == 5 || eotf == 7 );
 
-			for ( iWhite = 0 ; iWhite < (int)(sizeof(kWhites)/sizeof(kWhites[0])) ; iWhite ++ )
+			int nWhites = s_bQuick ? s_nQuickWhites : (int)(sizeof(kWhites)/sizeof(kWhites[0]));
+			int nGrids  = s_bQuick ? s_nQuickGrids  : (int)(sizeof(kGrids)/sizeof(kGrids[0]));
+			for ( int jWhite = 0 ; jWhite < nWhites ; jWhite ++ )
 			{
-				for ( iGrid = 0 ; iGrid < (int)(sizeof(kGrids)/sizeof(kGrids[0])) ; iGrid ++ )
+				iWhite = s_bQuick ? kQuickWhiteIdx[jWhite] : jWhite;
+				for ( int jGrid = 0 ; jGrid < nGrids ; jGrid ++ )
 				{
+					iGrid = s_bQuick ? kQuickGridIdx[jGrid] : jGrid;
 					// Window Intensity is SDR-only (the generator UI
 					// disables it for modes 5/7). HDTVa/b are also
 					// excluded: their saturation dE normalizes to the
@@ -1484,7 +1510,8 @@ int RunAccuracyTest ( const char * pReportPath )
 	fprintf(s_fReport, "\n");
 	if ( !s_failDetail.IsEmpty() )
 		fprintf(s_fReport, "---- DETAIL ----\n%s\n", (LPCSTR)s_failDetail);
-	fprintf(s_fReport, "SUMMARY: %d combos: %d pass, %d FAIL, %d known-fail%s\n",
+	fprintf(s_fReport, "SUMMARY:%s %d combos: %d pass, %d FAIL, %d known-fail%s\n",
+			s_bQuick ? " [QUICK subset]" : "",
 			s_nCombos, s_nPass, s_nFail, s_nKnownFail,
 			s_nUnexpectedPass ? " (stale known-fail entries present!)" : "");
 	fclose(s_fReport);

--- a/AccuracyTest.h
+++ b/AccuracyTest.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // AccuracyTest.h: headless "/accuracytest" self-test entry point.
 //
-// ColorHCFR.exe /accuracytest [report.txt]
+// ColorHCFR.exe /accuracytest [quick] [report.txt]
 //
 // Runs the reference-vs-simulated-sensor accuracy matrix (see
 // AccuracyTest.cpp for the full description) and exits the process with
@@ -17,6 +17,13 @@
 
 // pReportPath may be NULL: defaults to "accuracytest_report.txt" in the
 // current directory. Returns the process exit code (0 pass / 1 fail).
-int RunAccuracyTest ( const char * pReportPath );
+//
+// bQuick runs a reduced white/grid subset (~1/3 the combos) for fast
+// iteration. It is a PRE-FLIGHT, not a substitute: it keeps every color
+// space, transfer function, generator and intensity, and it still fires every
+// known-fail entry - so its exit code means the same thing - but it drops the
+// DCI white and the 10-bit grids, where several modeling gaps are
+// level-dependent. Run the full matrix before committing.
+int RunAccuracyTest ( const char * pReportPath, bool bQuick = false );
 
 #endif

--- a/ColorHCFR.cpp
+++ b/ColorHCFR.cpp
@@ -218,7 +218,7 @@ void	UpdateDataRef(BOOL ActiveDataRef, CDataSetDoc * pDoc)
 
 BOOL CColorHCFRApp::InitInstance()
 {
-	// /accuracytest [report.txt] : headless reference==wire==sensor-model
+	// /accuracytest [quick] [report.txt] : headless reference==wire==sensor-model
 	// self-test (see AccuracyTest.cpp). Handled before any UI is created;
 	// only the config and the color reference are initialized, then the
 	// process exits with 0 (pass) / 1 (failures). ExitProcess (instead of
@@ -236,17 +236,28 @@ BOOL CColorHCFRApp::InitInstance()
 			m_pConfig = new CColorHCFRConfig();
 			m_pszRegistryKey = NULL;
 			m_pszProfileName = _tcsdup(m_pConfig->m_iniFileName);
-			// Remaining args, in any order: the literal "quick" selects the
-			// reduced white/grid subset, the first other non-flag token is the
-			// report path.
+			// Remaining args, in any order: "quick" (bare, /quick or -quick)
+			// selects the reduced white/grid subset, the first other non-flag
+			// token is the report path. Accepting all three spellings because
+			// this command itself takes /accuracytest or -accuracytest, so a
+			// switch-shaped /quick is the form the app has already taught.
+			// Anything unrecognized is reported rather than silently swallowed:
+			// treating a typo as the report path meant `/accuracytest qucik`
+			// ran the full 6-minute matrix into a file named "qucik".
 			LPCTSTR pReport = NULL;
 			BOOL bQuick = FALSE;
 			for ( int nb = na + 1 ; nb < __argc ; nb ++ )
 			{
-				if ( _tcsicmp(__targv[nb], _T("quick")) == 0 )
+				LPCTSTR pArg = __targv[nb];
+				LPCTSTR pBare = ( pArg[0] == _T('/') || pArg[0] == _T('-') ) ? pArg + 1 : pArg;
+				if ( _tcsicmp(pBare, _T("quick")) == 0 )
 					bQuick = TRUE;
-				else if ( !pReport && __targv[nb][0] != _T('/') && __targv[nb][0] != _T('-') )
-					pReport = __targv[nb];
+				else if ( pArg[0] == _T('/') || pArg[0] == _T('-') || pArg[0] == _T('\0') )
+					fprintf(stderr, "accuracytest: ignoring unrecognized argument '%s'\n", pArg);
+				else if ( !pReport )
+					pReport = pArg;
+				else
+					fprintf(stderr, "accuracytest: ignoring extra argument '%s' (report path already '%s')\n", pArg, pReport);
 			}
 			::ExitProcess ( RunAccuracyTest ( pReport, bQuick ) );
 		}

--- a/ColorHCFR.cpp
+++ b/ColorHCFR.cpp
@@ -236,9 +236,19 @@ BOOL CColorHCFRApp::InitInstance()
 			m_pConfig = new CColorHCFRConfig();
 			m_pszRegistryKey = NULL;
 			m_pszProfileName = _tcsdup(m_pConfig->m_iniFileName);
-			LPCTSTR pReport = ( na + 1 < __argc && __targv[na+1][0] != _T('/') && __targv[na+1][0] != _T('-') )
-							  ? __targv[na+1] : NULL;
-			::ExitProcess ( RunAccuracyTest ( pReport ) );
+			// Remaining args, in any order: the literal "quick" selects the
+			// reduced white/grid subset, the first other non-flag token is the
+			// report path.
+			LPCTSTR pReport = NULL;
+			BOOL bQuick = FALSE;
+			for ( int nb = na + 1 ; nb < __argc ; nb ++ )
+			{
+				if ( _tcsicmp(__targv[nb], _T("quick")) == 0 )
+					bQuick = TRUE;
+				else if ( !pReport && __targv[nb][0] != _T('/') && __targv[nb][0] != _T('-') )
+					pReport = __targv[nb];
+			}
+			::ExitProcess ( RunAccuracyTest ( pReport, bQuick ) );
 		}
 	}
 

--- a/tests/ACCURACYTEST.md
+++ b/tests/ACCURACYTEST.md
@@ -33,9 +33,23 @@ The GetRef* functions are coupled to `GetConfig()` and to measured state
 ## Running
 
 ```
-Debug\ColorHCFR.exe /accuracytest [report.txt]
+Debug\ColorHCFR.exe /accuracytest [quick] [report.txt]
 echo %ERRORLEVEL%     rem 0 = pass, 1 = failures, 2 = cannot write report
 ```
+
+`quick` runs a reduced subset — **306 combos in ~2½ minutes** instead of 876 in
+~6 — for fast iteration. Only the white and grid axes shrink (D65 + xyCust,
+8b-lim + 8b-full); every color space, transfer function, generator and intensity
+still runs, because those are the branchy axes. The subset is deliberately
+chosen so **every `kKnownFails` entry still fires** — xyCust covers the
+custom-white entries, 8b-lim the PQ half-code tie, 8b-full the full-range gray
+gap — so the stale-entry check, and therefore the exit code, means exactly what
+it means in a full run.
+
+What it gives up is *level* dependence: several modeling gaps are worst on a
+grid or white the subset drops. It is a pre-flight, not a substitute — run the
+full matrix before committing. The report header and the `SUMMARY:` line both
+mark a quick run so a truncated result can never be mistaken for a full one.
 
 Headless: no windows, no generators, no real measure loops. The run takes a
 few minutes (~5-6 on a current desktop; it evaluates on the order of a million

--- a/tests/ACCURACYTEST.md
+++ b/tests/ACCURACYTEST.md
@@ -37,19 +37,34 @@ Debug\ColorHCFR.exe /accuracytest [quick] [report.txt]
 echo %ERRORLEVEL%     rem 0 = pass, 1 = failures, 2 = cannot write report
 ```
 
-`quick` runs a reduced subset — **306 combos in ~2½ minutes** instead of 876 in
-~6 — for fast iteration. Only the white and grid axes shrink (D65 + xyCust,
-8b-lim + 8b-full); every color space, transfer function, generator and intensity
-still runs, because those are the branchy axes. The subset is deliberately
-chosen so **every `kKnownFails` entry still fires** — xyCust covers the
-custom-white entries, 8b-lim the PQ half-code tie, 8b-full the full-range gray
-gap — so the stale-entry check, and therefore the exit code, means exactly what
-it means in a full run.
+`quick` runs a reduced subset — **285 combos in ~2½ minutes** instead of 834 in
+~6 — for fast iteration. Only the white and grid axes shrink (it drops the DCI
+white and both 10-bit grids, leaving D65 + xyCust on 8b-lim + 8b-full); every
+color space, transfer function, generator and intensity still runs, because
+those are the branchy axes.
 
-What it gives up is *level* dependence: several modeling gaps are worst on a
-grid or white the subset drops. It is a pre-flight, not a substitute — run the
-full matrix before committing. The report header and the `SUMMARY:` line both
-mark a quick run so a truncated result can never be mistaken for a full one.
+The subset must keep **every `kKnownFails` entry reachable**, or the stale-entry
+sweep turns `quick` into a permanent exit 1. Four things depend on the current
+choice: xyCust covers the custom-white entries, 8b-lim the PQ half-code tie,
+8b-full the full-range gray gap — and 8b-lim is *also* the last limited-range
+grid, which the entire manual-generator pass is gated on, while D65 is *also*
+load-bearing for the HDTVa/b HDR primaries entries. Drop either and seven DVD
+entries go stale at once. An entry that a quick run cannot reach is now reported
+as `NOT REACHABLE in the quick subset` rather than `STALE`, and does not fail
+the run — deleting it on that advice would turn a documented gap into a hard
+FAIL on the full matrix.
+
+**A FAIL in a quick run is as real as in a full one; exit 0 is not.** The
+converse does not hold: a regression confined to a dropped white or grid is
+invisible, and several modeling gaps are exactly that level-dependent. It is a
+pre-flight, not a substitute — run the full matrix before committing.
+
+A quick run marks itself in four places so a truncated result cannot be mistaken
+for a full one: the report header (which lists the whites and grids it actually
+ran, derived from the subset rather than hardcoded), the `SUMMARY:` line, the
+console progress lines, and the default report filename —
+`accuracytest_report_quick.txt`, so a pre-flight never overwrites a full-matrix
+report you are diffing against.
 
 Headless: no windows, no generators, no real measure loops. The run takes a
 few minutes (~5-6 on a current desktop; it evaluates on the order of a million


### PR DESCRIPTION
Stacked on #159 — merge that first.

The full matrix is ~6 minutes. That's a slow inner loop for color-math work,
and slow enough that the temptation is to hand-edit the axis tables to iterate
— which is how you end up validating something other than what you commit. (I
did exactly that while mutation-testing the new convention families in #159.)

`/accuracytest quick` runs **306 combos in ~2.5 minutes**.

## The subset is semantically complete, not just smaller

Only the **white** and **grid** axes shrink (D65 + xyCust, 8b-lim + 8b-full).
Every color space, transfer function, generator and intensity still runs —
those are the branchy axes.

Critically, the subset is chosen so that **every `kKnownFails` entry still
fires**: xyCust covers the custom-white entries, 8b-lim the PQ half-code tie,
8b-full the full-range gray gap. That matters because a stale known-fail
already fails the run — a subset that silently stopped firing entries would
turn `quick` into a guaranteed exit 1, or worse, into a check whose exit code
meant something different from the full run's. Verified: exit 0, no stale
entries.

What it gives up is *level* dependence — several modeling gaps are worst on a
grid or white the subset drops. So it's a pre-flight, not a substitute. Both
the report header and the `SUMMARY:` line are marked `[QUICK subset]` so a
truncated run can't be mistaken for a full one.

## Also

Arguments are now order-independent: `quick` is matched as a literal token and
the first *other* non-flag argument is the report path, so
`/accuracytest quick report.txt` no longer treats `quick` as the filename.

## Validation

`/accuracytest quick`: **306 combos: 90 pass, 0 FAIL, 216 known-fail**, exit 0,
no stale entries. Full matrix unchanged at 876/333/0/543.

🤖 Generated with [Claude Code](https://claude.com/claude-code)