### PR TITLE
Fix the 3D viewer's gamut solid under the special color standards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,9 @@ tests.xml
 CORRECTION-IMPORT-PLAN.md
 REFERENCES-SIGNAL-SYNC-PLAN.md
 TEN-BIT-PIPELINE-PLAN.md
+
+# /accuracytest writes its report to the CWD (repo root when run from there).
+# Generated output, and a stale one left lying around reads exactly like a
+# passing run when grepped - keep it out of the tree entirely.
+accuracytest_report.txt
+accuracytest_report_quick.txt

--- a/Views/Color3DView.cpp
+++ b/Views/Color3DView.cpp
@@ -197,6 +197,20 @@ C3DColorView::~C3DColorView()
 /////////////////////////////////////////////////////////////////////////////
 // scene
 
+// The scene's GEOMETRY reference: the colorspace basis every plotted coordinate
+// and the gamut solid are built in. Single definition on purpose - the three
+// scene-building entry points must not be able to drift apart, which is the way
+// this fix would most plausibly regress (ColorMathTest T10 pins the helper's
+// contract, but cannot see this call site).
+//
+// NOT the white target. For HDTVa/HDTVb this is a fixed Rec.709/D65, matching
+// how SetRGBValue manufactures their references; anything needing the user's
+// active white must read GetColorReference() directly.
+static CColorReference SceneGamutReference()
+{
+	return SpecialModeGamutReference( GetColorReference() );
+}
+
 // Map a measured/reference XYZ to a model-space coordinate (roughly a unit cube)
 // for the current plot space.
 void C3DColorView::ToModel(const ColorXYZ & xyz, double whiteY, CColorReference & ref,
@@ -256,9 +270,16 @@ void C3DColorView::AppendMeasure(const CColor & c, double whiteY, CColorReferenc
 	double mx, my, mz;
 	ToModel( xyz, m_lumTop > 0.0 ? m_lumTop : whiteY, ref, mx, my, mz );
 
+	// Swatches take the ACTIVE reference, not the geometry one. GetRGBValue has
+	// its own HDTVa/b substitution to a fixed Rec.709/D65, which is what the
+	// measures grid's RGB column uses (MainView's bRef); handing it the already-
+	// substituted geometry reference would suppress that branch and, under a
+	// custom white, tint the viewer's dots differently from the grid.
+	const CColorReference & activeRef = GetColorReference();
+
 	ScenePoint p;
 	p.mx = (float)mx; p.my = (float)my; p.mz = (float)mz;
-	p.trueColor = RgbSwatch( c.GetRGBValue( ref ) );
+	p.trueColor = RgbSwatch( c.GetRGBValue( activeRef ) );
 	p.tx = p.ty = p.tz = 0.0f;
 	p.dE = 0.0f;
 	p.hasTarget = false;
@@ -296,9 +317,8 @@ void C3DColorView::AppendMeasure(const CColor & c, double whiteY, CColorReferenc
 		// follow that swap. GetDeltaE's own substitution is a fixed Rec.709/D65,
 		// so under a custom white target grading against the swapped reference
 		// (Rec.709 + custom white) would silently split the viewer's dE from the
-		// grid's. GetColorReference() returns a reference, so this is the same
-		// single copy the old `= ref` made, not an extra one.
-		CColorReference dERef = GetColorReference();
+		// grid's. Same single copy the old `= ref` made, not an extra one.
+		CColorReference dERef = activeRef;
 		if ( !isGS && ( dERef.m_standard == UHDTV3 || dERef.m_standard == UHDTV4 ) )
 			dERef = ContainerTransportReference( dERef );
 		p.dE = ( dEOverride >= 0.0 ) ? (float)dEOverride
@@ -322,7 +342,7 @@ void C3DColorView::AppendMeasure(const CColor & c, double whiteY, CColorReferenc
 
 		// In non-heatmap mode, colour the dot by its TARGET colour: it identifies
 		// which patch this is regardless of how far off the display measured.
-		p.trueColor = RgbSwatch( markerTarget.GetRGBValue( ref ) );
+		p.trueColor = RgbSwatch( markerTarget.GetRGBValue( activeRef ) );
 	}
 	m_points.push_back( p );
 }
@@ -443,8 +463,11 @@ void C3DColorView::BuildScene()
 	// its 100%-saturation sweeps and color-checker patches well OUTSIDE the solid
 	// at dE 0.00. Substitute Rec.709 once, here, so every geometry consumer below
 	// (ToModel, BuildGamut, EnsureTongueTexture) agrees.
-	const CColorReference active = GetColorReference();
-	CColorReference ref = SpecialModeGamutReference( active );
+	//
+	// `active` stays available for the two things that must NOT follow the swap:
+	// the white target, and the satSpecial flag below.
+	const CColorReference & active = GetColorReference();
+	CColorReference ref = SceneGamutReference();
 
 	// White luminance reference for L*a*b* / xyY normalisation (mirrors the CIE
 	// chart: prefer the pseudo-colour-space prime white, else grayscale white;
@@ -458,7 +481,10 @@ void C3DColorView::BuildScene()
 		m_lumTop = GetConfig()->m_TargetMaxL;
 
 	int i, n;
-	ColorxyY wChroma( ref.GetWhite() );
+	// ACTIVE white, not the geometry basis's: this is the grayscale family's target
+	// chromaticity and must follow the user's white target, which the special-mode
+	// substitution deliberately drops.
+	ColorxyY wChroma( active.GetWhite() );
 	const int  gammaMode = GetConfig()->m_GammaOffsetType;
 	const int  dEgray    = GetConfig()->m_dE_gray;
 	const bool bRound    = GetConfig()->m_bUseRoundDown != FALSE;
@@ -1739,9 +1765,9 @@ void C3DColorView::AppendNewFreeMeasures()
 		return;
 	CMeasure * pMeasure = pDoc->GetMeasure();
 
-	// Same Rec.709 substitution BuildScene applies, so incrementally appended free
-	// measures use the same model transform as the ones added by a full rebuild.
-	CColorReference ref = SpecialModeGamutReference( GetColorReference() );
+	// Same geometry basis BuildScene uses, so incrementally appended free measures
+	// get the same model transform as the ones added by a full rebuild.
+	CColorReference ref = SceneGamutReference();
 	// Same normaliser as the rest of the scene: the local prime/on-off-white
 	// fallback returned PEAK white in PQ-HDR, so free measures were plotted and
 	// scaled against a different white than every other point.
@@ -1749,7 +1775,10 @@ void C3DColorView::AppendNewFreeMeasures()
 	const double gsWhiteY = GridGrayWhiteY( pMeasure );
 	const int    dEgray   = GetConfig()->m_dE_gray;
 
-	CColor wRef( ref.GetWhite() );
+	// ACTIVE white, like BuildScene's wChroma: this classifies a free measure as
+	// near-neutral and supplies the gray target, so it follows the user's white
+	// target rather than the geometry basis's fixed D65.
+	CColor wRef( GetColorReference().GetWhite() );
 	ColorxyY wc( wRef.GetxyYValue() );
 	int n = pMeasure->GetMeasurementsSize();
 	for ( int i = m_freeInScene; i < n; i++ )
@@ -1819,7 +1848,7 @@ void C3DColorView::AppendNewProfileMeasures()
 	// INNER (content, e.g. P3) colors, so plot/swatch in the active reference --
 	// the measured cloud then lands inside the P3 gamut solid, not stretched to 2020.
 	// (HDTVa/b substitute Rec.709 for the same reason BuildScene does.)
-	CColorReference ref = SpecialModeGamutReference( GetColorReference() );
+	CColorReference ref = SceneGamutReference();
 	// Diffuse white (measured, or the standalone-profile fallback) so reference
 	// targets scale into measured units instead of collapsing at whiteY = 1.0.
 	double whiteY = SceneDiffuseWhiteY( pMeasure );

--- a/Views/Color3DView.cpp
+++ b/Views/Color3DView.cpp
@@ -289,9 +289,18 @@ void C3DColorView::AppendMeasure(const CColor & c, double whiteY, CColorReferenc
 		// while the grayscale families use the active reference (its grayscale
 		// branch passes GetColorReference()). HDTVa/b/CC6 are forced to Rec.709
 		// inside GetDeltaE itself, so they need no branch here.
-		CColorReference dERef = ref;
-		if ( !isGS && ( ref.m_standard == UHDTV3 || ref.m_standard == UHDTV4 ) )
-			dERef = ContainerTransportReference( ref );
+		//
+		// Taken from the ACTIVE reference, not the `ref` parameter: `ref` is the
+		// GEOMETRY reference, which has already had HDTVa/b swapped for Rec.709 so
+		// the solid matches the basis those references were built in. dE must not
+		// follow that swap. GetDeltaE's own substitution is a fixed Rec.709/D65,
+		// so under a custom white target grading against the swapped reference
+		// (Rec.709 + custom white) would silently split the viewer's dE from the
+		// grid's. GetColorReference() returns a reference, so this is the same
+		// single copy the old `= ref` made, not an extra one.
+		CColorReference dERef = GetColorReference();
+		if ( !isGS && ( dERef.m_standard == UHDTV3 || dERef.m_standard == UHDTV4 ) )
+			dERef = ContainerTransportReference( dERef );
 		p.dE = ( dEOverride >= 0.0 ) ? (float)dEOverride
 									 : (float)c.GetDeltaE( ywForDE, dETarget, 1.0, dERef, GetConfig()->m_dE_form, isGS, gw );
 		if ( !( p.dE == p.dE ) || p.dE < 0.0f )   // NaN / negative: no usable dE
@@ -426,7 +435,16 @@ void C3DColorView::BuildScene()
 	if ( pMeasure == NULL )
 		return;
 
-	CColorReference ref = GetColorReference();
+	// HDTVa/HDTVb carry PATCH chromaticities where a gamut belongs (see
+	// SpecialModeGamutReference), so the solid built from them was a small
+	// desaturated triangle while the measurements - whose own references come
+	// from GetRefSat's / SetRGBValue's Rec.709 substitution - legitimately reach
+	// the real Rec.709 boundary. A perfect (simulated) display therefore plotted
+	// its 100%-saturation sweeps and color-checker patches well OUTSIDE the solid
+	// at dE 0.00. Substitute Rec.709 once, here, so every geometry consumer below
+	// (ToModel, BuildGamut, EnsureTongueTexture) agrees.
+	const CColorReference active = GetColorReference();
+	CColorReference ref = SpecialModeGamutReference( active );
 
 	// White luminance reference for L*a*b* / xyY normalisation (mirrors the CIE
 	// chart: prefer the pseudo-colour-space prime white, else grayscale white;
@@ -561,7 +579,9 @@ void C3DColorView::BuildScene()
 	// 105.95640 with tone mapping off (* 100 for the Mascior-style HDR CC
 	// sets, matching the measures grid).
 	const bool hdr10Refs = ( GetConfig()->m_GammaOffsetType == 5 );
-	const bool satSpecial = ( ref.m_standard == HDTVa || ref.m_standard == HDTVb );
+	// ACTIVE standard, not the substituted one: this selects GetRefSat's special
+	// branch, which is what makes those references Rec.709 in the first place.
+	const bool satSpecial = ( active.m_standard == HDTVa || active.m_standard == HDTVb );
 
 	// dE normalisation, separate from the marker geometry below: ask CMeasure
 	// rather than re-deriving it, so this cannot drift from the measures grid
@@ -701,6 +721,10 @@ static void XyYModelPt(const ColorXYZ & xyz, const ColorXYZ & dirXyz, double ref
 // chromaticity while only luminance shrinks), so in xyY the three zero-faces are
 // rebuilt as vertical walls over the triangle sides and the base rim is stored
 // for outlining.
+//
+// `ref` is the caller's already-substituted reference (BuildScene runs it through
+// SpecialModeGamutReference), so there is deliberately no HDTVa/HDTVb branch here:
+// by this point the special standards are plain Rec.709, like everywhere else.
 void C3DColorView::BuildGamut(CColorReference & ref)
 {
 	// Reference primaries already sum to the reference white, so normalise heights
@@ -1715,7 +1739,9 @@ void C3DColorView::AppendNewFreeMeasures()
 		return;
 	CMeasure * pMeasure = pDoc->GetMeasure();
 
-	CColorReference ref = GetColorReference();
+	// Same Rec.709 substitution BuildScene applies, so incrementally appended free
+	// measures use the same model transform as the ones added by a full rebuild.
+	CColorReference ref = SpecialModeGamutReference( GetColorReference() );
 	// Same normaliser as the rest of the scene: the local prime/on-off-white
 	// fallback returned PEAK white in PQ-HDR, so free measures were plotted and
 	// scaled against a different white than every other point.
@@ -1792,7 +1818,8 @@ void C3DColorView::AppendNewProfileMeasures()
 	// The capture remaps the cube inner->transport and the sensor recovers the
 	// INNER (content, e.g. P3) colors, so plot/swatch in the active reference --
 	// the measured cloud then lands inside the P3 gamut solid, not stretched to 2020.
-	CColorReference ref = GetColorReference();
+	// (HDTVa/b substitute Rec.709 for the same reason BuildScene does.)
+	CColorReference ref = SpecialModeGamutReference( GetColorReference() );
 	// Diffuse white (measured, or the standalone-profile fallback) so reference
 	// targets scale into measured units instead of collapsing at whiteY = 1.0.
 	double whiteY = SceneDiffuseWhiteY( pMeasure );

--- a/Views/Color3DView.cpp
+++ b/Views/Color3DView.cpp
@@ -370,8 +370,21 @@ static double SceneDiffuseWhiteY( CMeasure * pM )
 	}
 	// SDR: measured grayscale / prime white (100% == diffuse == peak); for a
 	// standalone profile fall back to the measured white cube node.
-	CColor cw = pM->GetPrimeWhite();
-	if ( !cw.isValid() || cw.GetY() <= 0.0 )
+	//
+	// HDTVa/HDTVb read the ON/OFF white and never the prime white. Their primaries
+	// run measures its white at the 75% anchor (GenColors[6] = 75,75,75), so
+	// GetPrimeWhite comes back at roughly HALF the display's real white - 0.75^2.4
+	// of it under a 2.4 power law. Normalising the scene by that put every
+	// measurement above ~50% stimulus past Y = 1, where ToModel's clamp pinned them
+	// all to the top of the gamut solid; since the solid's cross-section up there
+	// has narrowed to the white point, they fanned out visibly OUTSIDE it while
+	// their dE read fine. The measures grid has always avoided this - see
+	// GetColorDEWhiteY's `bSpecial ? yOnOff` branch, which this now mirrors,
+	// deliberately including its refusal to fall back to the prime white.
+	const bool specialWhite = ( GetColorReference().m_standard == HDTVa ||
+								GetColorReference().m_standard == HDTVb );
+	CColor cw = specialWhite ? pM->GetOnOffWhite() : pM->GetPrimeWhite();
+	if ( !specialWhite && ( !cw.isValid() || cw.GetY() <= 0.0 ) )
 		cw = pM->GetOnOffWhite();
 	if ( cw.isValid() && cw.GetY() > 0.0 )
 		return cw.GetY();
@@ -585,14 +598,33 @@ void C3DColorView::BuildScene()
 		}
 	}
 
+	// The primaries family has its OWN white, and it is not the scene's.
+	// GetRefPrimary/GetRefSecondary are relative to the PRIME white - the one
+	// measured alongside the primaries themselves - which the measures grid also
+	// uses here: MainView's YWhite keeps the prime white for this mode and only
+	// falls back to the on/off white for the saturation/CC modes 4..12 under
+	// HDTVa/HDTVb. In those two standards the primaries run measures its white at
+	// the 75% anchor, so prime white is ~half the on/off white the scene now
+	// normalises by, and sharing one white would plot every primary/secondary
+	// target at ~2x its measurement (dE ~16 on a patch the grid grades at 0.1).
+	// Everywhere else the two coincide and this is the same number as before.
+	// PQ keeps the scene white: there SceneDiffuseWhiteY returns the tone-mapped
+	// diffuse white and GetRefPrimary already carries GetHDRRefScale internally.
+	double primWhiteY = whiteY;
+	if ( GetConfig()->m_GammaOffsetType != 5 )
+	{
+		CColor pw = pMeasure->GetPrimeWhite();
+		if ( pw.isValid() && pw.GetY() > 0.0 )
+			primWhiteY = pw.GetY();
+	}
 	static const wchar_t * primName[3] = { L"Red primary",      L"Green primary",  L"Blue primary" };
 	static const wchar_t * secName[3]  = { L"Yellow secondary", L"Cyan secondary", L"Magenta secondary" };
 	for ( i = 0; i < 3; i++ )
 	{
 		CColor refP = pMeasure->GetRefPrimary( i );
-		AppendMeasure( pMeasure->GetPrimary( i ), whiteY, ref, refP, refP, false, whiteY, primName[i], SRC_PRIMARY, i );
+		AppendMeasure( pMeasure->GetPrimary( i ), primWhiteY, ref, refP, refP, false, primWhiteY, primName[i], SRC_PRIMARY, i );
 		CColor refS = pMeasure->GetRefSecondary( i );
-		AppendMeasure( pMeasure->GetSecondary( i ), whiteY, ref, refS, refS, false, whiteY, secName[i], SRC_SECONDARY, i );
+		AppendMeasure( pMeasure->GetSecondary( i ), primWhiteY, ref, refS, refS, false, primWhiteY, secName[i], SRC_SECONDARY, i );
 	}
 
 	// Saturation sweeps: plot EVERY measured stimulus level from the store, not
@@ -603,8 +635,8 @@ void C3DColorView::BuildScene()
 	// the scene needs the diffuse-white-relative convention (YWhiteRef is 1.0
 	// in AppendMeasure). The scale is 10000 / tone-mapped white - the legacy
 	// 105.95640 with tone mapping off (* 100 for the Mascior-style HDR CC
-	// sets, matching the measures grid).
-	const bool hdr10Refs = ( GetConfig()->m_GammaOffsetType == 5 );
+	// sets, matching the measures grid). It now falls out of the marker/dE white
+	// identity below rather than needing a mode-5 flag of its own.
 	// ACTIVE standard, not the substituted one: this selects GetRefSat's special
 	// branch, which is what makes those references Rec.709 in the first place.
 	const bool satSpecial = ( active.m_standard == HDTVa || active.m_standard == HDTVb );
@@ -624,10 +656,28 @@ void C3DColorView::BuildScene()
 	const ColorDENorm satNorm = pMeasure->GetColorDENorm( 5 );	// any saturation mode
 	const double satDEWhite = ( satNorm.whiteY > 0.0 ) ? satNorm.whiteY : whiteY;
 	const double satDEScale = satNorm.deScale;
-	// Marker geometry: refC * markScale * tmWhite is absolute nits, so a perfect
-	// patch draws no tail. Same number GetHDRRefScale returns - taken from the
-	// helper so there is only one definition of the marker scale.
-	const double hdrRefScale = satNorm.markScale;
+	// Marker geometry, DERIVED from the dE scale rather than taken beside it.
+	// AppendMeasure plots the marker at refMark * whiteY, while GetDeltaE grades
+	// refDE against c / satDEWhite; a patch measuring exactly on target draws no
+	// tail only when refMark * whiteY == refDE * satDEWhite. So the marker scale
+	// is not free - it is satDEScale * satDEWhite / whiteY, and picking it
+	// independently (this used to take satNorm.markScale) splits the marker from
+	// its own dE target by whatever ratio the two whites differ by.
+	//
+	// They differ in exactly the cases this got wrong: HDTVa/HDTVb take the ON/OFF
+	// white for dE (GetColorDEWhiteY's special branch, no prime fallback) while the
+	// scene normalises by SceneDiffuseWhiteY, which prefers the PRIME white - and in
+	// those modes prime white is the 75% anchor, roughly half the on/off white. Every
+	// saturation and color-checker marker therefore plotted at ~0.49x its measurement
+	// while the dE read ~0. The grayscale block has bridged the same two whites all
+	// along (markPerGrid above); sat and CC never did.
+	//
+	// Reduces to the old value wherever those coincide: in PQ, satDEScale is
+	// 10000/satDEWhite and whiteY is tmWhite, so this is 10000/tmWhite - exactly
+	// GetHDRRefScale. In SDR it is the pure white ratio, 1.0 whenever the two
+	// whites agree, which is every standard except HDTVa/HDTVb.
+	const double hdrRefScale = ( whiteY > 0.0 ) ? satDEScale * satDEWhite / whiteY
+												: satNorm.markScale;
 	static const wchar_t * hueName[6] = { L"Red", L"Green", L"Blue", L"Yellow", L"Cyan", L"Magenta" };
 	int nSatLevels = pMeasure->GetSatLevelCount();
 	for ( int L = 0; L < nSatLevels; L++ )
@@ -645,8 +695,11 @@ void C3DColorView::BuildScene()
 				if ( i >= (int) set.sat[h].size() )
 					continue;
 				CColor refC = pMeasure->GetRefSat( h, satRatio, satSpecial, stim );
+				// No longer gated on HDR: in SDR satDEScale is 1.0 (a no-op) but
+				// hdrRefScale is the marker/dE white ratio, which is exactly what
+				// HDTVa/HDTVb need and what gating this on mode 5 used to skip.
 				CColor refMark = refC, refDE = refC;
-				if ( hdr10Refs && refC.isValid() )
+				if ( refC.isValid() )
 				{
 					refMark.SetX( refC.GetX() * hdrRefScale );
 					refMark.SetY( refC.GetY() * hdrRefScale );
@@ -677,11 +730,19 @@ void C3DColorView::BuildScene()
 	// convention against the grayscale top - hence the separate query.
 	const ColorDENorm ccNorm = pMeasure->GetColorDENorm( 11 );
 	const double ccDEWhite   = ( ccNorm.whiteY > 0.0 ) ? ccNorm.whiteY : whiteY;
-	const double ccMarkScale = ccNorm.markScale;
 	// Unconditional, like the saturation block: a bare 1.0 here would leave the
-	// dE reference unscaled while ccMarkScale still plots the marker at * 100 for
-	// a Mascior CC set, so the marker and its own dE target would disagree.
+	// dE reference unscaled while the marker still plots at * 100 for a Mascior
+	// CC set, so the marker and its own dE target would disagree.
 	const double ccDEScale   = ccNorm.deScale;
+	// Derived from the dE scale for the reason spelled out at the saturation
+	// block: refMark * whiteY must equal refDE * ccDEWhite or an on-target patch
+	// grows a tail. Note this also corrects the Mascior HDR CC sets, whose dE
+	// white is the grayscale top while the scene normalises by the tone-mapped
+	// white - the same split, from a different pair of whites. Those sets are
+	// untested (ACCURACYTEST gap 3 - they read their patch list from a CSV), so
+	// that half is derived rather than observed.
+	const double ccMarkScale = ( whiteY > 0.0 ) ? ccDEScale * ccDEWhite / whiteY
+												: ccNorm.markScale;
 	for ( i = 0; i < n; i++ )
 	{
 		CColor c = pMeasure->GetCC24Sat( i );
@@ -690,7 +751,7 @@ void C3DColorView::BuildScene()
 		CColor refC;
 		pMeasure->GetRefCC24Sat( i, refC );
 		CColor refMark = refC, refDE = refC;
-		if ( hdr10Refs && refC.isValid() )
+		if ( refC.isValid() )
 		{
 			refMark.SetX( refC.GetX() * ccMarkScale );
 			refMark.SetY( refC.GetY() * ccMarkScale );

--- a/libHCFR/Color.cpp
+++ b/libHCFR/Color.cpp
@@ -938,13 +938,29 @@ CColorReference ContainerTransportReference(const CColorReference& active)
 // GetRefSat's special branch. Use this wherever the substitution is needed on the
 // reference as an OBJECT (primaries, matrices) rather than inside those calls.
 //
-// Unlike the dE-side SpecialModeReference(), which is a fixed Rec.709/D65 and
-// deliberately ignores a custom white target, this keeps the active white: the
-// caller is drawing geometry the measured points must line up with.
+// The white is deliberately NOT carried over, unlike ContainerInner/Transport
+// Reference above. SetRGBValue - which is how these modes' references are
+// actually manufactured - substitutes a fixed CColorReference(HDTV), i.e.
+// Rec.709/D65, whatever white target is active; GetRGBValue and GetDeltaE do the
+// same. A basis that tracked the active white would therefore disagree with the
+// basis those references were built in for every non-D65 white - reintroducing,
+// in a narrower case, the very defect this helper exists to prevent.
+// ColorMathTest T10 pins it: 270 assertions fail if this returns
+// WithWhiteOf(HDTV, active) instead.
+//
+// Callers needing the user's WHITE TARGET (grayscale targets, neutral
+// classification) must read it from the ACTIVE reference, not from this one.
+//
+// CC6 is included to match SetRGBValue and GetDeltaE, the two predicates that
+// decide what a reference IS. GetRGBValue's omits CC6, so for that (unreachable
+// - the enum marks it unused) standard a swatch would decode in the CC6 matrix
+// while geometry used Rec.709. Making GetRGBValue consistent would remove the
+// wart, but that is a live libHCFR behaviour change on a dead path, so the
+// mismatch is left documented rather than fixed here.
 CColorReference SpecialModeGamutReference(const CColorReference& active)
 {
 	if (active.m_standard == HDTVa || active.m_standard == HDTVb || active.m_standard == CC6)
-		return WithWhiteOf(HDTV, active);
+		return CColorReference(HDTV);
 	return active;
 }
 

--- a/libHCFR/Color.cpp
+++ b/libHCFR/Color.cpp
@@ -960,7 +960,21 @@ CColorReference ContainerTransportReference(const CColorReference& active)
 CColorReference SpecialModeGamutReference(const CColorReference& active)
 {
 	if (active.m_standard == HDTVa || active.m_standard == HDTVb || active.m_standard == CC6)
-		return CColorReference(HDTV);
+	{
+		// Built once, for the reason spelled out above SpecialModeReference():
+		// the constructor derives the RGB->XYZ matrix, inverts it and solves four
+		// line intersections for the secondaries, and this value never varies.
+		// AppendNewProfileMeasures reaches here once per appended patch during a
+		// live cube capture - 9261 of them at 21^3.
+		//
+		// Returned BY VALUE, unlike SpecialModeReference: that one takes no
+		// arguments, whereas this returns `active` on the ordinary path, so a
+		// reference return would dangle for any caller passing a temporary. The
+		// copy is a matrix and a string; the construction it now avoids is a
+		// matrix inversion plus four intersections.
+		static const CColorReference s_hdtv(HDTV);
+		return s_hdtv;
+	}
 	return active;
 }
 

--- a/libHCFR/Color.cpp
+++ b/libHCFR/Color.cpp
@@ -930,6 +930,24 @@ CColorReference ContainerTransportReference(const CColorReference& active)
 	return active;
 }
 
+// The special standards' "primaries" are NOT a gamut: HDTVa carries the 75%
+// saturation / 75% amplitude PATCH chromaticities and HDTVb the plasma-optimized
+// color-checker ones, both far inside Rec.709. The display being measured is a
+// plain Rec.709 one, which is why every consumer that needs an actual colorspace
+// substitutes it - GetRGBValue, SetRGBValue, GetDeltaE (via SpecialModeReference),
+// GetRefSat's special branch. Use this wherever the substitution is needed on the
+// reference as an OBJECT (primaries, matrices) rather than inside those calls.
+//
+// Unlike the dE-side SpecialModeReference(), which is a fixed Rec.709/D65 and
+// deliberately ignores a custom white target, this keeps the active white: the
+// caller is drawing geometry the measured points must line up with.
+CColorReference SpecialModeGamutReference(const CColorReference& active)
+{
+	if (active.m_standard == HDTVa || active.m_standard == HDTVb || active.m_standard == CC6)
+		return WithWhiteOf(HDTV, active);
+	return active;
+}
+
 ColorRGB ContainerPrimaryLinear(const CColorReference& active, int index)
 {
 	CColorReference inner = ContainerInnerReference(active);

--- a/libHCFR/Color.h
+++ b/libHCFR/Color.h
@@ -752,6 +752,7 @@ ostream& operator <<(ostream& ostr, const CColor& obj);
 extern CColorReference GetStandardColorReference(ColorStandard aColorStandard);
 extern CColorReference ContainerInnerReference(const CColorReference& active);
 extern CColorReference ContainerTransportReference(const CColorReference& active);
+extern CColorReference SpecialModeGamutReference(const CColorReference& active);
 extern ColorRGB ContainerPrimaryLinear(const CColorReference& active, int index);
 
 extern CColor theMeasure;

--- a/tests/ACCURACYTEST.md
+++ b/tests/ACCURACYTEST.md
@@ -414,11 +414,18 @@ agree), and the gaps below are mostly places their reach stops.
    Blue`, but HDTVa/HDTVb hold PATCH chromaticities there, not a gamut, so
    under those standards a perfect simulated display plotted its own targets
    well outside the solid while every dE read 0.00. The whole matrix was green
-   throughout. `ColorMathTest`'s **T10** now covers the *geometry-basis* slice
-   as a pure libHCFR oracle (the basis a consumer plots in must be the basis
-   its references were built in), which is where that bug lived and is testable
-   without MFC. The rest of this gap — the `Yref` formulas and the widget math
-   above — is still open and still needs the extraction.
+   throughout. `ColorMathTest`'s **T10** now pins the *contract* that was
+   violated — the basis a consumer plots geometry in must be the basis its
+   references were built in — as a pure libHCFR oracle.
+   Be precise about what that buys: T10 tests the shared helper, **not any
+   view's use of it**. It cannot link MFC, so if `C3DColorView` stopped calling
+   `SpecialModeGamutReference` T10 would stay green and the bug would return.
+   The mitigation is structural rather than tested — the viewer funnels all
+   three scene-building entry points through one `SceneGamutReference()` — so
+   the display layer itself remains unverified, exactly as this gap says. What
+   genuinely closed is the *helper* half; the `Yref` formulas, the widget math,
+   and every view's application of a reference are still open and still need
+   the extraction.
 8. **Export is never exercised.** The PDF/CSV/spreadsheet dE paths duplicate the
    grid's normalization and have already drifted from it — their `YWhite` is a
    hand-rolled `special ? OnOff : Prime` (plus the Mascior grayscale top) that

--- a/tests/ACCURACYTEST.md
+++ b/tests/ACCURACYTEST.md
@@ -409,6 +409,16 @@ agree), and the gaps below are mostly places their reach stops.
    user-visible (swatches disagree while dE reads 0) and completely invisible
    here. This is MFC view code; extracting the pure math into a testable
    function is the prerequisite.
+   *Partially narrowed.* This gap is not hypothetical — it shipped. The 3D
+   viewer built its gamut solid straight from `CColorReference::GetRed/Green/
+   Blue`, but HDTVa/HDTVb hold PATCH chromaticities there, not a gamut, so
+   under those standards a perfect simulated display plotted its own targets
+   well outside the solid while every dE read 0.00. The whole matrix was green
+   throughout. `ColorMathTest`'s **T10** now covers the *geometry-basis* slice
+   as a pure libHCFR oracle (the basis a consumer plots in must be the basis
+   its references were built in), which is where that bug lived and is testable
+   without MFC. The rest of this gap — the `Yref` formulas and the widget math
+   above — is still open and still needs the extraction.
 8. **Export is never exercised.** The PDF/CSV/spreadsheet dE paths duplicate the
    grid's normalization and have already drifted from it — their `YWhite` is a
    hand-rolled `special ? OnOff : Prime` (plus the Mascior grayscale top) that

--- a/tests/ColorMathTest/ColorMathTest.cpp
+++ b/tests/ColorMathTest/ColorMathTest.cpp
@@ -663,11 +663,24 @@ static void RunT9()
 //      decoding that XYZ in SpecialModeGamutReference(S) must return rgb. Any
 //      standard whose geometry basis disagrees with its construction basis
 //      lands outside the unit cube here. Verified by mutation: reverting the
-//      helper to a plain `return active` fails 72 assertions on HDTVa (red
-//      decodes to 1.267,-0.072,-0.071 instead of 1,0,0), 72 on HDTVb, 36 on
-//      CC6, and none at all on the other eight standards.
+//      helper to a plain `return active` fails 600 assertions - 240 on HDTVa
+//      (red decodes to 1.267,-0.072,-0.071 instead of 1,0,0), 240 on HDTVb,
+//      120 on CC6, and none at all on the other eight standards.
 //   2. Helper agreement. SpecialModeGamutReference must reproduce GetRGBValue's
 //      own inline substitution exactly, so the two cannot drift apart.
+//
+// Each standard runs under three white targets, and that is load-bearing rather
+// than thoroughness for its own sake: the special modes' construction basis is a
+// FIXED Rec.709/D65 (SetRGBValue builds CColorReference(HDTV) unconditionally),
+// so a helper that carried the active white over would pass every default-white
+// case and fail 270 assertions the moment a non-D65 white is selected. The first
+// version of this helper did exactly that.
+//
+// SCOPE: this pins the helper's CONTRACT, not its application. Nothing here can
+// see C3DColorView - if the viewer stopped calling SpecialModeGamutReference, T10
+// would stay green. That call site is funnelled through a single
+// SceneGamutReference() in Color3DView.cpp to keep the blast radius of such a
+// regression to one line; the display itself is still only checked on screen.
 //
 // CUSTOM is deliberately absent: CColorReference's CUSTOM branch writes its
 // primaries THROUGH the default `primaries` pointer, which still aims at the
@@ -692,20 +705,37 @@ static void RunT10()
         {0.5,0,0}, {0,0.5,0}, {0,0,0.5}, {0.5,0.5,0.5},
         {0.75,0.25,0.10}, {0.10,0.75,0.25}, {0.25,0.10,0.75},
     };
+    // White targets matter: the special standards' construction basis is a FIXED
+    // Rec.709/D65 (SetRGBValue builds CColorReference(HDTV) unconditionally), so a
+    // geometry basis that tracked the active white instead would break leg 1 for
+    // every non-D65 white while passing under the default.
+    enum { W_DEFAULT, W_NAMED, W_CUSTOM, W_COUNT };
+    static const char * wName[W_COUNT] = { "D65", "D75", "custom" };
+
     const int nStd = (int)(sizeof(stds) / sizeof(stds[0]));
     const int nRGB = (int)(sizeof(rgbs) / sizeof(rgbs[0]));
 
     for (int s = 0; s < nStd; ++s)
+    for (int w = 0; w < W_COUNT; ++w)
     {
-        CColorReference ref(stds[s].cs);
+        CColorReference ref =
+            (w == W_NAMED)  ? CColorReference(stds[s].cs, D75) :
+            (w == W_CUSTOM) ? CColorReference(stds[s].cs, DCUST, -1.0, " modified",
+                                              ColorXYZ(ColorxyY(0.2900, 0.3000)))
+                            : CColorReference(stds[s].cs);
         CColorReference gref = SpecialModeGamutReference(ref);
+        char tag[48];
+        _snprintf(tag, sizeof(tag) - 1, "%s/%s", stds[s].name, wName[w]);
+        tag[sizeof(tag) - 1] = 0;
 
-        // The helper must never change the white point: the viewer normalises
-        // heights by GetWhite()[1] and plots black at the white chromaticity.
-        for (int k = 0; k < 3; ++k)
-            if (fabs(ref.GetWhite()[k] - gref.GetWhite()[k]) > 1e-12)
-                Fail("T10 %s: helper moved the white, component %d: %.17g -> %.17g",
-                     stds[s].name, k, ref.GetWhite()[k], gref.GetWhite()[k]);
+        // Ordinary standards must come back untouched - the helper is only ever
+        // allowed to act on the special ones.
+        bool special = (stds[s].cs == HDTVa || stds[s].cs == HDTVb || stds[s].cs == CC6);
+        if (!special)
+            for (int k = 0; k < 3; ++k)
+                if (fabs(ref.GetWhite()[k] - gref.GetWhite()[k]) > 1e-12)
+                    Fail("T10 %s: helper altered a non-special reference, white component "
+                         "%d: %.17g -> %.17g", tag, k, ref.GetWhite()[k], gref.GetWhite()[k]);
 
         for (int i = 0; i < nRGB; ++i)
         {
@@ -719,7 +749,7 @@ static void RunT10()
                 if (fabs(back[k] - rgb[k]) > 1e-9)
                     Fail("T10 %s rgb=(%.2f,%.2f,%.2f): reference is outside the plotted "
                          "gamut basis, channel %d came back %.6f (expected %.6f)",
-                         stds[s].name, rgb[0], rgb[1], rgb[2], k, back[k], rgb[k]);
+                         tag, rgb[0], rgb[1], rgb[2], k, back[k], rgb[k]);
 
             // ---- Leg 2: helper == GetRGBValue's own inline substitution.
             if (stds[s].cs == CC6)
@@ -729,7 +759,7 @@ static void RunT10()
                 if (fabs(viaGetter[k] - back[k]) > 1e-9)
                     Fail("T10 %s rgb=(%.2f,%.2f,%.2f): SpecialModeGamutReference disagrees "
                          "with GetRGBValue, channel %d: %.17g vs %.17g",
-                         stds[s].name, rgb[0], rgb[1], rgb[2], k, back[k], viaGetter[k]);
+                         tag, rgb[0], rgb[1], rgb[2], k, back[k], viaGetter[k]);
         }
     }
 }

--- a/tests/ColorMathTest/ColorMathTest.cpp
+++ b/tests/ColorMathTest/ColorMathTest.cpp
@@ -7,10 +7,11 @@
 // goldenDir defaults to "golden" relative to the current directory.
 // Exit code 0 = all pass, nonzero = mismatch/failure.
 //
-// T1 needs no golden file: it carries a frozen copy of the legacy quantizer as an oracle.
 // T2/T3/T4/T6 dump deterministic tables and compare them exactly against checked-in goldens.
-// T5 (rPI emission) is added by PR 3. T7 (.chc round-trip) needs app-level linkage and is
-// deliberately not in this console harness.
+// Everything else is a self-contained oracle needing no golden file: T1 carries a frozen
+// copy of the legacy quantizer, T5/T7/T8/T9 assert quantizer and generator invariants, and
+// T10 asserts gamut-basis consistency. The .chc round-trip originally planned for the T7
+// slot needs app-level linkage and is deliberately still not in this console harness.
 
 #include <afx.h>
 #include "../../libHCFR/Color.h"
@@ -643,6 +644,97 @@ static void RunT9()
 }
 
 //////////////////////////////////////////////////////////////////////////
+// T10 — gamut-basis consistency oracle (pure assertion, no golden file).
+//
+// Closes a real gap: dE-based tests are blind to which BASIS a consumer plots
+// against, because a point can be drawn in completely the wrong place while its
+// dE reads exactly 0.000. The 3D viewer built its gamut solid straight from
+// CColorReference::GetRed/Green/Blue, but HDTVa/HDTVb do not carry a gamut
+// there - HDTVa holds the 75% saturation/amplitude PATCH chromaticities and
+// HDTVb the plasma-optimized color-checker ones, both far inside Rec.709. So
+// the solid was a small desaturated triangle while the references themselves
+// are manufactured in real Rec.709 by SetRGBValue's substitution, and a perfect
+// simulated display plotted its own targets outside the solid at dE 0.00.
+//
+// The invariant: the basis a consumer uses for GEOMETRY must be the same basis
+// the references were BUILT in. Two legs, over every standard in the enum
+// except CUSTOM (see the carve-outs below):
+//   1. Round trip. SetRGBValue(rgb, S) is how the app manufactures a reference;
+//      decoding that XYZ in SpecialModeGamutReference(S) must return rgb. Any
+//      standard whose geometry basis disagrees with its construction basis
+//      lands outside the unit cube here. Verified by mutation: reverting the
+//      helper to a plain `return active` fails 72 assertions on HDTVa (red
+//      decodes to 1.267,-0.072,-0.071 instead of 1,0,0), 72 on HDTVb, 36 on
+//      CC6, and none at all on the other eight standards.
+//   2. Helper agreement. SpecialModeGamutReference must reproduce GetRGBValue's
+//      own inline substitution exactly, so the two cannot drift apart.
+//
+// CUSTOM is deliberately absent: CColorReference's CUSTOM branch writes its
+// primaries THROUGH the default `primaries` pointer, which still aims at the
+// global primariesRec601 array, so merely constructing one corrupts SDTV for
+// the rest of the process. Constructing it here would poison later tests.
+// CC6 (the unused enum slot) runs leg 1 only: GetRGBValue's substitution
+// predicate omits CC6 while SetRGBValue's and GetDeltaE's include it, a latent
+// inconsistency in dead-but-present code that leg 2 would trip over.
+//////////////////////////////////////////////////////////////////////////
+static void RunT10()
+{
+    printf("T10 gamut-basis consistency oracle...\n");
+    static const struct { ColorStandard cs; const char* name; } stds[] = {
+        { PALSECAM, "PALSECAM" }, { SDTV,   "SDTV"   }, { HDTV,   "HDTV"   },
+        { HDTVa,    "HDTVa"    }, { HDTVb,  "HDTVb"  }, { sRGB,   "sRGB"   },
+        { UHDTV,    "UHDTV"    }, { UHDTV2, "UHDTV2" }, { UHDTV3, "UHDTV3" },
+        { UHDTV4,   "UHDTV4"   }, { CC6,    "CC6"    },
+    };
+    // cube corners, face centres, grey, and a few off-axis points
+    static const double rgbs[][3] = {
+        {0,0,0}, {1,0,0}, {0,1,0}, {0,0,1}, {1,1,0}, {0,1,1}, {1,0,1}, {1,1,1},
+        {0.5,0,0}, {0,0.5,0}, {0,0,0.5}, {0.5,0.5,0.5},
+        {0.75,0.25,0.10}, {0.10,0.75,0.25}, {0.25,0.10,0.75},
+    };
+    const int nStd = (int)(sizeof(stds) / sizeof(stds[0]));
+    const int nRGB = (int)(sizeof(rgbs) / sizeof(rgbs[0]));
+
+    for (int s = 0; s < nStd; ++s)
+    {
+        CColorReference ref(stds[s].cs);
+        CColorReference gref = SpecialModeGamutReference(ref);
+
+        // The helper must never change the white point: the viewer normalises
+        // heights by GetWhite()[1] and plots black at the white chromaticity.
+        for (int k = 0; k < 3; ++k)
+            if (fabs(ref.GetWhite()[k] - gref.GetWhite()[k]) > 1e-12)
+                Fail("T10 %s: helper moved the white, component %d: %.17g -> %.17g",
+                     stds[s].name, k, ref.GetWhite()[k], gref.GetWhite()[k]);
+
+        for (int i = 0; i < nRGB; ++i)
+        {
+            ColorRGB rgb(rgbs[i][0], rgbs[i][1], rgbs[i][2]);
+            CColor c;
+            c.SetRGBValue(rgb, ref);
+
+            // ---- Leg 1: construction basis == geometry basis.
+            ColorRGB back(c.GetXYZValue(), gref);
+            for (int k = 0; k < 3; ++k)
+                if (fabs(back[k] - rgb[k]) > 1e-9)
+                    Fail("T10 %s rgb=(%.2f,%.2f,%.2f): reference is outside the plotted "
+                         "gamut basis, channel %d came back %.6f (expected %.6f)",
+                         stds[s].name, rgb[0], rgb[1], rgb[2], k, back[k], rgb[k]);
+
+            // ---- Leg 2: helper == GetRGBValue's own inline substitution.
+            if (stds[s].cs == CC6)
+                continue;
+            ColorRGB viaGetter = c.GetRGBValue(ref);
+            for (int k = 0; k < 3; ++k)
+                if (fabs(viaGetter[k] - back[k]) > 1e-9)
+                    Fail("T10 %s rgb=(%.2f,%.2f,%.2f): SpecialModeGamutReference disagrees "
+                         "with GetRGBValue, channel %d: %.17g vs %.17g",
+                         stds[s].name, rgb[0], rgb[1], rgb[2], k, back[k], viaGetter[k]);
+        }
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////
 
 int main(int argc, char* argv[])
 {
@@ -668,6 +760,7 @@ int main(int argc, char* argv[])
     RunT7();
     RunT8();
     RunT9();
+    RunT10();
 
     if (g_failures)
     {

--- a/tests/ColorMathTest/README.md
+++ b/tests/ColorMathTest/README.md
@@ -23,8 +23,19 @@ Guards the 8-bit signal path while the 10-bit work lands. Part of the plan in
   219/255/876/1023 — and its 8-bit limited form must equal the historical
   `floor(v*219+0.5)/219` exactly.
 - **T6** — `GetColorRef` COLORREF packing, vs golden file.
-- **T5** (rPI emission function) arrives with PR 3. **T7** (.chc round-trip) needs app-level
-  linkage and is not in this console harness.
+- **T5** — rPI emission quantizers (`PiPercentToCode` / `PiBackground8ToCode`) across all
+  four grids: endpoints, clamping, monotonicity, and distinct-code counts. No golden file.
+- **T7** — `GenerateProfileColors` determinism: plain and extra patch counts per cube size.
+  No golden file. (This slot was originally reserved for a `.chc` round-trip, which needs
+  app-level linkage and is still not in this console harness.)
+- **T9** — quantizer equivalence oracle (no golden file): the generator grid form, the
+  shared `SnapToVideoGrid`, and the rPI emitter must all select the same integer code for
+  every (bit depth, range) combo, including half-code ties plus/minus dust.
+- **T10** — gamut-basis consistency oracle (no golden file): for every selectable standard,
+  the basis a consumer plots GEOMETRY in must be the basis its references were BUILT in.
+  Catches the class dE tests are blind to — a point drawn in the wrong place while its dE
+  reads exactly 0.000 — which is how the 3D viewer came to draw HDTVa/HDTVb solids from
+  their 75%/plasma PATCH chromaticities instead of Rec.709.
 
 ## Build & run
 Build `libHCFR` first, then this project (Debug|Win32 only):

--- a/tests/ColorMathTest/README.md
+++ b/tests/ColorMathTest/README.md
@@ -31,11 +31,14 @@ Guards the 8-bit signal path while the 10-bit work lands. Part of the plan in
 - **T9** — quantizer equivalence oracle (no golden file): the generator grid form, the
   shared `SnapToVideoGrid`, and the rPI emitter must all select the same integer code for
   every (bit depth, range) combo, including half-code ties plus/minus dust.
-- **T10** — gamut-basis consistency oracle (no golden file): for every selectable standard,
-  the basis a consumer plots GEOMETRY in must be the basis its references were BUILT in.
-  Catches the class dE tests are blind to — a point drawn in the wrong place while its dE
-  reads exactly 0.000 — which is how the 3D viewer came to draw HDTVa/HDTVb solids from
-  their 75%/plasma PATCH chromaticities instead of Rec.709.
+- **T10** — gamut-basis consistency oracle (no golden file): for every standard in the
+  enum except `CUSTOM`, under three white targets, the basis a consumer plots GEOMETRY in
+  must be the basis its references were BUILT in. Catches the class dE tests are blind to
+  — a point drawn in the wrong place while its dE reads exactly 0.000 — which is how the
+  3D viewer came to draw HDTVa/HDTVb solids from their 75%/plasma PATCH chromaticities
+  instead of Rec.709. `CUSTOM` is excluded because constructing one corrupts the global
+  Rec.601 primaries (see the comment above `RunT10`); `CC6` skips the second leg only.
+  Note this pins the shared helper, **not** any view's use of it — nothing here links MFC.
 
 ## Build & run
 Build `libHCFR` first, then this project (Debug|Win32 only):


### PR DESCRIPTION
Fixes three distinct defects in the Information pane's 3D Viewer under the special colour standards **HDTVa** (`HDTV - REC 709 (75%/75%)`) and **HDTVb** (`HDTV(OPT-Plasma)`), plus the test coverage that was structurally blind to all of them.

## 1. The gamut solid was built from a colourspace that doesn't exist

`BuildGamut` tessellated the solid from the active reference's primaries used as a **basis**:

```cpp
ColorXYZ xyz( r*R[0] + g*G[0] + b*B[0], ... );   // R,G,B = ref.GetRed/Green/Blue
```

HDTVa doesn't carry a gamut there — `primariesRec709a` is the 75%-saturation / 75%-amplitude **patch** locations `(0.5575,0.3298) (0.3032,0.5313) (0.1911,0.1279)`. HDTVb carries the plasma-optimised colour-checker ones, which pull in hard on blue at `(0.245,0.217)`.

The measurements' own references are meanwhile built in **real Rec.709** — `SetRGBValue` substitutes it (`Color.cpp:2530`), and `GenerateSaturationColors` opens with `//use fully saturated space if user has special color space modes set` (`Color.cpp:3652`). So saturation sweeps legitimately reach the Rec.709 boundary, far outside the drawn solid, at dE 0.00.

The 3D viewer was the **only** consumer treating those primaries as a basis. New `SpecialModeGamutReference()` sits alongside the existing container helpers and returns the same fixed Rec.709/D65 that `SetRGBValue`, `GetRGBValue` and `GetDeltaE` already substitute. All three scene-building entry points funnel through one `SceneGamutReference()`.

**The 2D CIE chart is deliberately unchanged.** It *connects* the six reference points rather than using them as a basis, labels them as references (`IDS_REC709aREDREF`), and already substitutes Rec.709 via `bRef` where a colourspace is needed. Its presentation predates 4.x and is correct for what it claims to show.

## 2. Each patch family is relative to a different white — the viewer used one

| Family | Reference is relative to | Test dataset |
|---|---|---|
| Grayscale | grayscale top | 119.97 |
| Primaries / secondaries | **prime white** (the 75% anchor) | **59.611** |
| Saturation / colour checker | on/off white | 119.97 |

The measures grid encodes this — `MainView`'s `YWhite` keeps the prime white for the primaries mode and only drops to the on/off white for the sat/CC modes 4–12 under these standards. The viewer had no equivalent, so a patch the grid graded at **dE 0.1** showed as **dE 15.95**, its target plotted at 70.1% against a 34.8% measurement.

- `SceneDiffuseWhiteY` now reads the on/off white for these standards, mirroring `GetColorDEWhiteY`'s `bSpecial ? yOnOff` branch. Normalising by the 75% prime white had pushed every measurement above ~50% stimulus past `Y = 1`, where `ToModel`'s clamp pinned them to the top of the solid — and since the cross-section has narrowed to the white point up there, they fanned out visibly outside it at correct dE.
- The primaries/secondaries family passes its own prime white. PQ excluded: there the scene white is the tone-mapped diffuse white and `GetRefPrimary` already carries `GetHDRRefScale`.

## 3. The sat/CC marker scale was a free choice; it isn't

`AppendMeasure` plots the marker at `refMark * whiteY` while `GetDeltaE` grades `refDE` against `c / DEWhite`, so an on-target patch draws no tail only when `refMark * whiteY == refDE * DEWhite`. The marker scale is therefore **derived**: `deScale * DEWhite / whiteY`.

Reduces to `GetHDRRefScale` exactly in PQ and to `1.0` wherever the two whites agree. Still load-bearing on ordinary standards — `GetColorDEWhiteY` switches to the on/off white whenever `yPrime/yOnOff < 0.9` for colour-checker patches.

## Test coverage

`/accuracytest` was green throughout all three bugs and structurally cannot catch them — a point can plot in completely the wrong place while its dE reads exactly `0.000`. That is **gap 6** in `tests/ACCURACYTEST.md`.

New **T10** in `ColorMathTest` pins the contract that was violated: *the basis a consumer plots geometry in must be the basis its references were built in*. Every standard except `CUSTOM`, under three white targets.

**Verified by mutation** — reverting the helper to `return active` fails **600** assertions (240 HDTVa, 240 HDTVb, 120 CC6, **zero** on the other eight standards). The three white targets are load-bearing, not thoroughness: the first version of this helper carried the active white over, passed every default-white case, and failed 270 assertions the moment a non-D65 white was selected. That defect was found by writing this test, not by review.

**Be precise about what this buys.** T10 tests the shared helper, *not any view's use of it* — it cannot link MFC. If `C3DColorView` stopped calling the helper, T10 would stay green. The mitigation is structural (one `SceneGamutReference()` call site), not tested. `ACCURACYTEST.md` gap 6 is updated to say so rather than imply the display layer is covered.

`CUSTOM` is excluded from T10 because `CColorReference`'s CUSTOM branch writes its primaries *through* the default pointer, which still aims at the global `primariesRec601` array (`Color.cpp:689`) — constructing one corrupts SDTV for the rest of the process. Pre-existing, filed separately, not addressed here.

## Verification

| Check | Result |
|---|---|
| Full solution build, Debug\|Win32 | clean |
| `/accuracytest` | `834 combos: 333 pass, 0 FAIL, 501 known-fail`, 0 stale |
| `ColorMathTest verify` | all pass, incl. T10 across three white targets |
| On screen — HDTVa + HDTVb, all four families | confirmed by maintainer |
| On screen — control, `HDTV - REC 709` with and without a custom white | confirmed unchanged |

Primaries now read e.g. `measured Y 6.2% / target Y 6.3%, ΔE 0.36`, with the residual dE entirely chromaticity (Δxy 0.0014) and the luminance term at zero — against `34.8% / 70.1%, ΔE 15.95` before.

## Known gaps

- **Mascior HDR colour-checker sets are changed by derivation only.** Their dE white is the grayscale top while the scene uses the tone-mapped white — the same split from a different pair of whites, so change 3 corrects them too. They read their patch list from a CSV in `%APPDATA%\color\` and have zero coverage (ACCURACYTEST gap 3). Not observed.
- **PQ/HDR not re-checked on screen.** The marker formula provably reduces to `GetHDRRefScale` there (`deScale * DEWhite == 10000` by construction), and the matrix covers PQ dE, but marker geometry in PQ was not eyeballed.
- Custom white targets are unreachable in the UI for these standards — `ReferencesPropPage.cpp:250` disables the controls — though `/accuracytest` and T10 both exercise the path.

## Also included

- `ColorMathTest/README.md` had drifted: it described T5 as "arrives with PR 3" and T7 as "not in this console harness" when both exist and run, and omitted T9.
- `.gitignore` for the generated accuracytest reports — a stale one reads exactly like a passing run when grepped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
