### PR TITLE
Follow the active white for UHDTV3/UHDTV4 saturation endpoints

### DIFF
--- a/AccuracyTest.cpp
+++ b/AccuracyTest.cpp
@@ -64,7 +64,9 @@
 //   MT_PRIMARY/MT_SECONDARY/MT_SAT_* patch (grayscale MT_IRE and CC patches
 //   are not dimmed). The cancellation is exact only for a pure power law;
 //   quantization and non-power EOTFs (BT.1886, L*, sRGB) leave a small
-//   residual, so those combos get a looser, documented epsilon.
+//   residual - as does UHDTV3/UHDTV4's second, transport-space
+//   quantization under a custom white - so those combos get a looser,
+//   documented epsilon.
 // * The user's configuration is never touched: all profile reads/writes are
 //   redirected to a scratch ini in %TEMP%, every relevant config member is
 //   set explicitly per combo, settings are never saved, and the process
@@ -1234,7 +1236,7 @@ static double TolFor ( const Combo & c, int fam )
 		// one-code snap difference moves chroma most), BT.1886/L*/
 		// sRGB ~1.2 (their toes amplify the same one-code difference).
 		//
-		// UHDTV3/UHDTV4 take the wider ceiling at EVERY EOTF: their
+		// UHDTV3/UHDTV4 under a CUSTOM white take the wider ceiling: their
 		// transport-space encode quantizes a SECOND time (inner gamut ->
 		// 2020 transport), so the dimmed residual tracks CODE DENSITY rather
 		// than the transfer function's toe. Measured across the full matrix
@@ -1243,10 +1245,19 @@ static double TolFor ( const Combo & c, int fam )
 		// 8b-lim, 0.929 and 0.893 on the two 10-bit grids. The same patch
 		// (UHDTV3 DCI 8b-full, blue sat 25%) reads 1.059 under Power2.2 and
 		// 1.052 under BT.1886: one residual, and only the bucket differed -
-		// which is what made the 0.9 power-law ceiling the wrong one here.
+		// which is what made the 0.9 power-law ceiling the wrong one there.
+		// (Only eotf 0 is actually affected: BT.1886/L* already take 1.5,
+		// and PQ/HLG have no dimmed rows - Window Intensity is SDR-only.)
+		//
+		// D65 is deliberately NOT widened. Those rows were never masked by
+		// the deleted UHDTV3/4 known-fails (white == 999 = custom only):
+		// they were scored at 0.9 before this change and still pass there,
+		// so relaxing them would surrender 0.6 dE of regression sensitivity
+		// on the DEFAULT white for no measured reason.
 		if ( fam == FAM_PRIM || fam == FAM_SAT100 || fam == FAM_SAT75 )
 			return ( c.eotf == 0 && c.std != sRGB
-					 && c.std != UHDTV3 && c.std != UHDTV4 ) ? 0.9 : 1.5;
+					 && !( ( c.std == UHDTV3 || c.std == UHDTV4 )
+						   && c.white != D65 ) ) ? 0.9 : 1.5;
 	}
 	return 0.05;
 }
@@ -1455,7 +1466,8 @@ int RunAccuracyTest ( const char * pReportPath, bool bQuick )
 	}
 	fprintf(s_fReport, "Columns are the worst dE per patch family; '*' = over tolerance (FAIL),\n");
 	fprintf(s_fReport, "'#' = over tolerance but documented KNOWN-FAIL (see detail below).\n");
-	fprintf(s_fReport, "Tolerance: 0.05; Intensity-90%% combos: 0.9 (power law) / 1.5 (other EOTFs); conv*: 0.005\n");
+	fprintf(s_fReport, "Tolerance: 0.05; Intensity-90%% combos: 0.9 (power law) / 1.5 (other EOTFs,\n");
+	fprintf(s_fReport, "and UHDTV3/UHDTV4 at a custom white); conv*: 0.005\n");
 	fprintf(s_fReport, "dE settings: dE_form=3 (CIE2000), dE_gray=1 (gamma-predicted gray target), gw_Weight=0\n");
 	fprintf(s_fReport, "conv* families are DIFFERENTIAL: |grid dE - 3D-viewer dE| for a perturbed patch\n");
 	fprintf(s_fReport, "(-1.000 = family not run). convPV = nominal whites; convPVw = the three stored\n");

