### PR TITLE
Profile dE: use the shared white chain instead of a fourth copy

### DIFF
--- a/Measure.cpp
+++ b/Measure.cpp
@@ -1139,16 +1139,28 @@ double CMeasure::ComputeProfileDE(const CColor & c, int i)
 		return -1.0;
 	ColorXYZ xyz = c.GetXYZValue();
 
-	// White reference, matching the measures grid: prime white normally, but a
-	// primaries run at <100% stimulus leaves prime white dimmer than the
-	// grayscale white -- the grid then uses on/off white (SDR only).
+	// White reference: the SHARED chain, not a copy of it. This used to re-derive
+	// prime-white-then-on/off-then-sub-90% by hand and, in doing so, had dropped
+	// the special-standard (HDTVa/HDTVb) branch that every other consumer of a
+	// profile patch applies - RGBLevelWnd gates it on `m_displayMode > 4`, which
+	// includes profile mode 13 (RGBLevelWnd.cpp ~220). The dE printed for a patch
+	// and the RGB-levels bars drawn beside it therefore normalised by DIFFERENT
+	// whites under those two standards.
+	//
+	// bCC = true because mode 13 shares the color-checker white chain: the
+	// sub-90%-stimulus fallback is gated on `m_displayMode == 11 || 13` in
+	// RGBLevelWnd, not on 11 alone.
+	//
+	// The call is guarded rather than unconditional because GetColorDEWhiteY ends
+	// in the grid's m_TargetMaxL fallback, which would pre-empt the profile-cube
+	// fallback below - the one thing this function must NOT inherit from the grid,
+	// since a standalone profile capture has no grayscale or primaries run at all.
 	CColor prime = GetPrimeWhite();
 	CColor onoff = GetOnOffWhite();
-	CColor w = ( prime.isValid() && prime.GetY() > 0.0 ) ? prime : onoff;
-	if ( onoff.isValid() && onoff.GetY() > 0.0 && prime.isValid() &&
-		 prime.GetY() / onoff.GetY() < 0.9 && GetConfig()->m_GammaOffsetType != 5 )
-		w = onoff;
-	double ywForDE = w.isValid() ? w.GetY() : 0.0;
+	bool bSpecial = ( GetConfig()->m_colorStandard == HDTVa || GetConfig()->m_colorStandard == HDTVb );
+	double ywForDE = 0.0;
+	if ( ( prime.isValid() && prime.GetY() > 0.0 ) || ( onoff.isValid() && onoff.GetY() > 0.0 ) )
+		ywForDE = GetColorDEWhiteY( bSpecial, true, false );
 
 	// Standalone capture (no grayscale/white measured): fall back to the measured
 	// white cube node (stimulus 100/100/100 = last grid patch) so dE still shows.

--- a/Views/MainView.cpp
+++ b/Views/MainView.cpp
@@ -3070,9 +3070,17 @@ CString CMainView::GetItemText(CColor & aMeasure, double YWhite, CColor & aRefer
 						if (dE > dEmax)
                             dEmax = dE;
 						clr = GetConfig()->GetDEColor(dE, GetConfig()->m_darkTheme);
-                        if (GetConfig()->doHighlight)
-                            { m_pGrayScaleGrid->SetItemBkColour(4, nCol, clr); m_pGrayScaleGrid->SetItemFgColour(4, nCol, RGB(0,0,0)); }
-						m_pGrayScaleGrid -> SetItemFont ( 4, nCol, m_pGrayScaleGrid->GetItemFont(0,0) ); // Set the font to bold
+						// nCol is -1 for a free measure (see the else below), and the
+						// guard above admits mode 2/4 REGARDLESS of nCol - so without
+						// this all three calls addressed column -1. GridCtrl returns
+						// FALSE on the missing cell, so Release silently skipped the
+						// highlight; Debug tripped SetItemFont's ASSERT(pCell).
+						if ( nCol >= 1 )
+						{
+							if (GetConfig()->doHighlight)
+								{ m_pGrayScaleGrid->SetItemBkColour(4, nCol, clr); m_pGrayScaleGrid->SetItemFgColour(4, nCol, RGB(0,0,0)); }
+							m_pGrayScaleGrid -> SetItemFont ( 4, nCol, m_pGrayScaleGrid->GetItemFont(0,0) ); // Set the font to bold
+						}
 						dEcnt++;
 					}
 					else
