### PR TITLE
Fix Summary-pane undo and the ghosted line on insert

### DIFF
--- a/EditEx.cpp
+++ b/EditEx.cpp
@@ -85,37 +85,6 @@ void CEditEx::CDeleteSelectionCommand::DoExecute()
 }
 
 //////////////////////////////////////////////////////////////////////////
-// CEditEx::CDeleteCharacterCommand
-
-CEditEx::CDeleteCharacterCommand::CDeleteCharacterCommand(CEditEx* pEditControl, bool isBackspace) 
-	: CEditExCommand(pEditControl)
-	, m_isBackspace(isBackspace)
-{
-	ASSERT(m_pEditControl->IsSelectionEmpty());
-	m_pEditControl->GetSel(m_nStart, m_nStart);
-	CString text;
-	m_pEditControl->GetWindowText(text);
-	if (m_isBackspace)
-		--m_nStart;
-	m_charDeleted = text[m_nStart];
-}
-
-void CEditEx::CDeleteCharacterCommand::DoUndo()
-{
-	m_pEditControl->InsertChar(m_charDeleted, m_nStart);
-	if (m_isBackspace)
-		m_pEditControl->SetSel(m_nStart + 1, m_nStart + 1);
-	else
-		m_pEditControl->SetSel(m_nStart, m_nStart);
-}
-
-void CEditEx::CDeleteCharacterCommand::DoExecute()
-{
-	m_pEditControl->DeleteText(m_nStart, 1);
-	m_pEditControl->SetSel(m_nStart, m_nStart);
-}
-
-//////////////////////////////////////////////////////////////////////////
 // CEditEx::CReplaceSelectionCommand
 
 CEditEx::CReplaceSelectionCommand::CReplaceSelectionCommand(CEditEx* const pEditControl, const CString& text) 
@@ -189,6 +158,12 @@ CEditEx::CCommandHistory::~CCommandHistory()
 void CEditEx::CCommandHistory::AddCommand(CEditExCommand* pCommand)
 {
 	m_undoCommands.push(pCommand);
+	DestroyRedoCommands();
+}
+
+void CEditEx::CCommandHistory::Clear()
+{
+	DestroyUndoCommands();
 	DestroyRedoCommands();
 }
 
@@ -315,6 +290,14 @@ BOOL CEditEx::CanRedo() const
 	return m_commandHistory.CanRedo();
 }
 
+// Drops the recorded history. Needed whenever the text is replaced from outside
+// the control (the stored commands then describe text that is no longer there).
+void CEditEx::EmptyUndoBuffer()
+{
+	m_commandHistory.Clear();
+	CEdit::EmptyUndoBuffer();
+}
+
 // command pattern receiver methods
 
 void CEditEx::InsertText(const CString& textToInsert, int nStart)
@@ -323,15 +306,6 @@ void CEditEx::InsertText(const CString& textToInsert, int nStart)
 	CString text;
 	GetWindowText(text);
 	text.Insert(nStart, textToInsert);
-	SendMessage(WM_SETTEXT, (WPARAM)m_hWnd, (LPARAM)text.GetString());
-}
-
-void CEditEx::InsertChar(TCHAR charToInsert, int nStart)
-{
-	ASSERT(nStart <= GetWindowTextLength());
-	CString text;
-	GetWindowText(text);
-	text.Insert(nStart, charToInsert);
 	SendMessage(WM_SETTEXT, (WPARAM)m_hWnd, (LPARAM)text.GetString());
 }
 
@@ -347,45 +321,18 @@ void CEditEx::DeleteText(int nStart, int nLen)
 
 // CEditEx overrides
 
