### PR TITLE
Fix PGenerator Dolby Vision transport flags

### DIFF
--- a/Generators/Generator.cpp
+++ b/Generators/Generator.cpp
@@ -250,13 +250,14 @@ BOOL CGenerator::QueryPGeneratorInfo(CStringArray& vals, CString& err)
 	CString quant = PgenParseVal(PgSend(s, "CMD:GET_PGENERATOR_CONF_RGB_QUANT_RANGE"), "GET_PGENERATOR_CONF_RGB_QUANT_RANGE");
 	CString colm  = PgenParseVal(PgSend(s, "CMD:GET_PGENERATOR_CONF_COLORIMETRY"), "GET_PGENERATOR_CONF_COLORIMETRY");
 	CString isHdr = PgenParseVal(PgSend(s, "CMD:GET_PGENERATOR_CONF_IS_HDR"), "GET_PGENERATOR_CONF_IS_HDR");
-	CString isDov = PgenParseVal(PgSend(s, "CMD:GET_PGENERATOR_CONF_IS_LL_DOVI"), "GET_PGENERATOR_CONF_IS_LL_DOVI");
+	CString isLLDov = PgenParseVal(PgSend(s, "CMD:GET_PGENERATOR_CONF_IS_LL_DOVI"), "GET_PGENERATOR_CONF_IS_LL_DOVI");
+	CString isStdDov = PgenParseVal(PgSend(s, "CMD:GET_PGENERATOR_CONF_IS_STD_DOVI"), "GET_PGENERATOR_CONF_IS_STD_DOVI");
 	CString host  = PgenParseVal(PgSend(s, "CMD:GET_HOSTNAME"), "GET_HOSTNAME");
 
 	
 
 	CString status = _T("SDR");
-	if (isDov == "1") status = _T("Dolby Vision");
+	if (isLLDov == "1" || isStdDov == "1") status = _T("Dolby Vision");
 	else if (isHdr == "1") status = _T("HDR");
 
 	CString resval = res;