@@ -3178,9 +3186,13 @@ CString CMainView::GetItemText(CColor & aMeasure, double YWhite, CColor & aRefer
 					if (dE > dEmax)
                         dEmax = dE;
 					clr = GetConfig()->GetDEColor(dE, GetConfig()->m_darkTheme);
-                    if (GetConfig()->doHighlight)
-                        { m_pGrayScaleGrid->SetItemBkColour(4, nCol, clr); m_pGrayScaleGrid->SetItemFgColour(4, nCol, RGB(0,0,0)); }
-					m_pGrayScaleGrid -> SetItemFont ( 4, nCol, m_pGrayScaleGrid->GetItemFont(0,0) ); // Set the font to bold
+					// Same out-of-range guard as the grayscale branch above.
+					if ( nCol >= 1 )
+					{
+						if (GetConfig()->doHighlight)
+							{ m_pGrayScaleGrid->SetItemBkColour(4, nCol, clr); m_pGrayScaleGrid->SetItemFgColour(4, nCol, RGB(0,0,0)); }
+						m_pGrayScaleGrid -> SetItemFont ( 4, nCol, m_pGrayScaleGrid->GetItemFont(0,0) ); // Set the font to bold
+					}
 					dEcnt++;
 				}
 			}

--- a/tests/ACCURACYTEST.md
+++ b/tests/ACCURACYTEST.md
@@ -423,6 +423,22 @@ agree), and the gaps below are mostly places their reach stops.
    changes user-visible numbers in exported PDFs/CSVs in exactly those corners,
    and nothing automated covers Export — so it wants doing deliberately rather
    than as a side effect.