--- a/AccuracyTest.cpp
+++ b/AccuracyTest.cpp
@@ -254,20 +254,11 @@ struct KnownFail
 // the observed max) with headroom, tight enough to still catch a regression.
 static const KnownFail kKnownFails[] =
 {
-	// GetRefSat's UHDTV3/UHDTV4 sweep endpoints come from hardcoded xy tables
-	// (p3Ref/p3sRef/rRef/rsRef, Measure.cpp ~6955-6977). The secondary
-	// entries are white-point mixtures evaluated AT D65, so under any custom
-	// white the reference endpoints no longer match the wire patches built
-	// from ContainerPrimaryLinear (which follows the active white).
-	// GetRefPrimary/GetRefSecondary for these pseudo-spaces route through
-	// GetRefSat(i, 1.0), so the primaries family inherits the same skew.
-	// (observed worst ~8 dE)
-	{ UHDTV3, 999, -1, FAM_PRIM,   GRID_ANY, -1, 15.0, "hardcoded D65 endpoint xy tables in GetRefSat (p3Ref/p3sRef)" },
-	{ UHDTV3, 999, -1, FAM_SAT100, GRID_ANY, -1, 15.0, "hardcoded D65 endpoint xy tables in GetRefSat (p3Ref/p3sRef)" },
-	{ UHDTV3, 999, -1, FAM_SAT75,  GRID_ANY, -1, 15.0, "hardcoded D65 endpoint xy tables in GetRefSat (p3Ref/p3sRef)" },
-	{ UHDTV4, 999, -1, FAM_PRIM,   GRID_ANY, -1, 15.0, "hardcoded D65 endpoint xy tables in GetRefSat (rRef/rsRef)" },
-	{ UHDTV4, 999, -1, FAM_SAT100, GRID_ANY, -1, 15.0, "hardcoded D65 endpoint xy tables in GetRefSat (rRef/rsRef)" },
-	{ UHDTV4, 999, -1, FAM_SAT75,  GRID_ANY, -1, 15.0, "hardcoded D65 endpoint xy tables in GetRefSat (rRef/rsRef)" },
+	// (UHDTV3/UHDTV4 under custom whites used to be known-failed here:
+	// GetRefSat's sweep endpoints were hardcoded xy tables evaluated at D65
+	// whose secondary entries are white-point mixtures. GetRefSat now takes
+	// those endpoints from ContainerInnerReference, the same reference the
+	// wire is built from, so they follow the active white and pass.)
 	// HDTVa/HDTVb under custom whites: the wire tables, the pRef/sRef
 	// reference endpoints, the simulated sensor's decode space and the dE
 	// space are all fixed Rec.709/D65 constructions, while the gray/sat
@@ -1240,11 +1231,22 @@ static double TolFor ( const Combo & c, int fam )
 		// segment) leave a real residual; it is bounded and level-dependent,
 		// not a modeling error. Measured residual ceilings across the full
 		// matrix: pure power law ~0.8 (8-bit dark saturation steps, where a
-		// one-code snap difference moves chroma most; the UHDTV3/4
-		// transport-space encode adds a second quantization), BT.1886/L*/
+		// one-code snap difference moves chroma most), BT.1886/L*/
 		// sRGB ~1.2 (their toes amplify the same one-code difference).
+		//
+		// UHDTV3/UHDTV4 take the wider ceiling at EVERY EOTF: their
+		// transport-space encode quantizes a SECOND time (inner gamut ->
+		// 2020 transport), so the dimmed residual tracks CODE DENSITY rather
+		// than the transfer function's toe. Measured across the full matrix
+		// on the custom whites - only scorable since GetRefSat's endpoints
+		// stopped being hardcoded at D65 - worst 1.350 on 8b-full, 1.169 on
+		// 8b-lim, 0.929 and 0.893 on the two 10-bit grids. The same patch
+		// (UHDTV3 DCI 8b-full, blue sat 25%) reads 1.059 under Power2.2 and
+		// 1.052 under BT.1886: one residual, and only the bucket differed -
+		// which is what made the 0.9 power-law ceiling the wrong one here.
 		if ( fam == FAM_PRIM || fam == FAM_SAT100 || fam == FAM_SAT75 )
-			return ( c.eotf == 0 && c.std != sRGB ) ? 0.9 : 1.5;
+			return ( c.eotf == 0 && c.std != sRGB
+					 && c.std != UHDTV3 && c.std != UHDTV4 ) ? 0.9 : 1.5;
 	}
 	return 0.05;
 }