@@ -394,6 +395,7 @@ int CGenerator::QueryPGeneratorModes(CStringArray& labels, CArray<int,int>& ids,
 	st.colorimetry = atoi((LPCTSTR)PgenParseVal(PgSend(s, "CMD:GET_PGENERATOR_CONF_COLORIMETRY"), "GET_PGENERATOR_CONF_COLORIMETRY"));
 	st.isHdr       = atoi((LPCTSTR)PgenParseVal(PgSend(s, "CMD:GET_PGENERATOR_CONF_IS_HDR"), "GET_PGENERATOR_CONF_IS_HDR"));
 	st.isLLDovi    = atoi((LPCTSTR)PgenParseVal(PgSend(s, "CMD:GET_PGENERATOR_CONF_IS_LL_DOVI"), "GET_PGENERATOR_CONF_IS_LL_DOVI"));
+	st.isStdDovi   = atoi((LPCTSTR)PgenParseVal(PgSend(s, "CMD:GET_PGENERATOR_CONF_IS_STD_DOVI"), "GET_PGENERATOR_CONF_IS_STD_DOVI"));
 	st.eotf        = atoi((LPCTSTR)PgenParseVal(PgSend(s, "CMD:GET_PGENERATOR_CONF_EOTF"), "GET_PGENERATOR_CONF_EOTF"));
 	st.primaries   = atoi((LPCTSTR)PgenParseVal(PgSend(s, "CMD:GET_PGENERATOR_CONF_PRIMARIES"), "GET_PGENERATOR_CONF_PRIMARIES"));
 	st.doviMode    = atoi((LPCTSTR)PgenParseVal(PgSend(s, "CMD:GET_PGENERATOR_CONF_DV_MAP_MODE"), "GET_PGENERATOR_CONF_DV_MAP_MODE"));

--- a/Generators/Generator.h
+++ b/Generators/Generator.h
@@ -46,7 +46,7 @@ typedef char * (__stdcall *RB8PG_get)(SOCKET sock,const char *message);
 struct PGenSettings
 {
 	int colorFormat, quantRange, bitDepth, colorimetry;
-	int isHdr, isLLDovi;
+	int isHdr, isLLDovi, isStdDovi;
 	int eotf, primaries, doviMode;
 	int maxLuma, minLuma, maxCll, maxFall;
 	BOOL valid;

--- a/Generators/gdigeneproppage.cpp
+++ b/Generators/gdigeneproppage.cpp
@@ -730,6 +730,7 @@ BOOL CPGenSettingsDlg::OnInitDialog()
 	PGenSettings st; st.valid = FALSE;
 	st.colorFormat = st.quantRange = st.bitDepth = st.colorimetry = 0;
 	st.isHdr = st.isLLDovi = st.isStdDovi = st.eotf = st.primaries = 0;
+	st.doviMode = 1;
 	st.maxLuma = 1000; st.minLuma = 5; st.maxCll = 1000; st.maxFall = 400;
 	if (m_pGenerator)
 	{

--- a/Generators/gdigeneproppage.cpp
+++ b/Generators/gdigeneproppage.cpp
@@ -729,7 +729,7 @@ BOOL CPGenSettingsDlg::OnInitDialog()
 	int curMode = -1;
 	PGenSettings st; st.valid = FALSE;
 	st.colorFormat = st.quantRange = st.bitDepth = st.colorimetry = 0;
-	st.isHdr = st.isLLDovi = st.eotf = st.primaries = 0;
+	st.isHdr = st.isLLDovi = st.isStdDovi = st.eotf = st.primaries = 0;
 	st.maxLuma = 1000; st.minLuma = 5; st.maxCll = 1000; st.maxFall = 400;
 	if (m_pGenerator)
 	{
@@ -750,7 +750,7 @@ BOOL CPGenSettingsDlg::OnInitDialog()
 		CPoint lp = M.at(LX, y + 2); m_aviL[5].Create(LS(IDS_PGEN_DYNRANGE), WS_CHILD | WS_VISIBLE, CRect(lp.x, lp.y, lp.x + M.w(LW), lp.y + M.ht(9)), this); m_aviL[5].SetFont(font);
 		CPoint cp = M.at(CX, y); m_avi[5].Create(WS_CHILD | WS_VISIBLE | WS_TABSTOP | CBS_DROPDOWNLIST | WS_VSCROLL, CRect(cp.x, cp.y, cp.x + M.w(CW), cp.y + M.ht(80)), this, IDC_PGEN_AVI_BASE + 5); m_avi[5].SetFont(font);
 		for (int j = 0; j < 3; j++) m_avi[5].AddString(kPgDR[j]);
-		int sel = st.isLLDovi ? 2 : (st.isHdr ? 1 : 0);
+		int sel = (st.isLLDovi || st.isStdDovi) ? 2 : (st.isHdr ? 1 : 0);
 		m_avi[5].SetCurSel(sel); m_aviInit[5] = sel;
 	}
 	{
@@ -844,10 +844,10 @@ void CPGenSettingsDlg::OnOK()
 			CString c;
 			c.Format(_T("CMD:SET_PGENERATOR_CONF_IS_SDR:%d"), isSdr); cmds.Add(c);
 			c.Format(_T("CMD:SET_PGENERATOR_CONF_IS_HDR:%d"), isHdr); cmds.Add(c);
-			c.Format(_T("CMD:SET_PGENERATOR_CONF_IS_LL_DOVI:%d"), dovi); cmds.Add(c);
+			c.Format(_T("CMD:SET_PGENERATOR_CONF_IS_LL_DOVI:%d"), 0); cmds.Add(c);
 			c.Format(_T("CMD:SET_PGENERATOR_CONF_IS_STD_DOVI:%d"), dovi); cmds.Add(c);
 			c.Format(_T("CMD:SET_PGENERATOR_CONF_DV_STATUS:%d"), dovi); cmds.Add(c);
-			c.Format(_T("CMD:SET_PGENERATOR_CONF_DV_INTERFACE:%d"), dovi); cmds.Add(c);
+			c.Format(_T("CMD:SET_PGENERATOR_CONF_DV_INTERFACE:%d"), 0); cmds.Add(c);
 		}
 	}
 	{ int sel = m_doviCombo.GetCurSel(); if (sel >= 0 && sel != m_doviInit && drSel == 2) { CString c; c.Format(_T("CMD:SET_PGENERATOR_CONF_DV_MAP_MODE:%d"), (sel == 1) ? 2 : 1); cmds.Add(c); } }


### PR DESCRIPTION
Fixes #169.

HCFR now sends the coherent Standard Dolby Vision state for its single Dolby Vision option. It clears IS_LL_DOVI, enables IS_STD_DOVI and keeps DV_INTERFACE set to 0.

The PGenerator status and settings readback now check both transport flags, so Standard Dolby Vision is still shown as Dolby Vision after reconnecting.