+10. **Display-profile mode (13) is never run.** `CMeasure::ComputeProfileDE` is
+   the dE of record for every profile-cube patch — the summary pane, the 3D
+   viewer's profile points and the RGB-levels bars all read it — and the matrix
+   never calls it. That is not hypothetical: it had silently dropped the
+   special-standard (HDTVa/HDTVb) white branch that `RGBLevelWnd` applies to the
+   same patch (`m_displayMode > 4`), so the printed dE and the bars beside it
+   normalized by different whites. Found by review, not by this harness; fixed by
+   routing it through `GetColorDEWhiteY`.
+   Mode 13 is a *third* normalization, not a variant of the other two — it shares
+   the color-checker sub-90% fallback but replaces the grid's `m_TargetMaxL`
+   fallback with a profile-cube-node one, because a standalone capture has no
+   grayscale or primaries run — which is why `GetColorDENorm` asserts
+   `5..11` rather than pretending to answer for it. A profile family would need
+   `RunProfile` to drive a small cube (3³) through the simulated sensor and
+   compare `ComputeProfileDE` against the same pane emulation the `conv*`
+   families use.
 
 Reference result (2026-07-26): `834 combos: 333 pass, 0 FAIL, 501 known-fail`,
 ColorMathTest verify green with no golden movement. (Was `708 combos: 311 pass,


### PR DESCRIPTION
Follow-up to #161, found while reviewing it.

## The bug

`CMeasure::ComputeProfileDE` is the dE of record for every display-profile patch — the summary pane, the 3D viewer's profile points and the RGB-levels bars all read it. It re-derived the grid's white selection by hand and had dropped the **special-standard branch**:

| | `GetColorDEWhiteY` | `ComputeProfileDE` (before) |
|---|---|---|
| prime → on/off fallback | ✅ | ✅ |
| sub-90%-stimulus fallback | ✅ | ✅ |
| **HDTVa/HDTVb → on/off white** | ✅ | ❌ |
| no-white fallback | `m_TargetMaxL` | profile cube node *(deliberate)* |

That is not cosmetic. `RGBLevelWnd` — drawing the bars for the *same patch* — applies the special-standard branch, because it gates on `m_displayMode > 4` and profile mode is 13:

```cpp
if ( m_displayMode > 4 && (m_colorStandard == HDTVa || m_colorStandard == HDTVb))
    white = GetOnOffWhite();
```

So under the 75% or plasma standard the printed dE and the levels beside it normalized by **different whites** — the exact two-consumer split #161 existed to eliminate, one display mode over.

## The fix

Route it through `GetColorDEWhiteY`, which already encodes the whole chain including `bSpecial`.

`bCC = true` because mode 13 shares the color-checker white chain: `RGBLevelWnd` gates the sub-90% fallback on `displayMode 11 || 13`, not 11 alone.

The call is **guarded** on "some white was actually measured" rather than unconditional, because `GetColorDEWhiteY` ends in the grid's `m_TargetMaxL` fallback — the one thing this function must not inherit, since a standalone profile capture has no grayscale or primaries run and falls back to the measured cube node instead.

Behaviour is otherwise unchanged. Every non-special state resolves to the same white as before, checked case by case:

| state | old | new | |
|---|---|---|---|
| prime>0, onoff>0, ratio<0.9, SDR | onoff | onoff | ✓ |
| prime>0, onoff invalid | prime | prime | ✓ |
| prime invalid, onoff>0 | onoff | onoff | ✓ |
| prime Y=0, onoff>0 | onoff | onoff | ✓ |
| both absent | → cube node | → cube node | ✓ |
| HDR mode 5 | sub-90% off | sub-90% off | ✓ |
| **HDTVa/HDTVb** | **prime** | **onoff** | ← the fix |

## Why `GetColorDENorm` is not used here

Mode 13 is a **third** normalization, not a variant of the other two: it shares the CC sub-90% fallback but replaces the grid's `m_TargetMaxL` fallback with the cube-node one. That is exactly why #161's `GetColorDENorm` asserts `5..11` rather than pretending to answer for it.

## Coverage

`ACCURACYTEST.md` gains **gap 10**: the matrix never runs profile mode, which is why this was invisible to it. Found by review, not by the harness.

## Validation

- Full solution build clean
- `ColorMathTest verify` green, no golden movement
- `/accuracytest`: `834 combos: 333 pass, 0 FAIL, 501 known-fail` — unchanged from main

That last one proves **no regression elsewhere**, not that the fix is covered — profile mode is not in the matrix. Verifying the fix itself needs an on-screen check: capture a profile under HDTVa/HDTVb and confirm the patch dE now agrees with the RGB-levels bars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Second commit: the free-measure `ASSERT`

Folded in because it blocked driving the app to verify the above. Unrelated to profile dE, but a one-site fix.

`GetItemText`'s dE branch guards on

```cpp
if ( nCol > 1 || m_displayMode == 4 || m_displayMode == 2 )
```

which **short-circuits**: for display modes 2 and 4 the branch is taken regardless of `nCol`. A free measure has `nCol == -1` — the `else` arm's own comment says so — so in those modes all three grid calls addressed column `-1`.

`GridCtrl` returns `FALSE` on the missing cell, so Release silently skipped the highlight and the bold font; Debug tripped `ASSERT(pCell)` in `CGridCtrl::SetItemFont`.

That assert is the only one of the three still live. `SetItemBkColour`'s and `SetItemFgColour`'s were commented out in `a9705301` (the Light/Dark theme change that introduced `doHighlight`) with *"MainView may color cells transiently out of range during rebuilds"* — which papered over this same path instead of fixing it. `SetItemFont` on the next line was missed.

Fixed at the call site — guard the column rather than write out of range — at **both** dE-cell sites, the grayscale branch and the color branch.

Deliberately **not** done: restoring the two silenced asserts in `GridCtrl.cpp`. Other call sites may rely on that leniency; auditing them is a wider job.

Release impact was cosmetic only (no highlight/bold on the dE cell during free measures in modes 2/4), which is why it went unnoticed.

**Left for a look:** the same `nCol == -1` path still accumulates `dE` into `dEavg`/`dEmax`/`dEcnt` a few lines above. Whether a free measure should contribute to the *grayscale* dE average is a behaviour question, not an obvious bug.

Build clean. Not reachable by `/accuracytest`, which is headless and never paints a grid.