--- a/Measure.cpp
+++ b/Measure.cpp
@@ -7856,6 +7856,12 @@ CColor CMeasure::GetRefSat(int i, double sat_ratio, bool special, double stimLev
 	sRef[1].SetxyYValue(ColorxyY(0.224650,0.328741));
 	sRef[2].SetxyYValue(ColorxyY(0.320913, 0.154177));
 	int m_cRef=GetColorReference().m_standard;
+	// One basis for the endpoint below AND the YLuma switch further down.
+	// Both used to build this reference independently, which cost an extra
+	// matrix inversion + secondary solve on every call - and GetRefSat runs
+	// per hue per saturation step on the CIE-chart and 3D-viewer redraw paths.
+	const CColorReference basis = special ? CColorReference(HDTV)
+										  : ContainerInnerReference(GetColorReference());
 	//display rec709 sat points in special colorspace modes
 	if (!special)
 	{
@@ -7864,9 +7870,15 @@ CColor CMeasure::GetRefSat(int i, double sat_ratio, bool special, double stimLev
 			// UHDTV3/UHDTV4 are containers: the sweep runs from the active
 			// white out to the INNER gamut's corner (P3 inside 2020, Rec.709
 			// inside 2020). Take that corner from ContainerInnerReference -
-			// exactly the reference GenerateSaturationColors builds the wire
-			// patches from via ContainerPrimaryLinear - so the two sides share
-			// one definition. These endpoints used to be hardcoded xy tables
+			// the same reference GenerateSaturationColors builds the wire
+			// patches in (its cRef) and the same one ContainerPrimaryLinear
+			// indexes for the primaries wire - so reference and wire follow
+			// one white. Note the sat wire derives its corner as the primary
+			// SUM, ColorXYZ(ColorRGB(1,1,0), cRef), while this reads
+			// UpdateSecondary's line intersection: equal by construction
+			// (R+G = white-B lies on both lines), but two formulas - a change
+			// to either must keep them in step.
+			// These endpoints used to be hardcoded xy tables
 			// (p3Ref/p3sRef/rRef/rsRef) evaluated at D65: the primaries are
 			// white-independent so they were merely duplicated, but the
 			// secondaries are white-point MIXTURES (see UpdateSecondary) and
@@ -7874,15 +7886,17 @@ CColor CMeasure::GetRefSat(int i, double sat_ratio, bool special, double stimLev
 			//
 			// GetRefPrimary/GetRefSecondary route these two standards BACK
 			// through here (GetRefSat(i, 1.0)), so this must not call them.
-			CColorReference inner = ContainerInnerReference(GetColorReference());
 			switch (i)
 			{
-				case 0:	refColor.SetXYZValue(inner.GetRed());		break;
-				case 1:	refColor.SetXYZValue(inner.GetGreen());		break;
-				case 2:	refColor.SetXYZValue(inner.GetBlue());		break;
-				case 3:	refColor.SetXYZValue(inner.GetYellow());	break;
-				case 4:	refColor.SetXYZValue(inner.GetCyan());		break;
-				case 5:	refColor.SetXYZValue(inner.GetMagenta());	break;
+				case 0:	refColor.SetXYZValue(basis.GetRed());		break;
+				case 1:	refColor.SetXYZValue(basis.GetGreen());		break;
+				case 2:	refColor.SetXYZValue(basis.GetBlue());		break;
+				case 3:	refColor.SetXYZValue(basis.GetYellow());	break;
+				case 4:	refColor.SetXYZValue(basis.GetCyan());		break;
+				case 5:	refColor.SetXYZValue(basis.GetMagenta());	break;
+				// Fail the way GetRefPrimary/GetRefSecondary do rather than
+				// returning a plausible-looking chromaticity for a bad index.
+				default: ASSERT(0); return noDataColor;
 			}
 		}
 		else
@@ -7904,22 +7918,22 @@ CColor CMeasure::GetRefSat(int i, double sat_ratio, bool special, double stimLev
 	switch (i)
 	{
 		case 0:
-			YLuma = (special?CColorReference(HDTV):ContainerInnerReference(GetColorReference())).GetRedReferenceLuma(true);
+			YLuma = basis.GetRedReferenceLuma(true);
 			break;
 		case 1:
-			YLuma = (special?CColorReference(HDTV):ContainerInnerReference(GetColorReference())).GetGreenReferenceLuma(true);
+			YLuma = basis.GetGreenReferenceLuma(true);
 			break;
 		case 2:
-			YLuma = (special?CColorReference(HDTV):ContainerInnerReference(GetColorReference())).GetBlueReferenceLuma(true);
+			YLuma = basis.GetBlueReferenceLuma(true);
 			break;
 		case 3:
-			YLuma = (special?CColorReference(HDTV):ContainerInnerReference(GetColorReference())).GetYellowReferenceLuma(true);
+			YLuma = basis.GetYellowReferenceLuma(true);
 			break;
 		case 4:
-			YLuma = (special?CColorReference(HDTV):ContainerInnerReference(GetColorReference())).GetCyanReferenceLuma(true);
+			YLuma = basis.GetCyanReferenceLuma(true);
 			break;
 		case 5:
-			YLuma = (special?CColorReference(HDTV):ContainerInnerReference(GetColorReference())).GetMagentaReferenceLuma(true);
+			YLuma = basis.GetMagentaReferenceLuma(true);
 			break;
 	}
 	

--- a/Measure.cpp
+++ b/Measure.cpp
@@ -7855,39 +7855,35 @@ CColor CMeasure::GetRefSat(int i, double sat_ratio, bool special, double stimLev
 	sRef[0].SetxyYValue(ColorxyY(0.419314,0.505251));
 	sRef[1].SetxyYValue(ColorxyY(0.224650,0.328741));
 	sRef[2].SetxyYValue(ColorxyY(0.320913, 0.154177));
-	CColor p3Ref[3];
-	p3Ref[0].SetxyYValue(ColorxyY(0.6800, 0.3200));
-	p3Ref[1].SetxyYValue(ColorxyY(0.265, 0.690));
-	p3Ref[2].SetxyYValue(ColorxyY(0.150, 0.06));
-	CColor p3sRef[3];
-	p3sRef[0].SetxyYValue(ColorxyY(0.437849,0.535894));
-	p3sRef[1].SetxyYValue(ColorxyY(0.199611, 0.331782));				
-	p3sRef[2].SetxyYValue(ColorxyY(0.336194, 0.151341));
-	CColor rRef[3];
-	rRef[0].SetxyYValue(ColorxyY(0.64,	0.33));
-	rRef[1].SetxyYValue(ColorxyY(0.30, 0.60));
-	rRef[2].SetxyYValue(ColorxyY(0.150, 0.06));
-	CColor rsRef[3];
-	rsRef[0].SetxyYValue(ColorxyY(0.419314,0.505251));
-	rsRef[1].SetxyYValue(ColorxyY(0.224650, 0.328741));				
-	rsRef[2].SetxyYValue(ColorxyY(0.320913, 0.154177));
 	int m_cRef=GetColorReference().m_standard;
-	//display rec709 sat points in special colorspace modes	
+	//display rec709 sat points in special colorspace modes
 	if (!special)
 	{
-		if (m_cRef == UHDTV3)
+		if (m_cRef == UHDTV3 || m_cRef == UHDTV4)
 		{
-			if ( i < 3 )
-				refColor = p3Ref[i];
-			else
-				refColor = p3sRef[i-3];
-		}
-		else if (m_cRef == UHDTV4)
-		{
-			if ( i < 3 )
-				refColor = rRef[i];
-			else
-				refColor = rsRef[i-3];
+			// UHDTV3/UHDTV4 are containers: the sweep runs from the active
+			// white out to the INNER gamut's corner (P3 inside 2020, Rec.709
+			// inside 2020). Take that corner from ContainerInnerReference -
+			// exactly the reference GenerateSaturationColors builds the wire
+			// patches from via ContainerPrimaryLinear - so the two sides share
+			// one definition. These endpoints used to be hardcoded xy tables
+			// (p3Ref/p3sRef/rRef/rsRef) evaluated at D65: the primaries are
+			// white-independent so they were merely duplicated, but the
+			// secondaries are white-point MIXTURES (see UpdateSecondary) and
+			// so were wrong under any custom white.
+			//
+			// GetRefPrimary/GetRefSecondary route these two standards BACK
+			// through here (GetRefSat(i, 1.0)), so this must not call them.
+			CColorReference inner = ContainerInnerReference(GetColorReference());
+			switch (i)
+			{
+				case 0:	refColor.SetXYZValue(inner.GetRed());		break;
+				case 1:	refColor.SetXYZValue(inner.GetGreen());		break;
+				case 2:	refColor.SetXYZValue(inner.GetBlue());		break;
+				case 3:	refColor.SetXYZValue(inner.GetYellow());	break;
+				case 4:	refColor.SetXYZValue(inner.GetCyan());		break;
+				case 5:	refColor.SetXYZValue(inner.GetMagenta());	break;
+			}
 		}
 		else
 		{

--- a/tests/ACCURACYTEST.md
+++ b/tests/ACCURACYTEST.md
@@ -45,7 +45,8 @@ those are the branchy axes.
 
 The subset must keep **every `kKnownFails` entry reachable**, or the stale-entry
 sweep turns `quick` into a permanent exit 1. Four things depend on the current
-choice: xyCust covers the custom-white entries, 8b-lim the PQ half-code tie,
+choice: xyCust covers the HDTVa/HDTVb custom-white entries, 8b-lim the PQ
+half-code tie,
 8b-full the full-range gray gap — and 8b-lim is *also* the last limited-range
 grid, which the entire manual-generator pass is gated on, while D65 is *also*
 load-bearing for the HDTVa/b HDR primaries entries. Drop either and seven DVD
@@ -282,10 +283,6 @@ Kept in `kKnownFails` in `AccuracyTest.cpp`, each with the code-level reason
 and (where relevant) a grid filter. An entry that never fires across a whole
 run is reported as STALE. Current entries (expected, pre-existing):
 
-- **UHDTV3/UHDTV4 with custom whites** (`prim`, `sat*`): `GetRefSat`'s sweep
-  endpoints are hardcoded D65 xy tables (`p3Ref`/`p3sRef`/`rRef`/`rsRef`,
-  Measure.cpp ~6955-6977), while the wire patches follow the active white via
-  `ContainerPrimaryLinear`.
 - **HDTVa/HDTVb with custom whites** (`gray`, `prim`, `sat*`): the wire
   tables, `pRef`/`sRef` endpoints, the simulated sensor's decode space and
   the dE space are all fixed Rec.709/D65 constructions, while gray/sat
@@ -457,10 +454,31 @@ agree), and the gaps below are mostly places their reach stops.
    compare `ComputeProfileDE` against the same pane emulation the `conv*`
    families use.
 
-Reference result (2026-07-26): `834 combos: 333 pass, 0 FAIL, 501 known-fail`,
-ColorMathTest verify green with no golden movement. (Was `708 combos: 311 pass,
-0 FAIL, 397 known-fail` before this work: +84 tone-mapped 700-nit combos and +84
-manual-generator combos (limited-range grids only), the latter all landing in
-the new DVD known-fail.
+Reference result (2026-08-13): `834 combos: 441 pass, 0 FAIL, 393 known-fail`,
+ColorMathTest verify green with no golden movement.
+
+Was `834 combos: 333 pass, 0 FAIL, 501 known-fail` (2026-07-26) before
+`GetRefSat` stopped taking its UHDTV3/UHDTV4 sweep endpoints from xy tables
+hardcoded at D65 and started taking them from `ContainerInnerReference` — the
+same reference the wire is built from. That moved **exactly 160 rows**, all of
+them UHDTV3/UHDTV4 at DCI or xyCust (40 each), and **zero D65 rows**: the old
+tables were the correct D65 values, so the change is a no-op there by
+construction. 108 combos went known-fail -> pass and the six
+UHDTV3/UHDTV4-custom-white entries left `kKnownFails`. At full stimulus every
+one of those rows now reads exactly `0.000` on `prim`/`sat100`/`sat75`.
+
+The one combo that did not fall straight under tolerance (UHDTV3 Power2.2 DCI
+8b-full 90%, `sat100` 1.059) turned out to be the dimmed-combo quantization
+residual, not a reference error: the identical patch reads 1.052 under BT.1886,
+where only the tolerance bucket differs, and the residual tracks code density
+(1.350 8b-full / 1.169 8b-lim / 0.929 10b-lim / 0.893 10b-full) rather than the
+transfer function. `TolFor` now puts UHDTV3/UHDTV4 in the same 1.5 dimmed
+bucket as the toe EOTFs, for the reason its own comment already predicted —
+their transport-space encode quantizes a second time. That ceiling was only
+ever calibrated on rows these six entries had been masking.
+
+(Was `708 combos: 311 pass, 0 FAIL, 397 known-fail` before that: +84
+tone-mapped 700-nit combos and +84 manual-generator combos (limited-range grids
+only), the latter all landing in the new DVD known-fail.
 On the GDI half the three convention families read 0.000 across the whole
 matrix.)

--- a/tests/ACCURACYTEST.md
+++ b/tests/ACCURACYTEST.md
@@ -46,14 +46,13 @@ those are the branchy axes.
 The subset must keep **every `kKnownFails` entry reachable**, or the stale-entry
 sweep turns `quick` into a permanent exit 1. Four things depend on the current
 choice: xyCust covers the HDTVa/HDTVb custom-white entries, 8b-lim the PQ
-half-code tie,
-8b-full the full-range gray gap — and 8b-lim is *also* the last limited-range
-grid, which the entire manual-generator pass is gated on, while D65 is *also*
-load-bearing for the HDTVa/b HDR primaries entries. Drop either and seven DVD
-entries go stale at once. An entry that a quick run cannot reach is now reported
-as `NOT REACHABLE in the quick subset` rather than `STALE`, and does not fail
-the run — deleting it on that advice would turn a documented gap into a hard
-FAIL on the full matrix.
+half-code tie, 8b-full the full-range gray gap — and 8b-lim is *also* the last
+limited-range grid, which the entire manual-generator pass is gated on, while
+D65 is *also* load-bearing for the HDTVa/b HDR primaries entries. Drop either
+and seven DVD entries go stale at once. An entry that a quick run cannot reach
+is now reported as `NOT REACHABLE in the quick subset` rather than `STALE`, and
+does not fail the run — deleting it on that advice would turn a documented gap
+into a hard FAIL on the full matrix.
 
 **A FAIL in a quick run is as real as in a full one; exit 0 is not.** The
 converse does not hold: a regression confined to a dropped white or grid is
@@ -243,15 +242,21 @@ nearby regression). Stale entries print a warning **and fail the run** (nonzero
 exit) — remove them from `kKnownFails` in `AccuracyTest.cpp`. The exit code is
 nonzero if there is any real FAIL **or** any stale entry.
 
-Tolerances: **0.05** for exact-model combos (SnapToVideoGrid's 1e-9
-tie-breaker means no extra slack is needed), **0.005** for the three
-convention families (see above). The Intensity-90% combos get
-**0.9** (power law) / **1.5** (BT.1886, L*, sRGB): the cancellation is exact
-only for an ideal power law — the dimmed code snaps to a different grid point
-than the undimmed one, and non-power EOTFs break the ratio identity — so a
+Tolerances: **0.05** for exact-model combos (SnapToVideoGrid's 1e-9 tie-breaker
+means no extra slack is needed), **0.005** for the three convention families
+(see above). The Intensity-90% combos get **0.9** (power law) / **1.5**
+(BT.1886, L*, sRGB, and UHDTV3/UHDTV4 at a **custom** white): the cancellation
+is exact only for an ideal power law — the dimmed code snaps to a different grid
+point than the undimmed one, and non-power EOTFs break the ratio identity — so a
 bounded, level-dependent residual is expected behavior, not a modeling error
 (measured ceilings ~0.8 and ~1.2 across the full matrix; worst on 8-bit dark
-saturation steps).
+saturation steps). UHDTV3/UHDTV4 join the wider bucket only at a custom white,
+because their inner-to-transport encode quantizes a *second* time, so the
+residual tracks code density rather than the toe (worst 1.350 on 8b-full). Their
+**D65** rows stay at 0.9: the deleted known-fails never covered D65 (`white ==
+999` is custom-only), so those rows were always scored at 0.9 and always passed,
+and widening them would drop 0.6 dE of regression sensitivity on the default
+white.
 
 Harness dE settings (fixed, independent of the user's config): `dE_form=3`
 (CIE2000), `dE_gray=1` (gamma-predicted gray luminance target — the app's
@@ -472,10 +477,12 @@ The one combo that did not fall straight under tolerance (UHDTV3 Power2.2 DCI
 residual, not a reference error: the identical patch reads 1.052 under BT.1886,
 where only the tolerance bucket differs, and the residual tracks code density
 (1.350 8b-full / 1.169 8b-lim / 0.929 10b-lim / 0.893 10b-full) rather than the
-transfer function. `TolFor` now puts UHDTV3/UHDTV4 in the same 1.5 dimmed
-bucket as the toe EOTFs, for the reason its own comment already predicted —
-their transport-space encode quantizes a second time. That ceiling was only
-ever calibrated on rows these six entries had been masking.
+transfer function. `TolFor` now puts UHDTV3/UHDTV4 **at a custom white** in
+the same 1.5 dimmed bucket as the toe EOTFs, for the reason its own comment
+already predicted — their transport-space encode quantizes a second time.
+That ceiling was only ever calibrated on rows these six entries had been
+masking, which is also why the D65 rows are left at 0.9 — they were never
+masked, and they pass there.
 
 (Was `708 combos: 311 pass, 0 FAIL, 397 known-fail` before that: +84
 tone-mapped 700-nit combos and +84 manual-generator combos (limited-range grids


### PR DESCRIPTION
## What was wrong

`GetRefSat` built its UHDTV3/UHDTV4 sweep endpoints from four hardcoded xy tables (`p3Ref`/`p3sRef`/`rRef`/`rsRef`) evaluated at D65, while the wire patches come from `ContainerPrimaryLinear`, which follows the active white. The two agreed **only at D65**.

So on **P3-in-2020 or 709-in-2020 at any other white** the reference swept toward the wrong corner and the user was shown targets up to **~8 dE** off — calibrating toward them makes the display less accurate, with nothing on screen indicating a problem.

This is reachable, not theoretical: `whiteLocked` (ReferencesPropPage.cpp ~1080) covers only HDTVa/HDTVb/CC6, so UHDTV3/UHDTV4 expose the full white dropdown — DCI, D50/55/75, D93, A/B/C/E, manual xy.

## Only the secondaries were actually wrong

Verified numerically before changing anything, by printing both sides at D65 to full precision:

- **Primaries** — matched to `<= 1.1e-16`. Primary chromaticity is white-independent (the `CColorReference` ctor takes `ColorxyY(redPrimary)` and replaces only element `[2]` with the reference luma), so `p3Ref`/`rRef` were duplicates of `primariesP3`/`primariesRec709`. Correct at any white, just duplicated.
- **Secondaries** — the real defect. These are white-point *mixtures* derived through `UpdateSecondary`, so they move with the white. Each hardcoded value round-trips to the computed D65 mixture at 6 decimals (`0.43784882…` → `0.437849`), confirming they were the right numbers for the wrong white rather than a second, different bug.

Both halves now come from `ContainerInnerReference` — exactly the set `ContainerPrimaryLinear` indexes — so reference and wire share one definition instead of two that agreed at a single white. `GetRefPrimary`/`GetRefSecondary` route these two spaces back through `GetRefSat(i, 1.0)`, so the primaries family is fixed by the same edit.

## Tolerance change (the one judgment call)

Deleting the six known-fail entries left a single combo at 1.059 (UHDTV3 Power2.2 DCI 8b-full 90%, tol 0.9). That is **quantization, not reference error** — two measurements:

- the identical patch reads **1.052 under BT.1886** and passes, purely because that EOTF sits in the 1.5 bucket;
- the residual tracks **code density**, not the transfer function: 1.350 (8b-full) → 1.169 (8b-lim) → 0.929 (10b-lim) → 0.893 (10b-full).

`TolFor`'s own comment already predicted this — the UHDTV3/4 transport-space encode quantizes a second time — but the 0.9 ceiling was calibrated while these six entries masked the rows that would have shown it. UHDTV3/UHDTV4 now take the same 1.5 dimmed bucket as the toe EOTFs.

Re-adding a narrow known-fail entry was the alternative and is worse: it would label quantization dust a modeling failure and mask that entire family at ceiling 15.0.

## Verification

| | before | after |
|---|---|---|
| accuracytest (full) | 834: 333 pass, 0 FAIL, 501 known-fail | 834: **441 pass, 0 FAIL, 393 known-fail** |
| accuracytest (quick) | — | 285: 110 pass, 0 FAIL, no stale |
| ColorMathTest verify | green | green, **no golden movement** |

Exactly **160 rows move** — all UHDTV3/UHDTV4 at DCI or xyCust (40 each) and **zero at D65**, a no-op there by construction. 108 combos went known-fail → pass. At full stimulus every one of those rows now reads exactly `0.000` on `prim`/`sat100`/`sat75`, which is what confirms the endpoints are now exact at every white — the remaining dimmed residual therefore cannot be an endpoint error.

The six `kKnownFails` entries are deleted (a never-fired entry is reported STALE and fails the run) and `tests/ACCURACYTEST.md` is updated: known-failure bullet dropped, reference result refreshed with measured numbers, and the quick-subset `xyCust` rationale narrowed to the HDTVa/HDTVb entries that still depend on it.

Full-solution build (`ColorHCFR_VS2019.sln`, Debug|Win32) clean.

## Note

One matrix run exited -1 with a truncated report; the immediate re-run and all four subsequent runs were clean, so it looks like a flake rather than anything from this change. Flagging it because a half-written report reads like a pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)