-// intercept commands to add them to the history
+// Only the keyboard shortcuts the control does not implement itself are handled
+// here. Typed characters are left to the edit control and recorded in the undo
+// history by WindowProc(); an earlier version inserted them here by rewriting the
+// whole text on every keystroke and never added the command to the history, so
+// nothing the user typed could be undone.
 BOOL CEditEx::PreTranslateMessage(MSG* pMsg)
 {
 	switch (pMsg->message)
 	{
-		// Omardris
-		int i;
-	case WM_CHAR:
-		i = pMsg->wParam;
-		wchar_t wChar;
-		if (i > 31 || i == 13) {
-			wChar = pMsg->wParam;
-		}
-		//int nCount = wParam & 0xFF;
-		if (iswprint(wChar))
-		{			
-			CString newText(wChar, 1);
-			//CreateInsertTextCommand(newText);
-			if (IsSelectionEmpty()) {
-				CEditExCommand* pCommand = new CInsertTextCommand(this, newText);
-				pCommand->Execute();
-			}
-			else {
-				CEditExCommand* pCommand = new CReplaceSelectionCommand(this, newText);
-				pCommand->Execute();
-			}
-			Invalidate();
-			//UpdateWindow();
-			return true;
-		}
-		// Omardris
-
-		break;
-
 	case WM_KEYDOWN: // Non-System_key (without ALT)
-		if (PreTranslateKeyDownMessage(pMsg->wParam) == TRUE) {
-			//Invalidate();
+		if (PreTranslateKeyDownMessage(pMsg->wParam) == TRUE)
 			return TRUE;
-		}
 		break;
 		/*
 	case WM_SYSCHAR: // bedeutet, dass auch Alt-Taste mit gedrückt wurde
@@ -413,7 +360,13 @@ LRESULT CEditEx::WindowProc(UINT message, WPARAM wParam, LPARAM lParam)
 		{
 			wchar_t wChar = static_cast<wchar_t>(wParam);
 			int nCount = lParam & 0xFF;
-			if (iswprint(wChar))
+			// Return inserts a CR/LF pair in a multiline control; iswprint() rejects
+			// it, so it has to be recorded explicitly or a new line cannot be undone.
+			if ((wChar == _T('\r') || wChar == _T('\n')) && IsMultiLine() && (GetStyle() & ES_WANTRETURN))
+			{
+				CreateInsertTextCommand(_T("\r\n"));
+			}
+			else if (iswprint(wChar))
 			{
 				CString newText(wChar, nCount);
 				CreateInsertTextCommand(newText);
@@ -567,16 +520,6 @@ BOOL CEditEx::DoDelete()
 	// simple delete
 	DeleteSelectedChar();
 	return TRUE;
-	// macht eigentlich keinen Sinn mehr ??
-	if (IsSelectionEmpty() == false)
-		m_commandHistory.AddCommand(new CDeleteSelectionCommand(this, CDeleteSelectionCommand::Selection));
-	else
-	{
-		if (GetCursorPosition() < GetWindowTextLength())
-			m_commandHistory.AddCommand(new CDeleteCharacterCommand(this, false));
-	}
-	return FALSE; // Delete-Taste wird weitergereicht
-	
 }
 
 BOOL CEditEx::DoBackspace()
@@ -594,15 +537,6 @@ BOOL CEditEx::DoBackspace()
 	// plain Back
 	BackSelectedChar();
 	return TRUE;
-	// macht eigentlich keinen Sinn mehr ??
-	if (IsSelectionEmpty() == false)
-		m_commandHistory.AddCommand(new CDeleteSelectionCommand(this, CDeleteSelectionCommand::Selection));
-	else
-	{
-		if (GetCursorPosition() > 0)
-			m_commandHistory.AddCommand(new CDeleteCharacterCommand(this, true));
-	}
-	return FALSE; // BackSpace taste wird weitergereicht
 }
 
 void CEditEx::DoUndo()

--- a/EditEx.cpp
+++ b/EditEx.cpp
@@ -351,6 +351,24 @@ BOOL CEditEx::PreTranslateMessage(MSG* pMsg)
 	return CEdit::PreTranslateMessage(pMsg);
 }
 
+// True when the edit control will insert this WM_CHAR character. The undo history
+// has to mirror that exactly: recording an insert the control does not make - or
+// missing one it does - leaves the offsets held by the earlier commands describing
+// text that has since shifted, and a later undo then deletes the wrong characters.
+// The set below was measured against the Win32 control rather than taken from
+// iswprint(), which rejects both Tab and Return: a multiline control inserts Tab and
+// turns CR or LF into a CR/LF pair (with or without ES_WANTRETURN), a single-line one
+// drops all three, and both insert everything from 0x1E up. The remaining control
+// characters are swallowed, except Ctrl+C / Ctrl+X / Ctrl+V which arrive separately
+// as WM_COPY / WM_CUT / WM_PASTE.
+bool CEditEx::IsInsertedOnChar(wchar_t wChar) const
+{
+	if (wChar == _T('\t') || wChar == _T('\r') || wChar == _T('\n'))
+		return IsMultiLine();
+
+	return wChar >= 0x1E;
+}
+
 // intercept commands to add them to the history
 LRESULT CEditEx::WindowProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
@@ -359,22 +377,24 @@ LRESULT CEditEx::WindowProc(UINT message, WPARAM wParam, LPARAM lParam)
 	case WM_CHAR:
 		{
 			wchar_t wChar = static_cast<wchar_t>(wParam);
+			// The control inserts one copy per repeat. A WM_CHAR synthesised outside
+			// the keyboard (the context menu's Unicode control characters) carries a
+			// count of 0 and stands for a single character.
 			int nCount = lParam & 0xFF;
-			// Return inserts a CR/LF pair in a multiline control; iswprint() rejects
-			// it, so it has to be recorded explicitly or a new line cannot be undone.
-			if ((wChar == _T('\r') || wChar == _T('\n')) && IsMultiLine() && (GetStyle() & ES_WANTRETURN))
+			if (nCount == 0)
+				nCount = 1;
+			if (IsInsertedOnChar(wChar))
 			{
-				CreateInsertTextCommand(_T("\r\n"));
-			}
-			else if (iswprint(wChar))
-			{
-				CString newText(wChar, nCount);
-				CreateInsertTextCommand(newText);
-			}
-			// special case for Unicode control characters inserted from the context menu
-			else if (nCount == 0)
-			{
-				CString newText(wChar);
+				CString newText;
+				// Return and Ctrl+Return both insert a CR/LF pair rather than the
+				// character that was typed.
+				if (wChar == _T('\r') || wChar == _T('\n'))
+				{
+					for (int i = 0; i < nCount; i++)
+						newText += _T("\r\n");
+				}
+				else
+					newText = CString(wChar, nCount);
 				CreateInsertTextCommand(newText);
 			}
 		}

--- a/EditEx.h
+++ b/EditEx.h
@@ -151,6 +151,11 @@ public:
 	BOOL Redo();
 	BOOL CanUndo() const;
 	BOOL CanRedo() const;
+	// Hides the non-virtual CEdit::EmptyUndoBuffer rather than overriding it, so it
+	// clears m_commandHistory only when it is called through a CEditEx*. Reset the
+	// control through this class, never through a CEdit* or CWnd*: a base-class call
+	// dispatches statically past the Clear() and leaves behind the stale commands
+	// that used to make the first Ctrl+Z blank the summary.
 	void EmptyUndoBuffer();
 
 	// command pattern receiver methods
@@ -169,6 +174,7 @@ public:
 	afx_msg void OnEnterIdle(UINT nWhy, CWnd* pWho);
 
 private:
+	bool IsInsertedOnChar(wchar_t wChar) const;
 	void CreateInsertTextCommand(const CString& newText);
 	BOOL PreTranslateKeyDownMessage(WPARAM wParam);
 

--- a/EditEx.h
+++ b/EditEx.h
@@ -79,19 +79,6 @@ class CEditEx : public CEdit
 		CursorOnUndo m_cursorOnUndo;
 	};
 
-	class CDeleteCharacterCommand : public CEditExCommand
-	{
-	public:
-		CDeleteCharacterCommand(CEditEx* pEditControl, bool isBackspace);
-	protected:
-		virtual void DoUndo();
-		virtual void DoExecute();
-	private:
-		TCHAR m_charDeleted;
-		int m_nStart;
-		bool m_isBackspace;
-	};
-
 	class CReplaceSelectionCommand : public CEditExCommand
 	{
 	public:
@@ -126,6 +113,7 @@ class CEditEx : public CEdit
 		~CCommandHistory();
 
 		void AddCommand(CEditExCommand* pCommand);
+		void Clear();
 		bool Undo();
 		bool Redo();
 
@@ -163,10 +151,10 @@ public:
 	BOOL Redo();
 	BOOL CanUndo() const;
 	BOOL CanRedo() const;
+	void EmptyUndoBuffer();
 
 	// command pattern receiver methods
 	void InsertText(const CString& textToInsert, int nStart);
-	void InsertChar(TCHAR charToInsert, int nStart);
 	void DeleteText(int nStart, int nLen);
 
 public:

--- a/Views/MainView.cpp
+++ b/Views/MainView.cpp
@@ -9545,6 +9545,17 @@ static CEditEx * GetSummaryEdit ( CWnd * pInfoWnd )
 	if ( pEdit == NULL || ! ::IsWindow ( pEdit -> GetSafeHwnd () ) )
 		return NULL;
 
+	// Ctrl+Z and Alt+Backspace are frame accelerators, so ID_EDIT_UNDO is routed to
+	// this view whatever holds the focus. The competitor is the grid's in-place cell
+	// editor: CInPlaceEdit is a CEdit with its own undo, and it only swallows
+	// WM_SYSCHAR in PreTranslateMessage, so Ctrl+Z pressed while editing a cell still
+	// reaches the accelerator and would roll back the Summary pane instead - a
+	// rollback that goes on to rewrite the document's info string through EN_CHANGE.
+	// OnEditCut / OnEditPaste gate on the focus the same way, including the explicit
+	// ::GetParent ( ::GetFocus () ) branch for that same in-place editor.
+	if ( pEdit -> m_hWnd != ::GetFocus () )
+		return NULL;
+
 	return pEdit;
 }
 

--- a/Views/MainView.cpp
+++ b/Views/MainView.cpp
@@ -2758,6 +2758,11 @@ void CMainView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 		if ( m_pInfoWnd ) //in case colorchecker slot is updated
 		{
 				m_pInfoWnd -> SetWindowTextA(GetDocument()->GetMeasure()->GetInfoString());
+				// The text just came from the document, so the recorded commands
+				// describe text that is no longer there: drop them.
+				CEditEx * pSummaryEdit = DYNAMIC_DOWNCAST ( CEditEx, m_pInfoWnd );
+				if ( pSummaryEdit )
+					pSummaryEdit -> EmptyUndoBuffer ();
 				m_pInfoWnd -> Invalidate ();
 				m_pInfoWnd -> UpdateWindow();			
 		}
@@ -7839,8 +7844,17 @@ HBRUSH CMainView::OnCtlColor(CDC* pDC, CWnd* pWnd, UINT nCtlColor)
 			pDC->SetTextColor(FxGetSysColor(COLOR_MENUTEXT));
 			return *m_pBgBrush;
 			break;
-		case CTLCOLOR_BTN:
 		case CTLCOLOR_EDIT:
+			// An edit control repaints incrementally as its text changes and only
+			// erases its background on a full repaint. With TRANSPARENT the previous
+			// glyphs stay on screen underneath the new ones - inserting a line leaves
+			// a copy of the line it pushed down until something forces a redraw - so
+			// its text must be drawn opaque, over the colour it is erased with.
+			pDC->SetBkMode(OPAQUE);
+			pDC->SetBkColor(FxGetMenuBgColor());
+			pDC->SetTextColor(FxGetSysColor(COLOR_MENUTEXT));
+			return *m_pBgBrush;
+		case CTLCOLOR_BTN:
 		default:
 			pDC->SetBkMode(TRANSPARENT);
 			pDC->SetTextColor(FxGetSysColor(COLOR_MENUTEXT));
@@ -8242,6 +8256,11 @@ void CMainView::OnSelchangeInfoDisplay()
 			 pEdit -> Create (WS_VISIBLE | WS_CHILD | WS_BORDER | ES_MULTILINE | ES_AUTOVSCROLL | ES_AUTOHSCROLL | ES_WANTRETURN, Rect, this, IDC_INFO_VIEW );
 			 pEdit -> SetFont ( GetFont () );		 
 			 pEdit -> SetWindowText ( GetDocument()->GetMeasure()->GetInfoString() );
+
+			 // The initial fill reaches the control as WM_SETTEXT, which CEditEx
+			 // records as an undoable change; without this the first Ctrl+Z would
+			 // blank the summary instead of undoing what the user typed.
+			 ( (CEditEx *) pEdit ) -> EmptyUndoBuffer ();
 
 			 m_pInfoWnd = pEdit;
 			 m_pInfoWnd -> SetWindowPos ( pWnd, Rect.left, Rect.top, (Rect.right - Rect.left), (Rect.bottom - Rect.top), SWP_NOACTIVATE );
@@ -9516,12 +9535,32 @@ void CMainView::OnUpdateEditPaste(CCmdUI* pCmdUI)
 		m_pGrayScaleGrid -> OnUpdateEditPaste(pCmdUI);
 }
 
+// The Summary info window is the only editable text this view owns, so the Edit
+// menu's Undo (and its Ctrl+Z / Alt+Backspace accelerators) act on it. CEditEx
+// keeps its own command history - the edit control's built-in undo is not used.
+static CEditEx * GetSummaryEdit ( CWnd * pInfoWnd )
+{
+	CEditEx * pEdit = DYNAMIC_DOWNCAST ( CEditEx, pInfoWnd );
+
+	if ( pEdit == NULL || ! ::IsWindow ( pEdit -> GetSafeHwnd () ) )
+		return NULL;
+
+	return pEdit;
+}
+
 void CMainView::OnEditUndo() 
 {
+	CEditEx * pEdit = GetSummaryEdit ( m_pInfoWnd );
+
+	if ( pEdit )
+		pEdit -> Undo ();
 }
 
 void CMainView::OnUpdateEditUndo(CCmdUI* pCmdUI) 
 {
+	CEditEx * pEdit = GetSummaryEdit ( m_pInfoWnd );
+
+	pCmdUI -> Enable ( pEdit != NULL && pEdit -> CanUndo () );
 }
 
 void CMainView::UpdateAllGrids() 


### PR DESCRIPTION
Fixes two long-standing v3.x bugs in the **Summary** info pane (the editable text field in the measures view).

### Undo never worked
`CEditEx` keeps its own command history, and four things kept it from ever being useful:

- `PreTranslateMessage` intercepted every `WM_CHAR`, built an insert/replace command, called `Execute()` on it and **never added it to the history** — so nothing typed could be undone, and every command object leaked. It also read an uninitialised `wChar` for control characters.
- Return was not recorded either (`iswprint('\r')` is false), so a new line could not be undone.
- The initial `SetWindowText` that fills the pane *was* recorded, so the single entry on the stack was "blank the summary" — the first Ctrl+Z wiped the user's text.
- `CMainView::OnEditUndo` / `OnUpdateEditUndo` were empty bodies wired into the message map, so **Edit ▸ Undo** was a permanently-enabled no-op (logged as MV-023).

Now: characters are inserted by the control itself and recorded in `WindowProc`, Return is recorded as a CR/LF insert, the initial and document-driven fills clear the history, and Edit ▸ Undo acts on the pane and greys out when there is nothing to undo.

### Inserting a line duplicated the previous line
`CMainView::OnCtlColor` returned a background brush for `CTLCOLOR_EDIT` but set `SetBkMode(TRANSPARENT)`. An edit control repaints incrementally and only erases its background on a full repaint, so the shifted line was drawn *over* the still-visible old one. Edit controls now draw their text opaque over `FxGetMenuBgColor()` — the same colour the control is erased with, so nothing else changes visually.

This also explains the per-keystroke `Invalidate()` in the old `WM_CHAR` hack: it was a workaround for this repaint bug, which is why typing looked fine but Enter did not.

### Cleanup
Removes the unreachable code after the unconditional `return TRUE` in `DoDelete`/`DoBackspace` (SHELL-031), plus the `CDeleteCharacterCommand` class and the `InsertChar` receiver that only that dead code referenced.

### Testing
Full-solution build, Debug|Win32: 0 errors. Verified by hand in the running app — Enter mid-paragraph leaves no ghost line, and Ctrl+Z walks back typing/Return/delete/cut/paste without blanking the pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
