### PR TITLE
Share the sat/CC dE normalization instead of copying it (coverage gap 7)

### DIFF
--- a/AccuracyTest.cpp
+++ b/AccuracyTest.cpp
@@ -588,12 +588,16 @@ static double GridColorDE ( const CMeasure & m, const CColor & aMeasure, const C
 //            TmDiffuseWhiteNits, so the white SOURCE cannot be told apart)
 //   convPVw  the three stored whites pulled apart and off target (RunConvWhite)
 //   convNW   no white measured at all (RunConvNoWhite)
-// wDE is CMeasure::GetColorDEWhiteY for this family, passed in rather than
-// re-read per patch: the helper returns CColor copies internally, and
-// C3DColorView::BuildScene hoists it out of its patch loops for exactly that
-// reason - so hoisting here also keeps the emulation faithful.
+// norm is CMeasure::GetColorDENorm for this family - PRODUCTION code, not an
+// emulation. That asymmetry is the whole point: the pane side below is the
+// harness's own UpdateGrid/GetItemText emulation, so the check is "the grid's
+// normalisation == the shared helper every other consumer uses". Editing
+// C3DColorView::BuildScene without touching AccuracyTest.cpp can no longer
+// read 0.000, because the viewer's numbers now come from the same call.
+// It is passed in rather than re-read per patch because it reads CColor copies
+// internally, and BuildScene hoists it out of its patch loops for that reason.
 static void ConvCheck ( const CMeasure & m, const CColor & aColor, const CColor & refRaw,
-						double YWhite, double wDE, int displayMode, int nCol, int satsize,
+						double YWhite, const ColorDENorm & norm, int displayMode, int nCol, int satsize,
 						FamStat & stat, const char * name, int idx )
 {
 	CColorHCFRConfig * cfg = GetConfig();
@@ -619,12 +623,12 @@ static void ConvCheck ( const CMeasure & m, const CColor & aColor, const CColor 
 	double dEpane = GridColorDE(m, pert, refPane, YWhite, displayMode, nCol, satsize);
 
 	// Viewer side, as C3DColorView::BuildScene builds it: the reference scaled
-	// to the SHARED grid white (CMeasure::GetColorDEWhiteY) with YWhiteRef 1.0,
+	// to the SHARED normalization (CMeasure::GetColorDENorm) with YWhiteRef 1.0,
 	// and the grid's dE evaluation space. Scaling by 10000/white with
 	// YWhiteRef 1.0 is algebraically the grid's (ref * GetHDRRefScale(),
 	// RefWhite = YWhite/tmWhite) pair, so any drift between the two - a
 	// reference rescale, a white source, or a dE space - shows up here.
-	if ( wDE <= 0.0 )
+	if ( norm.whiteY <= 0.0 )
 	{
 		// Unreachable while GetColorDEWhiteY ends in its m_TargetMaxL fallback,
 		// and it must FAIL loudly if that ever stops being true: the grid would
@@ -633,14 +637,13 @@ static void ConvCheck ( const CMeasure & m, const CColor & aColor, const CColor 
 		// entirely - a real two-consumer divergence. Recording 0.0 here (which
 		// this used to do) promoted the family from the -1.0 "not run" sentinel
 		// to a 0.000 PASS: it failed OPEN on exactly the state convNW exists for.
-		stat.Add(999.0, "%s %d (no dE white: GetColorDEWhiteY returned %.3f)", name, idx, wDE);
+		stat.Add(999.0, "%s %d (no dE white: GetColorDENorm returned whiteY %.3f)", name, idx, norm.whiteY);
 		return;
 	}
 	CColor refView = refRaw;
-	if ( isHDR )
-		ScaleXYZ(refView, mascior ? 100. : 10000. / wDE);
+	ScaleXYZ(refView, norm.deScale);
 	// AppendMeasure's gw: 3 in mode 5, the configured weight otherwise.
-	double dEview = pert.GetDeltaE(wDE, refView, 1.0, *s_pViewDERef, cfg->m_dE_form, false,
+	double dEview = pert.GetDeltaE(norm.whiteY, refView, 1.0, *s_pViewDERef, cfg->m_dE_form, false,
 								   isHDR ? 3 : cfg->gw_Weight);
 
 	stat.Add(fabs(dEpane - dEview), "%s %d (pane %.3f vs viewer %.3f)", name, idx, dEpane, dEview);
@@ -1007,7 +1010,7 @@ static void RunSats ( const Combo & c, CMeasure & m, CSimulatedSensor & sensor, 
 	m.SetSaturationSize(kSatSize);
 	// Loop invariants, hoisted exactly as C3DColorView::BuildScene hoists them.
 	double YWhite = GridYWhite(m, special, false);
-	double wDE = m.GetColorDEWhiteY(special, false, false);
+	ColorDENorm norm = m.GetColorDENorm(5);	// same for every saturation mode
 	for ( int s = 0 ; s < 6 ; s ++ )
 	{
 		ColorRGBDisplay GenColors[kSatSize];
@@ -1018,7 +1021,7 @@ static void RunSats ( const Combo & c, CMeasure & m, CSimulatedSensor & sensor, 
 			// MT_SAT_* patches are Intensity-dimmed on the real wire
 			CColor aColor = Meas(sensor, GenColors[j], c.intensity);
 			CColor refColor = m.GetRefSat(s, (double)j / (double)(kSatSize - 1), special, stim);
-			ConvCheck(m, aColor, refColor, YWhite, wDE, 5 + s, j + 1, kSatSize, convStat, names[s], j);
+			ConvCheck(m, aColor, refColor, YWhite, norm, 5 + s, j + 1, kSatSize, convStat, names[s], j);
 			// Only the 100% sweep feeds the white-source replays: the 75% sweep
 			// exercises the same normalization with a different reference, so
 			// keeping both would double the replay cost for no new convention.
@@ -1053,7 +1056,7 @@ static void RunCC ( const Combo & c, CMeasure & m, CSimulatedSensor & sensor, CC
 	bool special = ( cfg->m_colorStandard == HDTVa || cfg->m_colorStandard == HDTVb );
 	double YWhite = GridYWhite(m, special, true);
 	bool mascior = ( ccMode >= MASCIOR50 && ccMode <= CCMAXHDR );
-	double wDE = m.GetColorDEWhiteY(special, true, mascior);
+	ColorDENorm norm = m.GetColorDENorm(11);
 
 	for ( int j = 0 ; j < count ; j ++ )
 	{
@@ -1061,7 +1064,7 @@ static void RunCC ( const Combo & c, CMeasure & m, CSimulatedSensor & sensor, CC
 		CColor aColor = Meas(sensor, GenColors[j], 1.0);
 		CColor refColor;
 		m.GetRefCC24Sat(j, refColor);
-		ConvCheck(m, aColor, refColor, YWhite, wDE, 11, j + 1, kSatSize, convStat, "patch", j);
+		ConvCheck(m, aColor, refColor, YWhite, norm, 11, j + 1, kSatSize, convStat, "patch", j);
 		// One CC set feeds the replays (the GCD run, which is also the CC mode
 		// left active afterwards - see RunConvWhite), stratified every 4th
 		// patch: a white-source split shows on every patch, so the replay only
@@ -1129,17 +1132,17 @@ static void RunConvWhite ( CMeasure & m, FamStat & stat )
 	bool mascior = ( cfg->m_CCMode >= MASCIOR50 && cfg->m_CCMode <= CCMAXHDR );
 
 	// UpdateGrid's YWhite recomputed from the PERTURBED state, plus the matching
-	// shared white - one pair for saturation samples, one for CC samples.
+	// shared normalization - one pair for saturation samples, one for CC samples.
 	double YWhiteSat = GridYWhite(m, special, false);
 	double YWhiteCC  = GridYWhite(m, special, true);
-	double wDESat = m.GetColorDEWhiteY(special, false, false);
-	double wDECC  = m.GetColorDEWhiteY(special, true, mascior);
+	ColorDENorm normSat = m.GetColorDENorm(5);
+	ColorDENorm normCC  = m.GetColorDENorm(11);
 
 	for ( int i = 0 ; i < s_nConvSamples ; i ++ )
 	{
 		const ConvSample & s = s_convSamples[i];
 		bool bCC = ( s.displayMode == 11 );
-		ConvCheck(m, s.meas, s.ref, bCC ? YWhiteCC : YWhiteSat, bCC ? wDECC : wDESat,
+		ConvCheck(m, s.meas, s.ref, bCC ? YWhiteCC : YWhiteSat, bCC ? normCC : normSat,
 				  s.displayMode, s.nCol, kSatSize, stat, s.name, s.idx);
 	}
 
@@ -1190,7 +1193,7 @@ static void RunConvNoWhite ( const Combo & c, CSimulatedSensor & sensor, FamStat
 	// after RunGray (the measured on/off white on HDR combos), NOT the value
 	// ApplyComboConfig set - which is fine, both sides read the same config.
 	double YWhite = cfg->m_TargetMaxL;
-	double wDE = m.GetColorDEWhiteY(special, false, false);
+	ColorDENorm norm = m.GetColorDENorm(5);
 
 	for ( int s = 0 ; s < 6 ; s ++ )
 	{
@@ -1201,7 +1204,7 @@ static void RunConvNoWhite ( const Combo & c, CSimulatedSensor & sensor, FamStat
 		{
 			CColor aColor = Meas(sensor, GenColors[j], c.intensity);
 			CColor refColor = m.GetRefSat(s, (double)j / (double)(kSatSize - 1), special, 1.0);
-			ConvCheck(m, aColor, refColor, YWhite, wDE, 5 + s, j + 1, kSatSize,
+			ConvCheck(m, aColor, refColor, YWhite, norm, 5 + s, j + 1, kSatSize,
 					  stat, names[s], j);
 		}
 	}

--- a/AccuracyTest.cpp
+++ b/AccuracyTest.cpp
@@ -548,7 +548,7 @@ static double GridColorDE ( const CMeasure & m, const CColor & aMeasure, const C
 		}
 		else
 		{
-			if ( cfg->m_CCMode >= MASCIOR50 && cfg->m_CCMode <= CCMAXHDR && displayMode == 11 )
+			if ( IsMasciorCC(cfg->m_CCMode) && displayMode == 11 )
 				YWhite = m.GetGray(m.GetGrayScaleSize() - 1).GetY();
 			else
 			{
@@ -568,20 +568,13 @@ static double GridColorDE ( const CMeasure & m, const CColor & aMeasure, const C
 // The convention families: pane-vs-viewer dE equality.
 //
 // The 3D viewer computes sat/CC dE as
-//   measured.GetDeltaE( GetColorDEWhiteY(), ref * (10000/that white), 1.0, ... )
+//   measured.GetDeltaE( norm.whiteY, ref * norm.deScale, 1.0, ... )
 // (Color3DView BuildScene + AppendMeasure). The measures grid uses the
 // GridColorDE chain above with the GetHDRRefScale reference rescale. With the
 // ideal sensor a perfect patch reads dE ~ 0 under EITHER convention, so the
 // wire-model families cannot see a convention mismatch. This check perturbs
 // the measured color (fixed asymmetric XYZ gains -> a few dE of luminance +
 // chroma error) and requires both formulas to yield the SAME dE.
-//
-// What is genuinely SHARED with production here is the dE white: the viewer
-// side calls CMeasure::GetColorDEWhiteY, while the pane side is fed the
-// harness's own UpdateGrid emulation. So the check also locks "UpdateGrid's
-// YWhite selection == GetColorDEWhiteY", which is what the white-source
-// families below exercise. The reference scale and the dE evaluation space are
-// still re-derived on both sides - see ACCURACYTEST.md coverage gap 7.
 //
 // Three families run this same comparison under different measured state:
 //   convPV   nominal whites (the ideal sensor's prime white lands exactly on
@@ -591,7 +584,7 @@ static double GridColorDE ( const CMeasure & m, const CColor & aMeasure, const C
 // norm is CMeasure::GetColorDENorm for this family - PRODUCTION code, not an
 // emulation. That asymmetry is the whole point: the pane side below is the
 // harness's own UpdateGrid/GetItemText emulation, so the check is "the grid's
-// normalisation == the shared helper every other consumer uses". Editing
+// normalization == the shared helper every other consumer uses". Editing
 // C3DColorView::BuildScene without touching AccuracyTest.cpp can no longer
 // read 0.000, because the viewer's numbers now come from the same call.
 // It is passed in rather than re-read per patch because it reads CColor copies
@@ -606,7 +599,7 @@ static void ConvCheck ( const CMeasure & m, const CColor & aColor, const CColor 
 
 	bool isHDR = ( cfg->m_GammaOffsetType == 5 );
 	bool bCC = ( displayMode == 11 );
-	bool mascior = ( bCC && cfg->m_CCMode >= MASCIOR50 && cfg->m_CCMode <= CCMAXHDR );
+	bool mascior = ( bCC && IsMasciorCC(cfg->m_CCMode) );
 
 	CColor pert = aColor;
 	pert.SetX(pert.GetX() * 1.07);
@@ -643,8 +636,24 @@ static void ConvCheck ( const CMeasure & m, const CColor & aColor, const CColor 
 	CColor refView = refRaw;
 	ScaleXYZ(refView, norm.deScale);
 	// AppendMeasure's gw: 3 in mode 5, the configured weight otherwise.
-	double dEview = pert.GetDeltaE(norm.whiteY, refView, 1.0, *s_pViewDERef, cfg->m_dE_form, false,
-								   isHDR ? 3 : cfg->gw_Weight);
+	int gw = isHDR ? 3 : cfg->gw_Weight;
+	double dEview = pert.GetDeltaE(norm.whiteY, refView, 1.0, *s_pViewDERef, cfg->m_dE_form, false, gw);
+
+	// ColorDENorm advertises TWO equivalent spellings - the viewer's
+	// (ref * deScale, YWhiteRef 1.0) just used, and the grid's
+	// (ref * markScale, YWhiteRef refWhite) - equal because deScale ==
+	// markScale / refWhite. Nothing else in the tree reads markScale or
+	// refWhite (the pane side above deliberately re-derives its own scale via
+	// PaneRefScale, because a differential test whose two sides call the same
+	// function tests nothing), so without this a mutation of either member
+	// escapes the whole 876-combo matrix while still moving the 3D viewer's
+	// HDR color-checker markers. Cheap: one extra GetDeltaE per patch.
+	CColor refMark = refRaw;
+	ScaleXYZ(refMark, norm.markScale);
+	double dEmark = pert.GetDeltaE(norm.whiteY, refMark, norm.refWhite, *s_pViewDERef,
+								   cfg->m_dE_form, false, gw);
+	stat.Add(fabs(dEmark - dEview), "%s %d (ColorDENorm markScale form %.3f vs deScale form %.3f)",
+			 name, idx, dEmark, dEview);
 
 	stat.Add(fabs(dEpane - dEview), "%s %d (pane %.3f vs viewer %.3f)", name, idx, dEpane, dEview);
 }
@@ -1055,7 +1064,7 @@ static void RunCC ( const Combo & c, CMeasure & m, CSimulatedSensor & sensor, CC
 	// and diverge from the grid.
 	bool special = ( cfg->m_colorStandard == HDTVa || cfg->m_colorStandard == HDTVb );
 	double YWhite = GridYWhite(m, special, true);
-	bool mascior = ( ccMode >= MASCIOR50 && ccMode <= CCMAXHDR );
+	bool mascior = IsMasciorCC(ccMode);
 	ColorDENorm norm = m.GetColorDENorm(11);
 
 	for ( int j = 0 ; j < count ; j ++ )
@@ -1129,7 +1138,6 @@ static void RunConvWhite ( CMeasure & m, FamStat & stat )
 	// tmWhite / GetHDRRefScale) at its converged value is what DECOUPLES the
 	// measured white from the theoretical one. Refreshing would drag the
 	// theoretical white along and restore the accidental equality.
-	bool mascior = ( cfg->m_CCMode >= MASCIOR50 && cfg->m_CCMode <= CCMAXHDR );
 
 	// UpdateGrid's YWhite recomputed from the PERTURBED state, plus the matching
 	// shared normalization - one pair for saturation samples, one for CC samples.

--- a/Measure.cpp
+++ b/Measure.cpp
@@ -7472,10 +7472,17 @@ double CMeasure::GetColorDEWhiteY(bool bSpecial, bool bCC, bool bMasciorCC) cons
 {
 	BOOL isHDR = ( GetConfig()->m_GammaOffsetType == 5 );
 
+	// The > 0.0 test matters as much as isValid(): ColorTriplet::isValid only
+	// rejects values below -1.0 (it is a FX_NODATA sentinel check), so a gray
+	// top that measured - or was typed into the grid as - zero luminance is
+	// "valid" with GetY() == 0. Returning it would skip the m_TargetMaxL
+	// fallback below and hand every consumer a zero dE white, which the 3D
+	// viewer turns into a 100x reference/marker mismatch and /accuracytest into
+	// a 999 convention failure.
 	if ( isHDR && bCC && bMasciorCC )
 	{
 		int n = GetGrayScaleSize();
-		if ( n > 0 && GetGray(n - 1).isValid() )
+		if ( n > 0 && GetGray(n - 1).isValid() && GetGray(n - 1).GetY() > 0.0 )
 			return GetGray(n - 1).GetY();
 	}
 
@@ -7523,10 +7530,17 @@ double CMeasure::GetColorDEWhiteY(bool bSpecial, bool bCC, bool bMasciorCC) cons
 // /accuracytest's kKnownFails.
 ColorDENorm CMeasure::GetColorDENorm(int displayMode) const
 {
+	// 5..10 saturation, 11 color checker. Nothing else is modelled: the grid
+	// normalises grayscale (0..4), primaries (1) and the profile cube (13)
+	// differently, and silently handing one of those the SATURATION convention
+	// would double-scale its reference (GetRefPrimary already applies
+	// GetHDRRefScale internally). Assert rather than guess.
+	ASSERT( displayMode >= 5 && displayMode <= 11 );
+
 	CColorHCFRConfig * cfg = GetConfig();
 	bool bCC      = ( displayMode == 11 );
 	bool bSpecial = ( cfg->m_colorStandard == HDTVa || cfg->m_colorStandard == HDTVb );
-	bool mascior  = ( bCC && cfg->m_CCMode >= MASCIOR50 && cfg->m_CCMode <= CCMAXHDR );
+	bool mascior  = ( bCC && IsMasciorCC(cfg->m_CCMode) );
 
 	ColorDENorm n;
 	n.whiteY    = GetColorDEWhiteY(bSpecial, bCC, mascior);
@@ -7553,11 +7567,22 @@ ColorDENorm CMeasure::GetColorDENorm(int displayMode) const
 	// markScale brings that to diffuse-white-relative (tone-map aware, = the
 	// legacy 105.95640 with tone mapping off); refWhite then expresses the
 	// measured white against the same diffuse white.
-	double tmWhite = TmDiffuseWhiteNits(GetOnOffWhite(), GetOnOffBlack());
+	// ONE tmWhite for all three members, and it comes from GetHDRRefScale so that
+	// its "<= 0 -> 94.37844" clamp applies to every one of them: refWhite is
+	// whiteY / tmWhite, and tmWhite == 10000 / markScale by construction.
+	// Recomputing TmDiffuseWhiteNits separately here (which this used to do) both
+	// dropped that clamp on refWhite alone - making deScale != markScale /
+	// refWhite in exactly the degenerate case the clamp exists for, i.e. the two
+	// documented spellings of this struct disagreeing - and paid a second full
+	// PQ/BT.2390 evaluation plus four CColor deep copies per call, for a number
+	// that is only equal to markScale's because mode-5 getL_EOTF happens to
+	// ignore White/Black.
 	n.markScale = GetHDRRefScale();
-	n.refWhite  = ( tmWhite > 0.0 && n.whiteY > 0.0 ) ? n.whiteY / tmWhite : 1.0;
-	// deScale == markScale / refWhite, but computed directly so a zero white
-	// cannot turn into a division by zero here instead of inside GetDeltaE.
+	n.refWhite  = ( n.whiteY > 0.0 ) ? n.whiteY * n.markScale / 10000. : 1.0;
+	// deScale == markScale / refWhite in every branch, including whiteY <= 0
+	// (where refWhite is 1.0 and deScale falls back to markScale). Computed
+	// directly so a zero white cannot become a division by zero here instead of
+	// inside GetDeltaE.
 	n.deScale   = ( n.whiteY > 0.0 ) ? 10000. / n.whiteY : n.markScale;
 	return n;
 }

--- a/Measure.cpp
+++ b/Measure.cpp
@@ -7497,8 +7497,73 @@ double CMeasure::GetColorDEWhiteY(bool bSpecial, bool bCC, bool bMasciorCC) cons
 	return y;
 }
 
-CColor CMeasure::GetMeasurement(int i) const 
-{ 
+// The WHOLE saturation / color-checker dE normalisation in one place: the dE
+// white, the reference rescale, and the YWhiteRef that pairs with it.
+// displayMode follows CMainView: 5..10 saturation sweeps, 11 color checker.
+//
+// This exists because the normalisation had been re-derived at roughly a dozen
+// sites - the measures grid, the 3D viewer, three Export blocks, RGBLevelWnd,
+// SatLumShiftView, the CIE tooltip and the /accuracytest harness - and they had
+// already drifted apart twice: the viewer normalised by the THEORETICAL
+// tone-mapped white where the grid uses the MEASURED one, and Export lost the
+// grid's manual-generator carve-out. A dE ~ 0 self-test cannot see that class of
+// split (it holds under any self-consistent normalisation), so the guard has to
+// be structural: one definition, no copies.
+//
+// SCOPE: the unified (automatic-generator) convention. The measures grid keeps a
+// legacy carve-out for the MANUAL generator - the Mascior disc's 92.254965-nit
+// white, a fixed 105.95640 rescale, and an extra YWhite * 94.37844 / tmWhite -
+// which is deliberately NOT modelled here, for two reasons. It is legacy the
+// 2026-07 unification chose to leave alone, and it is not even expressible as a
+// per-family normalisation: one of its branches keys off the patch's COLUMN
+// (UHDTV2's last saturation step), so it cannot be hoisted out of a patch loop
+// the way this can. Sites that must byte-match the grid's on-screen numbers for
+// a disc capture (Export) therefore keep an explicit, commented DVD branch. The
+// resulting grid-vs-viewer split is tracked by the manual-generator entries in
+// /accuracytest's kKnownFails.
+ColorDENorm CMeasure::GetColorDENorm(int displayMode) const
+{
+	CColorHCFRConfig * cfg = GetConfig();
+	bool bCC      = ( displayMode == 11 );
+	bool bSpecial = ( cfg->m_colorStandard == HDTVa || cfg->m_colorStandard == HDTVb );
+	bool mascior  = ( bCC && cfg->m_CCMode >= MASCIOR50 && cfg->m_CCMode <= CCMAXHDR );
+
+	ColorDENorm n;
+	n.whiteY    = GetColorDEWhiteY(bSpecial, bCC, mascior);
+	n.refWhite  = 1.0;
+	n.markScale = 1.0;
+	n.deScale   = 1.0;
+
+	// SDR: references are already white-relative and the measured white does all
+	// the work, so every scale stays 1.0.
+	if ( cfg->m_GammaOffsetType != 5 )
+		return n;
+
+	// Mascior-style HDR CC sets keep their own convention: references land on the
+	// HDR-100 scale and are normalised against the grayscale top (which
+	// GetColorDEWhiteY already returned), with YWhiteRef 1.0.
+	if ( mascior )
+	{
+		n.markScale = 100.;
+		n.deScale   = 100.;
+		return n;
+	}
+
+	// HDR-10: GetRefSat/GetRefCC24Sat produce the 1.0 = 10000 nits convention.
+	// markScale brings that to diffuse-white-relative (tone-map aware, = the
+	// legacy 105.95640 with tone mapping off); refWhite then expresses the
+	// measured white against the same diffuse white.
+	double tmWhite = TmDiffuseWhiteNits(GetOnOffWhite(), GetOnOffBlack());
+	n.markScale = GetHDRRefScale();
+	n.refWhite  = ( tmWhite > 0.0 && n.whiteY > 0.0 ) ? n.whiteY / tmWhite : 1.0;
+	// deScale == markScale / refWhite, but computed directly so a zero white
+	// cannot turn into a division by zero here instead of inside GetDeltaE.
+	n.deScale   = ( n.whiteY > 0.0 ) ? 10000. / n.whiteY : n.markScale;
+	return n;
+}
+
+CColor CMeasure::GetMeasurement(int i) const
+{
 	return m_measurementsArray[i]; 
 } 
 

--- a/Measure.h
+++ b/Measure.h
@@ -47,7 +47,7 @@ double TmDiffuseWhiteNits(const CColor & White, const CColor & Black);
 // consumer asks CMeasure for it instead of re-deriving it. See
 // CMeasure::GetColorDENorm.
 //
-// Two equivalent ways to spend it, both giving the SAME dE:
+// Two equivalent ways to spend it, giving the SAME dE:
 //   measures grid  measured.GetDeltaE( whiteY, ref * markScale, refWhite, ... )
 //   3D viewer      measured.GetDeltaE( whiteY, ref * deScale,   1.0,      ... )
 // because deScale == markScale / refWhite by construction. Use markScale for
@@ -55,13 +55,31 @@ double TmDiffuseWhiteNits(const CColor & White, const CColor & Black);
 // the reference lands in the same units as the measurement; use deScale when
 // only a dE is wanted.
 //
+// CAVEAT: that equivalence holds for dE_form 0..5, whose Lab/Luv constructors
+// DIVIDE by the white they are handed, so a common factor cancels. dE_form 6
+// (dICtCp) does not qualify - ColorXYZ::GetDeltaE case 6 SWAPS the two whites
+// and ColorICtCp MULTIPLIES by its white through the non-linear PQ curve, so
+// the two forms give different numbers there. Anything that must match the
+// measures grid under dICtCp has to spend the grid's (markScale, refWhite)
+// form, not deScale.
+//
 // All four members are 1.0 / measured-white in SDR: nothing rescales there.
+//
+// SCOPE: the unified (automatic-generator) convention only. The measures grid
+// keeps a legacy manual-generator (DVD) carve-out that is deliberately NOT
+// modelled here - see CMeasure::GetColorDENorm - so a site that must byte-match
+// the grid's on-screen numbers for a disc capture needs its own DVD branch.
 struct ColorDENorm
 {
 	double	whiteY;		// measured white the MEASUREMENT is normalised by
 	double	refWhite;	// YWhiteRef to pass alongside a markScale-scaled reference
 	double	markScale;	// reference rescale into diffuse-white-relative units
 	double	deScale;	// reference rescale for the YWhiteRef = 1.0 form
+
+	// Defaulted so a partially-filled instance degrades to "no rescale" and
+	// trips the <= 0.0 white guards consumers already have, rather than feeding
+	// indeterminate doubles into GetDeltaE as a divisor.
+	ColorDENorm() : whiteY(0.0), refWhite(1.0), markScale(1.0), deScale(1.0) {}
 };
 
 #define	DUPLGRAYLEVEL		0

--- a/Measure.h
+++ b/Measure.h
@@ -43,6 +43,27 @@ class CAsyncMeasurer;
 // White/Black (mode-5 PQ ignores them anyway).
 double TmDiffuseWhiteNits(const CColor & White, const CColor & Black);
 
+// The complete saturation / color-checker dE normalisation, so that every
+// consumer asks CMeasure for it instead of re-deriving it. See
+// CMeasure::GetColorDENorm.
+//
+// Two equivalent ways to spend it, both giving the SAME dE:
+//   measures grid  measured.GetDeltaE( whiteY, ref * markScale, refWhite, ... )
+//   3D viewer      measured.GetDeltaE( whiteY, ref * deScale,   1.0,      ... )
+// because deScale == markScale / refWhite by construction. Use markScale for
+// anything that also has to PLOT the reference (marker geometry, swatches) so
+// the reference lands in the same units as the measurement; use deScale when
+// only a dE is wanted.
+//
+// All four members are 1.0 / measured-white in SDR: nothing rescales there.
+struct ColorDENorm
+{
+	double	whiteY;		// measured white the MEASUREMENT is normalised by
+	double	refWhite;	// YWhiteRef to pass alongside a markScale-scaled reference
+	double	markScale;	// reference rescale into diffuse-white-relative units
+	double	deScale;	// reference rescale for the YWhiteRef = 1.0 form
+};
+
 #define	DUPLGRAYLEVEL		0
 #define	DUPLNEARBLACK		1
 #define	DUPLNEARWHITE		2
@@ -242,6 +263,7 @@ public:
 	void GetRefProfileSat(int i, CColor & ccRef);	// theoretical reference for patch i (grid conventions)
 	double ComputeProfileDE(const CColor & measured, int i);	// dE for profile patch i, matching the measures grid (SDR + PQ HDR); -1 to skip
 	double GetColorDEWhiteY(bool bSpecial, bool bCC, bool bMasciorCC) const;	// the white the grid normalises sat/CC dE by (measured, NOT the theoretical tmWhite)
+	ColorDENorm GetColorDENorm(int displayMode) const;	// the whole sat/CC dE normalisation, shared by every consumer
 	// Live profile-capture state (not serialized): the profiling pane pauses/observes through these
 	volatile BOOL m_bProfilePause;
 	double m_profileCurrentDrift;	// last anchor's drift factor minus 1.0

--- a/Views/Color3DView.cpp
+++ b/Views/Color3DView.cpp
@@ -481,20 +481,27 @@ void C3DColorView::BuildScene()
 	// 105.95640 with tone mapping off (* 100 for the Mascior-style HDR CC
 	// sets, matching the measures grid).
 	const bool hdr10Refs = ( GetConfig()->m_GammaOffsetType == 5 );
-	const double hdrRefScale = hdr10Refs ? pMeasure->GetHDRRefScale() : 1.0;
 	const bool satSpecial = ( ref.m_standard == HDTVa || ref.m_standard == HDTVb );
 
-	// dE normalisation, separate from the marker geometry above: ask CMeasure
+	// dE normalisation, separate from the marker geometry below: ask CMeasure
 	// rather than re-deriving it, so this cannot drift from the measures grid
 	// again (it did - this used to normalise by the THEORETICAL tone-mapped
 	// white where the grid uses the MEASURED one, which reads ~1% off whenever
-	// the display's white misses target). Marker geometry keeps hdrRefScale:
-	// refC * (10000 / tmWhite) * tmWhite is absolute nits, so a perfect patch
-	// draws no tail. (whiteY fallback: with no measured white at all the helper
-	// returns 0, which AppendMeasure would read as "blackish" and drop the dE.)
+	// the display's white misses target).
+	// The scales come from the helper UNCONDITIONALLY: it already degrades a
+	// missing white to deScale == markScale, and second-guessing that with a
+	// bare 1.0 (which this used to do) leaves the reference on the 1.0 = 10000
+	// nits convention while the measurement is normalised by ~100 nits - a 100x
+	// mismatch that also splits the plotted marker from its own dE target.
+	// Only whiteY keeps a local fallback, because the scene white is a better
+	// "blackish" guard than 0 for AppendMeasure.
 	const ColorDENorm satNorm = pMeasure->GetColorDENorm( 5 );	// any saturation mode
 	const double satDEWhite = ( satNorm.whiteY > 0.0 ) ? satNorm.whiteY : whiteY;
-	const double satDEScale = ( satNorm.whiteY > 0.0 ) ? satNorm.deScale : 1.0;
+	const double satDEScale = satNorm.deScale;
+	// Marker geometry: refC * markScale * tmWhite is absolute nits, so a perfect
+	// patch draws no tail. Same number GetHDRRefScale returns - taken from the
+	// helper so there is only one definition of the marker scale.
+	const double hdrRefScale = satNorm.markScale;
 	static const wchar_t * hueName[6] = { L"Red", L"Green", L"Blue", L"Yellow", L"Cyan", L"Magenta" };
 	int nSatLevels = pMeasure->GetSatLevelCount();
 	for ( int L = 0; L < nSatLevels; L++ )
@@ -545,7 +552,10 @@ void C3DColorView::BuildScene()
 	const ColorDENorm ccNorm = pMeasure->GetColorDENorm( 11 );
 	const double ccDEWhite   = ( ccNorm.whiteY > 0.0 ) ? ccNorm.whiteY : whiteY;
 	const double ccMarkScale = ccNorm.markScale;
-	const double ccDEScale   = ( ccNorm.whiteY > 0.0 ) ? ccNorm.deScale : 1.0;
+	// Unconditional, like the saturation block: a bare 1.0 here would leave the
+	// dE reference unscaled while ccMarkScale still plots the marker at * 100 for
+	// a Mascior CC set, so the marker and its own dE target would disagree.
+	const double ccDEScale   = ccNorm.deScale;
 	for ( i = 0; i < n; i++ )
 	{
 		CColor c = pMeasure->GetCC24Sat( i );

--- a/Views/Color3DView.cpp
+++ b/Views/Color3DView.cpp
@@ -484,20 +484,17 @@ void C3DColorView::BuildScene()
 	const double hdrRefScale = hdr10Refs ? pMeasure->GetHDRRefScale() : 1.0;
 	const bool satSpecial = ( ref.m_standard == HDTVa || ref.m_standard == HDTVb );
 
-	// dE normalisation, separate from the marker geometry above. The grid
-	// normalises sat/CC dE by the MEASURED white (CMeasure::GetColorDEWhiteY)
-	// and expresses the reference relative to it (RefWhite = YWhite / tmWhite);
-	// scaling the reference by 10000 / that white is the same thing with
-	// YWhiteRef 1.0, which is what AppendMeasure passes. Normalising by the
-	// theoretical tmWhite instead (what SceneDiffuseWhiteY returns in HDR, and
-	// what this used to pass) reads ~1% off the grid whenever the display's
-	// white misses target. Marker geometry keeps hdrRefScale: refC * (10000 /
-	// tmWhite) * tmWhite is absolute nits, so a perfect patch draws no tail.
-	// (whiteY fallback: with no measured white at all the helper returns 0,
-	// which AppendMeasure would read as "blackish" and drop the dE entirely.)
-	double satDEWhiteRaw = pMeasure->GetColorDEWhiteY( satSpecial, false, false );
-	const double satDEWhite = ( satDEWhiteRaw > 0.0 ) ? satDEWhiteRaw : whiteY;
-	const double satDEScale = ( hdr10Refs && satDEWhite > 0.0 ) ? 10000. / satDEWhite : 1.0;
+	// dE normalisation, separate from the marker geometry above: ask CMeasure
+	// rather than re-deriving it, so this cannot drift from the measures grid
+	// again (it did - this used to normalise by the THEORETICAL tone-mapped
+	// white where the grid uses the MEASURED one, which reads ~1% off whenever
+	// the display's white misses target). Marker geometry keeps hdrRefScale:
+	// refC * (10000 / tmWhite) * tmWhite is absolute nits, so a perfect patch
+	// draws no tail. (whiteY fallback: with no measured white at all the helper
+	// returns 0, which AppendMeasure would read as "blackish" and drop the dE.)
+	const ColorDENorm satNorm = pMeasure->GetColorDENorm( 5 );	// any saturation mode
+	const double satDEWhite = ( satNorm.whiteY > 0.0 ) ? satNorm.whiteY : whiteY;
+	const double satDEScale = ( satNorm.whiteY > 0.0 ) ? satNorm.deScale : 1.0;
 	static const wchar_t * hueName[6] = { L"Red", L"Green", L"Blue", L"Yellow", L"Cyan", L"Magenta" };
 	int nSatLevels = pMeasure->GetSatLevelCount();
 	for ( int L = 0; L < nSatLevels; L++ )
@@ -539,18 +536,16 @@ void C3DColorView::BuildScene()
 	if ( n > MAX_USER_CC_PATCH_SIZE )
 		n = MAX_USER_CC_PATCH_SIZE;   // the measure arrays are allocated to this;
 									  // GetCC24Sat indexes unchecked past it
-	// Loop-invariant: hoisted like the saturation block above. GetColorDEWhiteY
-	// returns CColor copies internally, so calling it per patch would allocate
-	// on every one of the 71 AXIS iterations. SDR is included because the grid
-	// falls back to the ON/OFF white for CC when the primaries run was made
-	// below 90% stimulus, which whiteY does not model.
-	const bool ccMascior = ( GetConfig()->m_CCMode >= MASCIOR50 && GetConfig()->m_CCMode <= CCMAXHDR );
-	double ccDEWhiteRaw = pMeasure->GetColorDEWhiteY( satSpecial, true, ccMascior );
-	const double ccDEWhite = ( ccDEWhiteRaw > 0.0 ) ? ccDEWhiteRaw : whiteY;
-	// Mascior-style HDR CC sets keep their own convention (* 100 against the
-	// grayscale top, RefWhite 1.0) on both sides - see the grid.
-	const double ccMarkScale = ccMascior ? 100. : hdrRefScale;
-	const double ccDEScale   = ccMascior ? 100. : ( 10000. / ccDEWhite );
+	// Loop-invariant: hoisted like the saturation block above. GetColorDENorm
+	// reads CColor copies internally, so calling it per patch would allocate on
+	// every one of the 71 AXIS iterations. The color-checker normalisation is
+	// genuinely different from the saturation one - the sub-90%-stimulus ON/OFF
+	// fallback is CC-only, and the Mascior-style HDR sets keep their own * 100
+	// convention against the grayscale top - hence the separate query.
+	const ColorDENorm ccNorm = pMeasure->GetColorDENorm( 11 );
+	const double ccDEWhite   = ( ccNorm.whiteY > 0.0 ) ? ccNorm.whiteY : whiteY;
+	const double ccMarkScale = ccNorm.markScale;
+	const double ccDEScale   = ( ccNorm.whiteY > 0.0 ) ? ccNorm.deScale : 1.0;
 	for ( i = 0; i < n; i++ )
 	{
 		CColor c = pMeasure->GetCC24Sat( i );

--- a/libHCFR/Color.h
+++ b/libHCFR/Color.h
@@ -95,6 +95,16 @@ typedef enum
     USER = 36
 } CCPatterns;
 
+// "Is this one of the Mascior-style HDR color-checker sets?" - the sets that
+// keep their own dE convention (a * 100 reference scale, normalised against the
+// grayscale top rather than the prime white). This is a CONTIGUOUS-RANGE
+// assumption about the enum above, so it lives here beside the constants that
+// have to stay contiguous, instead of being spelled out again at each consumer.
+inline bool IsMasciorCC ( int ccMode )
+{
+	return ( ccMode >= MASCIOR50 && ccMode <= CCMAXHDR );
+}
+
 typedef enum 
 {
 	Default = -1,

--- a/tests/ACCURACYTEST.md
+++ b/tests/ACCURACYTEST.md
@@ -358,6 +358,13 @@ agree), and the gaps below are mostly places their reach stops.
 5. ~~**Whites are always present.**~~ Closed by `convNW`.
 9. ~~**Hard-clip coverage is tone-map-OFF only.**~~ Closed by the second
    tone-mapped EOTF row at `TargetMaxL = 700`.
+2. ~~**The manual generator (DVD) is never configured.**~~ Closed by the
+   generator axis — and it immediately found a real grid-vs-3D-viewer
+   divergence, now the DVD known-fail entry above. The `if (DVD)` carve-outs in
+   `InitGrid`, `RGBLevelWnd` and Export are still not *directly* covered: they
+   duplicate the same normalization. That is gap 8's problem for Export;
+   `InitGrid` and `RGBLevelWnd` are simply not on `GetColorDENorm` yet and have
+   no gap of their own.
 7. ~~**The `conv*` families compare two harness-local copies.**~~ Closed by
    `CMeasure::GetColorDENorm`, which now owns the whole sat/CC normalization —
    the dE white, the reference rescale and the `YWhiteRef` that pairs with it.
@@ -370,15 +377,23 @@ agree), and the gaps below are mostly places their reach stops.
    same break read 0.000 until someone remembered to update the harness's copy
    too — which is the whole point: the harness now follows production instead of
    carrying its own copy of the formula.
-   Still re-derived on the pane side: the `markScale` application in `UpdateGrid`
-   and the dE evaluation space (`bRef`). Those are the grid's own definition of
-   record, so an emulation of them is the point rather than a duplicate.
-2. ~~**The manual generator (DVD) is never configured.**~~ Closed by the
-   generator axis — and it immediately found a real grid-vs-3D-viewer
-   divergence, now the DVD known-fail entry above. The `if (DVD)` carve-outs in
-   `InitGrid`, `RGBLevelWnd` and Export are still not *directly* covered: they
-   duplicate the same normalization, which is gap 7's problem, not a separate
-   axis.
+   All four struct members are locked: `whiteY`/`deScale` by the pane-vs-viewer
+   comparison, `markScale`/`refWhite` by the extra "both spellings of
+   `ColorDENorm` agree" check in `ConvCheck` — without which a mutation of
+   either escapes the whole matrix while still moving the viewer's HDR CC
+   markers. Mutation-verified in turn: scaling `refWhite` by 1.05 **in
+   production, with no harness edit** takes the quick subset from
+   `90 pass, 0 FAIL` to `66 pass, 96 FAIL`. Before that check it failed nothing,
+   because nothing in the tree read either member.
+   **Still re-derived, and NOT covered:** the `markScale` application in
+   `UpdateGrid` and the *grid's* dE space (`bRef`) — those are the grid's own
+   definition of record, so emulating them is the point — but also the
+   **viewer's** dE space and gray weight (`s_pViewDERef` and the `isHDR ? 3`
+   selection are harness-local copies of `AppendMeasure`'s). Deleting
+   `BuildScene`'s `ContainerTransportReference` branch for UHDTV3/4 still moves
+   real viewer dE while this reads 0.000. The lock is also `dE_form`-specific:
+   the matrix pins `m_dE_form = 3`, and the two `ColorDENorm` spellings are only
+   equivalent for the Lab/Luv forms 0–5 (dICtCp swaps its whites).
 
 ### Still open
 
@@ -399,6 +414,11 @@ agree), and the gaps below are mostly places their reach stops.
    hand-rolled `special ? OnOff : Prime` (plus the Mascior grayscale top) that
    is missing three of the grid's fallbacks: prime→ON/OFF when prime is invalid,
    the CC sub-90%-stimulus fallback, and `m_TargetMaxL` when no white exists.
+   The saturation block is worse still — a bare `GetPrimeWhite().GetY()` with no
+   special-standard branch at all — and every block computes `tmWhite` from
+   `TmDiffuseWhiteNits`, where the grid's DVD branch *reassigns* it to the disc's
+   ~92.25-nit 0.50-code white, so a manual-generator HDR capture already exports
+   sat/CC dE ~2.3% off the on-screen numbers.
    Moving them onto `GetColorDENorm` is the fix and would close this gap, but it
    changes user-visible numbers in exported PDFs/CSVs in exactly those corners,
    and nothing automated covers Export — so it wants doing deliberately rather

--- a/tests/ACCURACYTEST.md
+++ b/tests/ACCURACYTEST.md
@@ -358,6 +358,21 @@ agree), and the gaps below are mostly places their reach stops.
 5. ~~**Whites are always present.**~~ Closed by `convNW`.
 9. ~~**Hard-clip coverage is tone-map-OFF only.**~~ Closed by the second
    tone-mapped EOTF row at `TargetMaxL = 700`.
+7. ~~**The `conv*` families compare two harness-local copies.**~~ Closed by
+   `CMeasure::GetColorDENorm`, which now owns the whole sat/CC normalization —
+   the dE white, the reference rescale and the `YWhiteRef` that pairs with it.
+   The 3D viewer and the harness's viewer side both call it, so the `conv*`
+   families no longer *emulate* the viewer: the pane side is the harness's
+   `UpdateGrid`/`GetItemText` emulation, the viewer side is production code, and
+   the check is "the grid's normalization == the shared helper".
+   Mutation-verified: breaking `GetColorDENorm` **in production, with no edit to
+   `AccuracyTest.cpp`**, fails 105 of the 285 quick-subset combos. Before, the
+   same break read 0.000 until someone remembered to update the harness's copy
+   too — which is the whole point: the harness now follows production instead of
+   carrying its own copy of the formula.
+   Still re-derived on the pane side: the `markScale` application in `UpdateGrid`
+   and the dE evaluation space (`bRef`). Those are the grid's own definition of
+   record, so an emulation of them is the point rather than a duplicate.
 2. ~~**The manual generator (DVD) is never configured.**~~ Closed by the
    generator axis — and it immediately found a real grid-vs-3D-viewer
    divergence, now the DVD known-fail entry above. The `if (DVD)` carve-outs in
@@ -379,17 +394,15 @@ agree), and the gaps below are mostly places their reach stops.
    user-visible (swatches disagree while dE reads 0) and completely invisible
    here. This is MFC view code; extracting the pure math into a testable
    function is the prerequisite.
-7. **The `conv*` families compare two harness-local copies.** They *emulate* the
-   viewer's formula rather than calling it, so changing `C3DColorView::BuildScene`
-   without editing `AccuracyTest.cpp` still reads 0.000. Only the white is
-   genuinely shared (`CMeasure::GetColorDEWhiteY`); the reference scale and the
-   dE evaluation space are re-derived. Extracting the whole normalization into
-   one `CMeasure` helper that the grid, the viewer, Export and the harness all
-   call would make the lock real.
 8. **Export is never exercised.** The PDF/CSV/spreadsheet dE paths duplicate the
-   grid's normalization and have already drifted from it. Gap 7's shared helper
-   is the better fix than an export family: if Export calls it, there is nothing
-   left to diverge.
+   grid's normalization and have already drifted from it — their `YWhite` is a
+   hand-rolled `special ? OnOff : Prime` (plus the Mascior grayscale top) that
+   is missing three of the grid's fallbacks: prime→ON/OFF when prime is invalid,
+   the CC sub-90%-stimulus fallback, and `m_TargetMaxL` when no white exists.
+   Moving them onto `GetColorDENorm` is the fix and would close this gap, but it
+   changes user-visible numbers in exported PDFs/CSVs in exactly those corners,
+   and nothing automated covers Export — so it wants doing deliberately rather
+   than as a side effect.
 
 Reference result (2026-07-26): `834 combos: 333 pass, 0 FAIL, 501 known-fail`,
 ColorMathTest verify green with no golden movement. (Was `708 combos: 311 pass,


### PR DESCRIPTION
Rebased onto `main` (#159 and #160 are merged). Reviewed only in part — the
other session stopped mid-review, so this has NOT had a full review pass.

Closes coverage gap 7, the deep one.

## Why

The saturation / color-checker dE normalization was re-derived at roughly a
dozen sites — the measures grid, the 3D viewer, three Export blocks,
`RGBLevelWnd`, `SatLumShiftView`, the CIE tooltip and `/accuracytest` — and had
already drifted apart **twice**: the viewer normalized by the *theoretical*
tone-mapped white where the grid uses the *measured* one, and Export lost the
grid's manual-generator carve-out.

A dE ~ 0 self-test structurally cannot see that class of split, because it holds
under any self-consistent normalization. So the guard has to be structural: one
definition, no copies.

## What

`CMeasure::GetColorDENorm(displayMode)` → `ColorDENorm { whiteY, refWhite,
markScale, deScale }`, carrying the dE white, the reference rescale, and the
`YWhiteRef` that pairs with it. The two consumer shapes are algebraically the
same thing — the grid's `(ref * markScale, refWhite)` and the viewer's
`(ref * deScale, 1.0)` — because `deScale == markScale / refWhite` by
construction, so both spend the same struct.

Moved onto it: `C3DColorView::BuildScene` (saturation + color checker) and the
harness's `convPV`/`convPVw`/`convNW` viewer side.

## The harness change is the point

Those families used to compare **two harness-local copies** — they *emulated*
the viewer rather than calling it, so editing `BuildScene` without also editing
`AccuracyTest.cpp` still read 0.000. Now the pane side is the harness's
`UpdateGrid`/`GetItemText` emulation and the viewer side is production code, so
the check is "the grid's normalization == the shared helper every other consumer
uses".

**Mutation-verified:** breaking `GetColorDENorm` *in production, with no harness
edit*, fails **105 of the 285** quick-subset combos. Before this, the same break
read 0.000 until someone remembered to update the harness's copy too.

## Scope, deliberately

The helper models the **unified (automatic-generator)** convention only. The
grid's manual-generator carve-out stays where it is — it's legacy the 2026-07
unification chose not to touch, and it isn't even expressible as a per-family
normalization: one of its branches keys off the patch's **column** (UHDTV2's
last saturation step), so unlike this it can't be hoisted out of a patch loop.
The resulting grid-vs-viewer split stays tracked by the manual-generator
`kKnownFails` entries.

One behavior change falls out: with a Mascior CC set under an **SDR** transfer
function, the viewer used to scale references by 100 while the grid applies no
rescale at all (`UpdateGrid` gates its block on mode 5). The helper is mode-5
gated like the grid, so the viewer now matches it.

## Not moved, on purpose

Export, `RGBLevelWnd`, `SatLumShiftView` and the CIE tooltip. Export especially
is a real fix — its hand-rolled `YWhite` is missing three of the grid's
fallbacks (prime→ON/OFF, the CC sub-90% case, and `m_TargetMaxL`) — but that
changes numbers in exported PDFs/CSVs and **nothing automated covers Export**,
so it wants a deliberate change rather than riding along here. Gap 8 in
`ACCURACYTEST.md` records the specifics.

## Validation

- `/accuracytest`: **834 combos: 333 pass, 0 FAIL, 501 known-fail** — byte-identical
  to before, confirming the helper reproduces every consumer's previous values.
- `ColorMathTest verify`: green, no golden movement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
