### PR TITLE
Fix BT.2390 leaving near-black un-tone-mapped

### DIFF
--- a/libHCFR/Color.cpp
+++ b/libHCFR/Color.cpp
@@ -1592,14 +1592,21 @@ double getL_EOTF ( double valx, CColor White, CColor Black, double g_rel, double
 				E1 = valx - pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2);
 				d = pow( (c1 + c2 * pow(m_MaxML/Scale,m1)) / (1 + c3 * pow(m_MaxML/Scale,m1)), m2) - pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2);
 				E1 = E1 / d;
-				// BT.2390's EETF is defined on the normalised [0,1] range. Signals below
-				// the mastering display's black (E1 < 0) or above its peak (E1 > 1) used
-				// to leave E2 outside [0,1] and fall through to the un-tone-mapped PQ
-				// branch below, so near-black got no black lift at all: Y target at 0%
-				// (which returns the display black target) could come out ABOVE Y target
-				// at 1-5%. Clamp instead - sub-black maps to the black target, above-peak
-				// to the peak target - which keeps the tone curve monotonic.
-				E1 = min(max(E1, 0.0), 1.0);
+				// Signals below the mastering display's black make E1 negative, which
+				// left E2 outside [0,1] and fell through to the un-tone-mapped PQ branch
+				// below, so near-black got no black lift at all: Y target at 0% (which
+				// returns the display black target) could come out ABOVE Y target at
+				// 1-5%. Floor E1 so sub-black maps to the black target instead.
+				//
+				// Only the LOW end. E1 > 1 - a signal above the mastering peak - must keep
+				// falling through: when TargetMaxL > MasterMaxL (a display brighter than
+				// the disc, both fields user-editable) maxL > 1, so KS = 1.5*maxL - 0.5 > 1
+				// and the knee never fires. Capping E1 at 1 would then pin every signal
+				// above the mastering peak to PQ(MasterMaxL) - a 1000-nit-mastered disc on
+				// a 4000-nit target flat-lined the whole top quarter of the grid at 1000
+				// instead of tracking PQ up to TargetMaxL. The fall-through returns true PQ
+				// capped at m_MaxTL, which is what the expansion region wants.
+				E1 = max(E1, 0.0);
 				minL = (pow( (c1 + c2 * pow(m_MinTL/Scale,m1)) / (1 + c3 * pow(m_MinTL/Scale,m1)), m2)-pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2)) / d;
 				maxL = (pow( (c1 + c2 * pow(m_MaxTL/Scale,m1)) / (1 + c3 * pow(m_MaxTL/Scale,m1)), m2)-pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2)) / d;
 				KS = 1.5 * maxL - 0.5;
@@ -1644,37 +1651,41 @@ double getL_EOTF ( double valx, CColor White, CColor Black, double g_rel, double
 			{
 				BT2390x.clear();
 				BT2390y.clear();
-				int ii = 1024;
 
 				if (m_MinML > m_MinTL)
 					m_MinML = m_MinTL;
 				m_MaxML = m_MaxML * m_diffuseL / 94.37844; 
 
-				// Diffuse-white fast path: compute the tone-mapped white
-				// directly for the requested signal instead of building the
-				// 1024-entry inverse LUT. Tolerance instead of exact equality:
-				// the white patch reaches the display grid-quantized (110/219,
-				// 128/255, 440/876, 514/1023 are all within 3.2e-4 of the
-				// nominal 0.5022283), and the snapped code must take the same
-				// exact path as the nominal constant.
-				if (fabs(valx - 0.5022283) < 5e-4)
-					ii = 1;
-				for (int i=0; i < ii;i++)
+				// The whole table, every time. The diffuse-white fast path that
+				// used to short this to a single entry when valx landed within
+				// 5e-4 of 0.5022283 existed only for the tmWhite call deleted
+				// above; case -10 is now the sole cBT2390 caller and it needs the
+				// full curve to search. Leaving it in was a live hazard: a caller
+				// inverting a luminance inside that window got a one-entry table
+				// and a nearest-neighbour search with exactly one candidate, so it
+				// returned its own input as the answer.
+				for (int i=0; i < 1024; i++)
 				{
-					if (ii != 1)
-						valx = i / 1024.;
+					valx = i / 1024.;
 
 					E1 = valx - pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2);
 					d = pow( (c1 + c2 * pow(m_MaxML/Scale,m1)) / (1 + c3 * pow(m_MaxML/Scale,m1)), m2) - pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2);
 					E1 = E1 / d;
-					// BT.2390's EETF is defined on the normalised [0,1] range. Signals below
-					// the mastering display's black (E1 < 0) or above its peak (E1 > 1) used
-					// to leave E2 outside [0,1] and fall through to the un-tone-mapped PQ
-					// branch below, so near-black got no black lift at all: Y target at 0%
-					// (which returns the display black target) could come out ABOVE Y target
-					// at 1-5%. Clamp instead - sub-black maps to the black target, above-peak
-					// to the peak target - which keeps the tone curve monotonic.
-					E1 = min(max(E1, 0.0), 1.0);
+					// Signals below the mastering display's black make E1 negative, which
+					// left E2 outside [0,1] and fell through to the un-tone-mapped PQ branch
+					// below, so near-black got no black lift at all: Y target at 0% (which
+					// returns the display black target) could come out ABOVE Y target at
+					// 1-5%. Floor E1 so sub-black maps to the black target instead.
+					//
+					// Only the LOW end. E1 > 1 - a signal above the mastering peak - must keep
+					// falling through: when TargetMaxL > MasterMaxL (a display brighter than
+					// the disc, both fields user-editable) maxL > 1, so KS = 1.5*maxL - 0.5 > 1
+					// and the knee never fires. Capping E1 at 1 would then pin every signal
+					// above the mastering peak to PQ(MasterMaxL) - a 1000-nit-mastered disc on
+					// a 4000-nit target flat-lined the whole top quarter of the grid at 1000
+					// instead of tracking PQ up to TargetMaxL. The fall-through returns true PQ
+					// capped at m_MaxTL, which is what the expansion region wants.
+					E1 = max(E1, 0.0);
 					minL = (pow( (c1 + c2 * pow(m_MinTL/Scale,m1)) / (1 + c3 * pow(m_MinTL/Scale,m1)), m2)-pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2)) / d;
 					maxL = (pow( (c1 + c2 * pow(m_MaxTL/Scale,m1)) / (1 + c3 * pow(m_MaxTL/Scale,m1)), m2)-pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2)) / d;
 					KS = 1.5 * maxL - 0.5;
@@ -1721,15 +1732,16 @@ double getL_EOTF ( double valx, CColor White, CColor Black, double g_rel, double
 		break;
 		case -10: //BT.2084/2390 inverse curve look-up
 			{
-				// Build the LUT before reading it. valx == 0 would trip the
-				// `valx == 0 && mode > 4` early return at the top of this function,
-				// coming back before the cBT2390 branch ran and leaving BT2390x/y
-				// untouched - empty on the first such call, so the lookup below
-				// indexed BT2390y[0] out of bounds (MATH-008). Substitute the first
-				// LUT step: it is off the diffuse-white fast path, so the full
-				// 1024-entry table gets built, which is what this nearest-neighbour
-				// search wants anyway. The search still runs on the caller's valx.
-				getL_EOTF(valx > 0.0 ? valx : 1.0 / 1024.0, White, Black, g_rel, split, 5, m_diffuseL, m_MinML, m_MaxML, m_MinTL, m_MaxTL, ToneMap, TRUE, bbc_gamma, b_fact, E2_fact, E2_fact1);
+				// Build the LUT before reading it. The signal passed here is dead - the
+				// builder overwrites valx on every iteration and its return is discarded -
+				// so pass a fixed one rather than the caller's. Forwarding the caller's
+				// value was two bugs: valx == 0 tripped the `valx == 0 && mode > 4` early
+				// return at the top of this function, coming back before the cBT2390 branch
+				// ran and leaving BT2390x/y empty for the lookup below to index out of
+				// bounds (MATH-008); and a value near 0.5022283 used to trip the
+				// diffuse-white fast path into a one-entry table. The search itself still
+				// runs on the caller's valx.
+				getL_EOTF(1.0 / 1024.0, White, Black, g_rel, split, 5, m_diffuseL, m_MinML, m_MaxML, m_MinTL, m_MaxTL, ToneMap, TRUE, bbc_gamma, b_fact, E2_fact, E2_fact1);
 				value = abs(valx - BT2390y[0]);
 				outL = BT2390x[0];
 				for (int i = 0; i < (int)BT2390y.size(); i++)

--- a/libHCFR/Color.cpp
+++ b/libHCFR/Color.cpp
@@ -1503,14 +1503,21 @@ static double BT2390ToneMap ( double valx, double m_diffuseL, double m_MinML, do
 	// which is what the expansion region wants.
 
 	// d <= 0 is degenerate mastering metadata - a mastering peak at or below the
-	// mastering black, which is what blank ST.2086 fields entered as 0 produce
-	// (MasterMinL = MasterMaxL = 0 gives d == 0 exactly). E1, minL and maxL are
-	// then all +/-inf or NaN, and the floor below would turn a sub-black E2 of
-	// -inf into 0 and route a near-zero signal into the tone-map branch, where an
-	// infinite b yields a NaN that min(NaN, cap) resolves to the FULL target peak:
-	// 1000 cd/m2 for a signal of 1e-7. Leave the floor off for those and the
-	// values keep falling through to raw PQ, which is what this returned before
-	// the floor existed.
+	// mastering black. E1, minL and maxL are then all +/-inf or NaN, and the floor
+	// below would turn a sub-black E2 of -inf into 0 and route a near-zero signal
+	// into the tone-map branch, where an infinite b yields a NaN that
+	// min(NaN, cap) resolves to the FULL target peak: 1000 cd/m2 for a signal of
+	// 1e-7. Leave the floor off for those and the values keep falling through to
+	// raw PQ, which is what this returned before the floor existed.
+	//
+	// The References page cannot produce it: MasterMaxL is validated to
+	// [100, 10000] and MasterMinL to [0, 0.5], and over the corners of all four
+	// luminance fields - DiffuseL's [1, 200] included - the smallest d is 0.0733.
+	// It arrives from a hand-edited INI (ColorHCFRConfig.cpp:566 reads the value
+	// back with GetProfileDouble and does not re-validate) or from a direct caller
+	// of this public API. d == 0 exactly for MasterMinL = MasterMaxL = 0; d is
+	// negative and finite for MasterMinL > MasterMaxL, where every normalised
+	// value is a sign-flipped fiction, and the same guard covers it.
 	bool bMappable = (d > 0.0);
 
 	minL = (pow( (c1 + c2 * pow(m_MinTL/Scale,m1)) / (1 + c3 * pow(m_MinTL/Scale,m1)), m2)-pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2)) / d;
@@ -1572,6 +1579,15 @@ static double BT2390ToneMap ( double valx, double m_diffuseL, double m_MinML, do
 
 	if (E2 >= 0.0 && E2 <= 1.0)
 	{
+		// Pre-existing and deliberately left alone: p < 1 makes the slope of the
+		// black lift b(1 - E2)^p diverge as E2 -> 1, so the curve turns over
+		// MID-SCALE rather than near black - neither of the two dead-zone
+		// mechanisms above, and not something the E2 floor touches. Two entrances,
+		// both reachable from the References page: a Black Slope below 0.25
+		// (4 * b_fact < 1), or b > 1 from a high target black against a low diffuse
+		// white. Bounding p at 1 clears it but moves ~400k of 5.9M rows by up to
+		// 6617 cd/m2 - a different change from this one, and listed under "still
+		// not monotonic" rather than fixed here.
 		p = min(1.0 / b, 4 * b_fact);
 		E3 = E2 + b * pow((1.0 - E2),p);
 		E3 = (E3 * d + pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2));
@@ -1733,7 +1749,17 @@ double getL_EOTF ( double valx, CColor White, CColor Black, double g_rel, double
 				// cBT2390 asks for the inverse LUT to be rebuilt rather than for a
 				// value; the table is the product and the return has never been read.
 				// case -10 no longer arrives through here - it calls the builder
-				// directly - so this is only the public API's way in.
+				// directly - so this is only the public API's way in, and nothing in
+				// the tree rebuilds the table this way any more.
+				//
+				// Which is just as well, because getting here is still gated on the
+				// SIGNAL as well as on `ToneMap && mode == 5` promoting to case 10: a
+				// caller asking for a rebuild with valx == 0 takes the
+				// `valx == 0 && mode > 4` early return at the top of this function and
+				// builds nothing, leaving BT2390x/y as they were. That is the half of
+				// MATH-008 case -10 used to be exposed to; it is why case -10 calls
+				// BuildBT2390Table itself rather than coming through here, and it is
+				// what any future caller of this branch has to know.
 				BuildBT2390Table(m_diffuseL, m_MinML, m_MaxML, m_MinTL, m_MaxTL, b_fact, E2_fact, E2_fact1);
 				outL = 0.0;
 			}

--- a/libHCFR/Color.cpp
+++ b/libHCFR/Color.cpp
@@ -1584,7 +1584,6 @@ double getL_EOTF ( double valx, CColor White, CColor Black, double g_rel, double
 			double E1,E2,E4,b,d,KS,T,p;
 			if (!cBT2390)
 			{
-				double tmWhite = getL_EOTF(0.5022283, White, Black, g_rel, split, 5, m_diffuseL, m_MinML, m_MaxML, m_MinTL, m_MaxTL, ToneMap, TRUE, bbc_gamma, b_fact, E2_fact) * 100.0;
 				m_MaxML = m_MaxML * m_diffuseL / 94.37844 ; 
 
 				if (m_MinML > m_MinTL)
@@ -1593,6 +1592,14 @@ double getL_EOTF ( double valx, CColor White, CColor Black, double g_rel, double
 				E1 = valx - pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2);
 				d = pow( (c1 + c2 * pow(m_MaxML/Scale,m1)) / (1 + c3 * pow(m_MaxML/Scale,m1)), m2) - pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2);
 				E1 = E1 / d;
+				// BT.2390's EETF is defined on the normalised [0,1] range. Signals below
+				// the mastering display's black (E1 < 0) or above its peak (E1 > 1) used
+				// to leave E2 outside [0,1] and fall through to the un-tone-mapped PQ
+				// branch below, so near-black got no black lift at all: Y target at 0%
+				// (which returns the display black target) could come out ABOVE Y target
+				// at 1-5%. Clamp instead - sub-black maps to the black target, above-peak
+				// to the peak target - which keeps the tone curve monotonic.
+				E1 = min(max(E1, 0.0), 1.0);
 				minL = (pow( (c1 + c2 * pow(m_MinTL/Scale,m1)) / (1 + c3 * pow(m_MinTL/Scale,m1)), m2)-pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2)) / d;
 				maxL = (pow( (c1 + c2 * pow(m_MaxTL/Scale,m1)) / (1 + c3 * pow(m_MaxTL/Scale,m1)), m2)-pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2)) / d;
 				KS = 1.5 * maxL - 0.5;
@@ -1660,6 +1667,14 @@ double getL_EOTF ( double valx, CColor White, CColor Black, double g_rel, double
 					E1 = valx - pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2);
 					d = pow( (c1 + c2 * pow(m_MaxML/Scale,m1)) / (1 + c3 * pow(m_MaxML/Scale,m1)), m2) - pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2);
 					E1 = E1 / d;
+					// BT.2390's EETF is defined on the normalised [0,1] range. Signals below
+					// the mastering display's black (E1 < 0) or above its peak (E1 > 1) used
+					// to leave E2 outside [0,1] and fall through to the un-tone-mapped PQ
+					// branch below, so near-black got no black lift at all: Y target at 0%
+					// (which returns the display black target) could come out ABOVE Y target
+					// at 1-5%. Clamp instead - sub-black maps to the black target, above-peak
+					// to the peak target - which keeps the tone curve monotonic.
+					E1 = min(max(E1, 0.0), 1.0);
 					minL = (pow( (c1 + c2 * pow(m_MinTL/Scale,m1)) / (1 + c3 * pow(m_MinTL/Scale,m1)), m2)-pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2)) / d;
 					maxL = (pow( (c1 + c2 * pow(m_MaxTL/Scale,m1)) / (1 + c3 * pow(m_MaxTL/Scale,m1)), m2)-pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2)) / d;
 					KS = 1.5 * maxL - 0.5;
@@ -1706,9 +1721,6 @@ double getL_EOTF ( double valx, CColor White, CColor Black, double g_rel, double
 		break;
 		case -10: //BT.2084/2390 inverse curve look-up
 			{
-//				double tmWhite = getL_EOTF(0.5022283, White, Black, g_rel, split, 5, m_diffuseL, m_MinML, m_MaxML, m_MinTL, m_MaxTL, ToneMap, TRUE, bbc_gamma, b_fact, E2_fact, E2_fact1) * 100.0;
-//				m_MaxML = m_MaxML * tmWhite / 94.37844;
-//				m_MaxML = m_MaxML * m_diffuseL / 94.37844 ; 
 				getL_EOTF(valx, White, Black, g_rel, split, 5, m_diffuseL, m_MinML, m_MaxML, m_MinTL, m_MaxTL, ToneMap, TRUE, bbc_gamma, b_fact, E2_fact, E2_fact1);
 				value = abs(valx - BT2390y[0]);
 				outL = BT2390x[0];

--- a/libHCFR/Color.cpp
+++ b/libHCFR/Color.cpp
@@ -1721,7 +1721,15 @@ double getL_EOTF ( double valx, CColor White, CColor Black, double g_rel, double
 		break;
 		case -10: //BT.2084/2390 inverse curve look-up
 			{
-				getL_EOTF(valx, White, Black, g_rel, split, 5, m_diffuseL, m_MinML, m_MaxML, m_MinTL, m_MaxTL, ToneMap, TRUE, bbc_gamma, b_fact, E2_fact, E2_fact1);
+				// Build the LUT before reading it. valx == 0 would trip the
+				// `valx == 0 && mode > 4` early return at the top of this function,
+				// coming back before the cBT2390 branch ran and leaving BT2390x/y
+				// untouched - empty on the first such call, so the lookup below
+				// indexed BT2390y[0] out of bounds (MATH-008). Substitute the first
+				// LUT step: it is off the diffuse-white fast path, so the full
+				// 1024-entry table gets built, which is what this nearest-neighbour
+				// search wants anyway. The search still runs on the caller's valx.
+				getL_EOTF(valx > 0.0 ? valx : 1.0 / 1024.0, White, Black, g_rel, split, 5, m_diffuseL, m_MinML, m_MaxML, m_MinTL, m_MaxTL, ToneMap, TRUE, bbc_gamma, b_fact, E2_fact, E2_fact1);
 				value = abs(valx - BT2390y[0]);
 				outL = BT2390x[0];
 				for (int i = 0; i < (int)BT2390y.size(); i++)

--- a/libHCFR/Color.cpp
+++ b/libHCFR/Color.cpp
@@ -1460,6 +1460,153 @@ double ColorXYZ::GetDeltaLCH(double YWhite, const ColorXYZ& refColor, double YWh
 	return dLight;
 }
 
+//////////////////////////////////////////////////////////////////////////
+// BT.2390 tone map: one signal in, cd/m2 / 100 out.
+//
+// getL_EOTF case 10 used to carry two verbatim copies of this block - one for the
+// scalar path, one inside the loop that builds the inverse LUT - and the copies had
+// already drifted: the knee gate read `E1 <= 1.0` in the scalar copy and `E1 <= 1.2`
+// in the builder. Swept over 14.2M points spanning the mastering / target / slider
+// grid the two gates agree bit for bit (above E1 = 1 the extrapolated knee always
+// exceeds the peak cap, so both clip to the same value), so they are unified here on
+// the spec's own domain. One definition also means the forward oracle (ColorMathTest
+// T11) and the inverse oracle (T12) exercise the same code, not two lookalikes.
+//////////////////////////////////////////////////////////////////////////
+static double BT2390ToneMap ( double valx, double m_diffuseL, double m_MinML, double m_MaxML, double m_MinTL, double m_MaxTL, double b_fact, double E2_fact, double E2_fact1 )
+{
+	double m1=0.1593017578125;
+	double m2=78.84375;
+	double c1=0.8359375;
+	double c2=18.8515625;
+	double c3=18.6875;
+	// The same value getL_EOTF writes into the file-scope Scale before it dispatches.
+	double Scale = m_diffuseL / 94.37844 * 10000.;
+	double E1,E2,E3,E4,b,d,KS,T,p,minL,maxL,outL;
+
+	m_MaxML = m_MaxML * m_diffuseL / 94.37844 ;
+
+	if (m_MinML > m_MinTL)
+		m_MinML = m_MinTL;
+
+	E1 = valx - pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2);
+	d = pow( (c1 + c2 * pow(m_MaxML/Scale,m1)) / (1 + c3 * pow(m_MaxML/Scale,m1)), m2) - pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2);
+	E1 = E1 / d;
+
+	// E1 is deliberately left unclamped at BOTH ends here; the single clamp this
+	// curve needs is on E2, below. The top end especially must keep falling
+	// through: when TargetMaxL > MasterMaxL (a display brighter than the disc,
+	// both fields user-editable) maxL > 1, so KS = 1.5*maxL - 0.5 > 1 and the
+	// knee never fires. Capping E1 at 1 pins every signal above the mastering
+	// peak to PQ(MasterMaxL) - a 1000-nit-mastered disc on a 4000-nit target
+	// flat-lines the whole top quarter of the grid at 1000 instead of tracking
+	// PQ up to TargetMaxL. The fall-through returns true PQ capped at m_MaxTL,
+	// which is what the expansion region wants.
+
+	// d <= 0 is degenerate mastering metadata - a mastering peak at or below the
+	// mastering black, which is what blank ST.2086 fields entered as 0 produce
+	// (MasterMinL = MasterMaxL = 0 gives d == 0 exactly). E1, minL and maxL are
+	// then all +/-inf or NaN, and the floor below would turn a sub-black E2 of
+	// -inf into 0 and route a near-zero signal into the tone-map branch, where an
+	// infinite b yields a NaN that min(NaN, cap) resolves to the FULL target peak:
+	// 1000 cd/m2 for a signal of 1e-7. Leave the floor off for those and the
+	// values keep falling through to raw PQ, which is what this returned before
+	// the floor existed.
+	bool bMappable = (d > 0.0);
+
+	minL = (pow( (c1 + c2 * pow(m_MinTL/Scale,m1)) / (1 + c3 * pow(m_MinTL/Scale,m1)), m2)-pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2)) / d;
+	maxL = (pow( (c1 + c2 * pow(m_MaxTL/Scale,m1)) / (1 + c3 * pow(m_MaxTL/Scale,m1)), m2)-pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2)) / d;
+	KS = 1.5 * maxL - 0.5;
+	b = minL;
+	E2 = E1;
+
+	double slope = 1.0;
+	double lower = KS;
+	double upper = pow( (c1 + c2 * pow(m_MaxML/Scale,m1)) / (1 + c3 * pow(m_MaxML/Scale,m1)), m2);
+	double mmaxL = lower + E2_fact1 / 100 * (upper - lower);
+
+	// Bounded at 1 because pow((1.0-E1),0.75) is NaN for any E1 above it, and that
+	// NaN propagates through slope into E1, where it fails both knee comparisons -
+	// the same place E1 > 1 lands on its own. Same 14.2M-point sweep: identical
+	// output either way, so this only keeps the NaN out of the arithmetic.
+	if (E1 >= mmaxL && E1 <= 1.0 && (upper > lower))
+	{
+			slope = pow((E1 - mmaxL),2.0) * pow((1.0-E1),0.75)*E2_fact*(2.5*pow(mmaxL,2.0)+3*pow(mmaxL,3.0)) + 1.0;
+			E1 = E1 / slope;
+	}
+
+	if (E1 >= KS && E1 <= 1.0)
+	{
+		T = (E1 - KS) / (1.0 - KS);
+		E2 = ((2 * pow(T,3.0) - 3 * pow(T,2.0) + 1.0)*KS + (pow(T,3.0) - 2 * pow(T, 2.0) + T) * (1.0 - KS)) + ( -2.0 * pow(T,3.0) + 3.0 * pow(T,2.0)) * maxL;
+	}
+
+	// The one clamp. BT.2390's black lift, E3 = E2 + b(1-E2)^p, is defined on
+	// E2 in [0,1], and everything that landed outside it used to fall through
+	// to the raw, UN-tone-mapped PQ branch below - so near-black got the
+	// highlight roll-off but no black lift at all, and Y target at 0% (which
+	// returns the display black target directly) could come out ABOVE Y target
+	// at 1-5%. Two different inputs reach that dead zone:
+	//
+	//  - a signal below the mastering display's black, which makes E1 - and
+	//    with the knee not firing, E2 - negative;
+	//  - a target peak below a third of the mastering range, which drives
+	//    KS = 1.5*maxL - 0.5 NEGATIVE, so E1 = 0 clears `E1 >= KS`, enters the
+	//    Hermite knee, and the spline hands back a negative E2 (a 30-nit target
+	//    off a 10000-nit master read 0.300 cd/m2 at 0% and 0.000040 at 1/1024).
+	//
+	// Flooring E2 covers both: the lift then runs with E2 = 0 and maps the
+	// bottom of the curve onto the black target. An equivalent floor on E1
+	// only covers the first, and once this one is here it is measurably inert -
+	// 4.51M points over the mastering / target / slider grid, zero rows differ
+	// with it removed - so there is one clamp, not two.
+	//
+	// LOW end only, and a comparison rather than max(). The MSVC max macro
+	// answers its second operand for a NaN, and this NaN is load-bearing:
+	// TargetMaxL == MasterMaxL puts E1, KS and maxL all at exactly 1 at full
+	// signal, so the knee runs with T = 0/0 and E2 comes out NaN. That NaN has
+	// to keep failing the gate below and reach raw PQ, which is what returns
+	// the display peak at 100%; max(E2, 0.0) floors it to 0 and white reads as
+	// black.
+	if (bMappable && E2 < 0.0)
+		E2 = 0.0;
+
+	if (E2 >= 0.0 && E2 <= 1.0)
+	{
+		p = min(1.0 / b, 4 * b_fact);
+		E3 = E2 + b * pow((1.0 - E2),p);
+		E3 = (E3 * d + pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2));
+		E4 = pow(max(pow(E3,1.0 / m2) - c1,0) / (c2 - c3 * pow(E3, 1.0 / m2)), 1.0 / m1);
+		outL = E4 * 10000. / 100.00 * m_diffuseL / 94.37844;
+		outL = min(outL, m_MaxTL / 100.0 );
+	}
+	else
+	{
+		outL = pow(max(pow(valx,1.0 / m2) - c1,0) / (c2 - c3 * pow(valx, 1.0 / m2)), 1.0 / m1);
+		outL = outL * 10000. / 100.00 * m_diffuseL / 94.37844;
+		outL = min(outL, m_MaxTL / 100.0);
+	}
+
+	return outL;
+}
+
+//////////////////////////////////////////////////////////////////////////
+// Rebuild BT2390x/y, the 1024-entry sample of the forward curve that case -10
+// inverts by nearest-neighbour search. y is in the LUT's own units, nits/10000.
+//////////////////////////////////////////////////////////////////////////
+static void BuildBT2390Table ( double m_diffuseL, double m_MinML, double m_MaxML, double m_MinTL, double m_MaxTL, double b_fact, double E2_fact, double E2_fact1 )
+{
+	BT2390x.clear();
+	BT2390y.clear();
+
+	for (int i=0; i < 1024; i++)
+	{
+		double valx = i / 1024.;
+		double outL = BT2390ToneMap(valx, m_diffuseL, m_MinML, m_MaxML, m_MinTL, m_MaxTL, b_fact, E2_fact, E2_fact1);
+		BT2390x.push_back(valx);
+		BT2390y.push_back(outL / 100.0 / m_diffuseL * 94.37844);
+	}
+}
+
 double getL_EOTF ( double valx, CColor White, CColor Black, double g_rel, double split, int mode, double m_diffuseL, double m_MinML, double m_MaxML, double m_MinTL, double m_MaxTL, bool ToneMap, bool cBT2390, double bbc_gamma, double b_fact, double E2_fact, double E2_fact1)
 {
 	if (valx == 0 && mode > 4) return (ToneMap?m_MinTL / 100.:0.0);
@@ -1537,7 +1684,7 @@ double getL_EOTF ( double valx, CColor White, CColor Black, double g_rel, double
 
 	Lbt = ( a * pow ( (valx + b)<0?0:(valx+b), exp0 ) );
 
-	double value, E3 = 0.0;
+	double value;
 	Scale = m_diffuseL / 94.37844 * 10000.;
 
 	switch (mode)
@@ -1581,167 +1728,31 @@ double getL_EOTF ( double valx, CColor White, CColor Black, double g_rel, double
 			outL = outL_bbc;
 		break;
 		case 10: //BT.2084/2390
-			double E1,E2,E4,b,d,KS,T,p;
-			if (!cBT2390)
+			if (cBT2390)
 			{
-				m_MaxML = m_MaxML * m_diffuseL / 94.37844 ; 
-
-				if (m_MinML > m_MinTL)
-					m_MinML = m_MinTL;
-
-				E1 = valx - pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2);
-				d = pow( (c1 + c2 * pow(m_MaxML/Scale,m1)) / (1 + c3 * pow(m_MaxML/Scale,m1)), m2) - pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2);
-				E1 = E1 / d;
-				// Signals below the mastering display's black make E1 negative, which
-				// left E2 outside [0,1] and fell through to the un-tone-mapped PQ branch
-				// below, so near-black got no black lift at all: Y target at 0% (which
-				// returns the display black target) could come out ABOVE Y target at
-				// 1-5%. Floor E1 so sub-black maps to the black target instead.
-				//
-				// Only the LOW end. E1 > 1 - a signal above the mastering peak - must keep
-				// falling through: when TargetMaxL > MasterMaxL (a display brighter than
-				// the disc, both fields user-editable) maxL > 1, so KS = 1.5*maxL - 0.5 > 1
-				// and the knee never fires. Capping E1 at 1 would then pin every signal
-				// above the mastering peak to PQ(MasterMaxL) - a 1000-nit-mastered disc on
-				// a 4000-nit target flat-lined the whole top quarter of the grid at 1000
-				// instead of tracking PQ up to TargetMaxL. The fall-through returns true PQ
-				// capped at m_MaxTL, which is what the expansion region wants.
-				E1 = max(E1, 0.0);
-				minL = (pow( (c1 + c2 * pow(m_MinTL/Scale,m1)) / (1 + c3 * pow(m_MinTL/Scale,m1)), m2)-pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2)) / d;
-				maxL = (pow( (c1 + c2 * pow(m_MaxTL/Scale,m1)) / (1 + c3 * pow(m_MaxTL/Scale,m1)), m2)-pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2)) / d;
-				KS = 1.5 * maxL - 0.5;
-				b = minL;
-				E2 = E1;
-
-				double slope = 1.0;
-				double lower = KS;
-				double upper = pow( (c1 + c2 * pow(m_MaxML/Scale,m1)) / (1 + c3 * pow(m_MaxML/Scale,m1)), m2);
-				double mmaxL = lower + E2_fact1 / 100 * (upper - lower);
-
-				if (E1 >= mmaxL && (upper > lower))
-				{
-						slope = pow((E1 - mmaxL),2.0) * pow((1.0-E1),0.75)*E2_fact*(2.5*pow(mmaxL,2.0)+3*pow(mmaxL,3.0)) + 1.0;
-						E1 = E1 / slope;
-				}
-
-				if (E1 >= KS && E1 <= 1.0)
-				{
-					T = (E1 - KS) / (1.0 - KS);
-					E2 = ((2 * pow(T,3.0) - 3 * pow(T,2.0) + 1.0)*KS + (pow(T,3.0) - 2 * pow(T, 2.0) + T) * (1.0 - KS)) + ( -2.0 * pow(T,3.0) + 3.0 * pow(T,2.0)) * maxL;
-				}
-
-				if (E2 >= 0.0 && E2 <= 1.0)
-				{
-					p = min(1.0 / b, 4 * b_fact);
-					E3 = E2 + b * pow((1.0 - E2),p);
-					E3 = (E3 * d + pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2)); 
-					E4 = pow(max(pow(E3,1.0 / m2) - c1,0) / (c2 - c3 * pow(E3, 1.0 / m2)), 1.0 / m1);
-					outL = E4 * 10000. / 100.00 * m_diffuseL / 94.37844;
-					outL = min(outL, m_MaxTL / 100.0 );
-				}
-				else
-				{
-					outL = pow(max(pow(valx,1.0 / m2) - c1,0) / (c2 - c3 * pow(valx, 1.0 / m2)), 1.0 / m1);
-					outL = outL * 10000. / 100.00 * m_diffuseL / 94.37844; 
-					outL = min(outL, m_MaxTL / 100.0);
-//					outL = min(outL, 100.0);
-				}
+				// cBT2390 asks for the inverse LUT to be rebuilt rather than for a
+				// value; the table is the product and the return has never been read.
+				// case -10 no longer arrives through here - it calls the builder
+				// directly - so this is only the public API's way in.
+				BuildBT2390Table(m_diffuseL, m_MinML, m_MaxML, m_MinTL, m_MaxTL, b_fact, E2_fact, E2_fact1);
+				outL = 0.0;
 			}
 			else
-			{
-				BT2390x.clear();
-				BT2390y.clear();
-
-				if (m_MinML > m_MinTL)
-					m_MinML = m_MinTL;
-				m_MaxML = m_MaxML * m_diffuseL / 94.37844; 
-
-				// The whole table, every time. The diffuse-white fast path that
-				// used to short this to a single entry when valx landed within
-				// 5e-4 of 0.5022283 existed only for the tmWhite call deleted
-				// above; case -10 is now the sole cBT2390 caller and it needs the
-				// full curve to search. Leaving it in was a live hazard: a caller
-				// inverting a luminance inside that window got a one-entry table
-				// and a nearest-neighbour search with exactly one candidate, so it
-				// returned its own input as the answer.
-				for (int i=0; i < 1024; i++)
-				{
-					valx = i / 1024.;
-
-					E1 = valx - pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2);
-					d = pow( (c1 + c2 * pow(m_MaxML/Scale,m1)) / (1 + c3 * pow(m_MaxML/Scale,m1)), m2) - pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2);
-					E1 = E1 / d;
-					// Signals below the mastering display's black make E1 negative, which
-					// left E2 outside [0,1] and fell through to the un-tone-mapped PQ branch
-					// below, so near-black got no black lift at all: Y target at 0% (which
-					// returns the display black target) could come out ABOVE Y target at
-					// 1-5%. Floor E1 so sub-black maps to the black target instead.
-					//
-					// Only the LOW end. E1 > 1 - a signal above the mastering peak - must keep
-					// falling through: when TargetMaxL > MasterMaxL (a display brighter than
-					// the disc, both fields user-editable) maxL > 1, so KS = 1.5*maxL - 0.5 > 1
-					// and the knee never fires. Capping E1 at 1 would then pin every signal
-					// above the mastering peak to PQ(MasterMaxL) - a 1000-nit-mastered disc on
-					// a 4000-nit target flat-lined the whole top quarter of the grid at 1000
-					// instead of tracking PQ up to TargetMaxL. The fall-through returns true PQ
-					// capped at m_MaxTL, which is what the expansion region wants.
-					E1 = max(E1, 0.0);
-					minL = (pow( (c1 + c2 * pow(m_MinTL/Scale,m1)) / (1 + c3 * pow(m_MinTL/Scale,m1)), m2)-pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2)) / d;
-					maxL = (pow( (c1 + c2 * pow(m_MaxTL/Scale,m1)) / (1 + c3 * pow(m_MaxTL/Scale,m1)), m2)-pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2)) / d;
-					KS = 1.5 * maxL - 0.5;
-					b = minL;
-					E2 = E1;
-
-					double slope = 1.0;
-					double lower = KS;
-					double upper = pow( (c1 + c2 * pow(m_MaxML/Scale,m1)) / (1 + c3 * pow(m_MaxML/Scale,m1)), m2);
-					double mmaxL = lower + E2_fact1 / 100 * (upper - lower);
-
-					if (E1 >= mmaxL && (upper > lower))
-					{
-							slope = pow((E1 - mmaxL),2.0) * pow((1.0-E1),0.75)*E2_fact*(2.5*pow(mmaxL,2.0)+3*pow(mmaxL,3.0)) + 1.0;
-							E1 = E1 / slope;
-					}
-
-					if (E1 >= KS && E1 <= 1.2)
-					{
-						T = (E1 - KS) / (1.0 - KS);
-						E2 = ((2 * pow(T,3.0) - 3 * pow(T,2.0) + 1.0)*KS + (pow(T,3.0) - 2 * pow(T, 2.0) + T) * (1.0 - KS))  + ( -2.0 * pow(T,3.0) + 3.0 * pow(T,2.0)) * maxL;
-					}
-			
-					if (E2 >= 0.0 && E2 <= 1.0)
-					{
-						p = min(1.0 / b, 4 * b_fact); //Hoech mod
-						E3 = E2 + b * pow((1.0 - E2),p);
-						E3 = (E3 * d + pow( (c1 + c2 * pow(m_MinML/Scale,m1)) / (1 + c3 * pow(m_MinML/Scale,m1)), m2)); 
-						E4 = pow(max(pow(E3,1.0 / m2) - c1,0) / (c2 - c3 * pow(E3, 1.0 / m2)), 1.0 / m1);
-						outL = E4 * 10000. / 100.00 * m_diffuseL / 94.37844;
-						outL = min(outL, m_MaxTL / 100.0);
-					}
-					else
-					{
-						outL = pow(max(pow(valx,1.0 / m2) - c1,0) / (c2 - c3 * pow(valx, 1.0 / m2)), 1.0 / m1);
-						outL = outL * 10000. / 100.00 * m_diffuseL / 94.37844; 
-						outL = min(outL, m_MaxTL / 100.0);
-//						outL = min(outL, 100.0);
-					}
-					BT2390x.push_back(valx);
-					BT2390y.push_back(outL / 100.0 / m_diffuseL * 94.37844);
-				}
-			}
+				outL = BT2390ToneMap(valx, m_diffuseL, m_MinML, m_MaxML, m_MinTL, m_MaxTL, b_fact, E2_fact, E2_fact1);
 		break;
 		case -10: //BT.2084/2390 inverse curve look-up
 			{
-				// Build the LUT before reading it. The signal passed here is dead - the
-				// builder overwrites valx on every iteration and its return is discarded -
-				// so pass a fixed one rather than the caller's. Forwarding the caller's
-				// value was two bugs: valx == 0 tripped the `valx == 0 && mode > 4` early
-				// return at the top of this function, coming back before the cBT2390 branch
-				// ran and leaving BT2390x/y empty for the lookup below to index out of
-				// bounds (MATH-008); and a value near 0.5022283 used to trip the
-				// diffuse-white fast path into a one-entry table. The search itself still
-				// runs on the caller's valx.
-				getL_EOTF(1.0 / 1024.0, White, Black, g_rel, split, 5, m_diffuseL, m_MinML, m_MaxML, m_MinTL, m_MaxTL, ToneMap, TRUE, bbc_gamma, b_fact, E2_fact, E2_fact1);
+				// Build the table, then search it. This used to re-enter getL_EOTF with
+				// mode 5 and cBT2390 = TRUE, which made the build depend on getting past
+				// the top-of-function guards and on `ToneMap && mode == 5` promoting to
+				// case 10. Both let it through without a table: a valx of 0 tripped the
+				// `valx == 0 && mode > 4` early return and came back before the branch
+				// ran (MATH-008), and a caller reaching mode -10 with ToneMap false
+				// skipped the promotion entirely - either way the search below indexed
+				// BT2390y[0] on an empty vector. Calling the builder directly removes the
+				// dependency, along with the 17-argument self-call and the dummy signal
+				// it had to pass. The search still runs on the caller's valx.
+				BuildBT2390Table(m_diffuseL, m_MinML, m_MaxML, m_MinTL, m_MaxTL, b_fact, E2_fact, E2_fact1);
 				value = abs(valx - BT2390y[0]);
 				outL = BT2390x[0];
 				for (int i = 0; i < (int)BT2390y.size(); i++)

--- a/tests/ColorMathTest/ColorMathTest.cpp
+++ b/tests/ColorMathTest/ColorMathTest.cpp
@@ -789,8 +789,8 @@ static void RunT10()
 //
 // The invariant is the weakest thing that catches it and stays true of any sane
 // EOTF: an electro-optical transfer function must be non-decreasing in the
-// signal. Verified by mutation - dropping the E1 clamp in Color.cpp fails 768
-// of the 1440 configurations swept here.
+// signal. Verified by mutation - dropping the forward-path E1 clamp in Color.cpp
+// fails 1440 of the 2160 configurations swept here.
 //
 // The grid deliberately mixes MasterMinL above and below TargetMinL: the
 // dead zone only opens when the mastering black is nonzero, and case 10's own

--- a/tests/ColorMathTest/ColorMathTest.cpp
+++ b/tests/ColorMathTest/ColorMathTest.cpp
@@ -805,6 +805,20 @@ static void RunT10()
 // sub-black dead zone only opens when the mastering black is nonzero, and
 // BT2390ToneMap's own `if (m_MinML > m_MinTL) m_MinML = m_MinTL` clamp shrinks
 // it again from the other side.
+//
+// Where the grid deliberately does NOT go. The invariant below is stated
+// absolutely, but it is only swept over a band where it currently holds: the
+// black lift's exponent p = min(1/b, 4*BS) falls under 1 when Black Slope drops
+// below 0.25, or when b exceeds 1 from a high target black against a low
+// diffuse white. p < 1 makes the lift's slope diverge as E2 -> 1 and turns the
+// curve over MID-SCALE - a third non-monotonic band, distinct from both
+// near-black mechanisms above, pre-existing and untouched by the E2 floor (225
+// of 5760 UI-reachable configurations, every one at BS = 0.1, and identical on
+// main). BS is pinned to {1.0, 2.0} and diffuse to {94.37844, 203} to stay
+// clear of both entrances; widen either and T11 becomes a test of that band
+// instead of this fix. (203 is BT.2408's reference white and sits just above
+// the References page's own DiffuseL cap of 200, so it reaches libHCFR only
+// through an INI - a separate question from what this test covers.)
 //////////////////////////////////////////////////////////////////////////
 static void RunT11()
 {
@@ -829,6 +843,7 @@ static void RunT11()
     //    full white reads as black. 1000 is the same equality lower down, where
     //    PQ(MasterMaxL) < 1 keeps E1 away from the singular point.
     static const double maxTLs[] = { 30.0, 120.0, 400.0, 1000.0, 2000.0, 10000.0 };
+    // Both pinned clear of the p < 1 band described above, not for coverage.
     static const double diffuses[] = { 94.37844, 203.0 };
     static const double bFacts[] = { 1.0, 2.0 };          // m_BT2390_BS
     static const double e2Facts[] = { 0.0, 1.0 };         // m_BT2390_WS
@@ -887,9 +902,13 @@ static void RunT11()
     }
     printf("  %d tone-map configurations swept\n", configs);
 
-    // Degenerate mastering metadata. MasterMaxL = 0 - blank ST.2086 fields typed
-    // in as 0 - makes the PQ span d zero or negative, so E1, minL and maxL all
-    // come out +/-inf or NaN. The E2 floor has to stay OFF for those: an infinite
+    // Degenerate mastering metadata. MasterMaxL = 0 makes the PQ span d zero or
+    // negative, so E1, minL and maxL all come out +/-inf or NaN. The References
+    // page cannot produce it - it validates MasterMaxL to [100, 10000] and
+    // MasterMinL to [0, 0.5], and the smallest d over the corners of all four
+    // luminance fields is 0.0733 - so it arrives from a hand-edited INI, which
+    // is read back without re-validation, or from a direct caller of the public
+    // getL_EOTF. The E2 floor has to stay OFF for those: an infinite
     // b turns the black lift into a NaN, and min(NaN, cap) resolves to the full
     // target peak, so a signal of 1e-7 returned the whole 1000-nit target peak
     // while 1e-5 next door returned 4e-9. Sampled on a sub-grid ladder because

--- a/tests/ColorMathTest/ColorMathTest.cpp
+++ b/tests/ColorMathTest/ColorMathTest.cpp
@@ -804,7 +804,10 @@ static void RunT11()
     static const double minMLs[] = { 0.0, 0.0001, 0.001, 0.005, 0.05, 0.5 };
     static const double maxMLs[] = { 1000.0, 4000.0, 10000.0 };
     static const double minTLs[] = { 0.0, 0.005, 0.05, 0.1, 0.3 };
-    static const double maxTLs[] = { 120.0, 400.0 };
+    // 2000 is above the 1000-nit mastering peak on purpose: that is the
+    // EXPANSION region (a display brighter than the disc), which the original
+    // grid never entered and where a bad clamp flat-lines the top of the curve.
+    static const double maxTLs[] = { 120.0, 400.0, 2000.0 };
     static const double diffuses[] = { 94.37844, 203.0 };
     static const double bFacts[] = { 1.0, 2.0 };          // m_BT2390_BS
     static const double e2Facts[] = { 0.0, 1.0 };         // m_BT2390_WS
@@ -842,6 +845,24 @@ static void RunT11()
             }
             prev = y;
         }
+
+        // Peak reach. Monotonicity alone cannot see a curve that goes FLAT
+        // early - that is still non-decreasing - so pin the endpoint too: full
+        // signal must land on the display's peak, whatever the mastering peak
+        // was. Clamping E1's top end broke exactly this, pinning everything
+        // above the mastering peak to PQ(MasterMaxL): a 1000-nit-mastered disc
+        // on a 2000-nit target returned 1000 here instead of 2000, flat across
+        // the whole top of the grid, with T11 none the wiser.
+        const double peak = getL_EOTF(1.0, noDataColor, noDataColor, 0.0, 0.0, 5,
+                                      diffuses[e], minMLs[a], maxMLs[b],
+                                      minTLs[c], maxTLs[d], true, false, 1.2,
+                                      bFacts[f], e2Facts[g], 25.0) * 100.0;
+        if (fabs(peak - maxTLs[d]) > 1e-6 * maxTLs[d])
+            Fail("T11 MasterMin=%g MasterMax=%g TargetMin=%g TargetMax=%g "
+                 "diffuse=%g BS=%g WS=%g: full signal reaches %.4f cd/m2, "
+                 "expected the display peak %.4f",
+                 minMLs[a], maxMLs[b], minTLs[c], maxTLs[d], diffuses[e],
+                 bFacts[f], e2Facts[g], peak, maxTLs[d]);
     }
     printf("  %d tone-map configurations swept\n", configs);
 }
@@ -932,6 +953,32 @@ static void RunT12()
             }
         }
     }
+    // (3) The old diffuse-white fast path. Building the table used to short to a
+    // SINGLE entry whenever the signal handed to the builder landed within 5e-4
+    // of 0.5022283, leaving the nearest-neighbour search one candidate and making
+    // it hand back its own input as the answer. The window is a real luminance -
+    // the LUT is in nits/10000, so it is ~5022 cd/m2, inside a 10000-nit target -
+    // and it was reachable from the near-white autoscale in Measure.cpp, where the
+    // inverted value is a free-ranging measured luminance. Walk straight across it.
+    {
+        const double lo = 0.5022283 - 8e-4, hi = 0.5022283 + 8e-4;
+        for (int i = 0; i <= 16; i++)
+        {
+            const double y = lo + (hi - lo) * i / 16.0;
+            const double sig = getL_EOTF(y, noDataColor, noDataColor, 0.0, 0.0, -5,
+                                         94.37844, 0.0, 10000.0, 0.0, 10000.0,
+                                         true, false, 1.2, 1.0, 0.0, 25.0);
+            const double y2 = getL_EOTF(sig, noDataColor, noDataColor, 0.0, 0.0, 5,
+                                        94.37844, 0.0, 10000.0, 0.0, 10000.0,
+                                        true, false, 1.2, 1.0, 0.0, 25.0) / 100.0;
+            // one LUT step is 1/1024 in signal; allow the luminance that spans
+            if (fabs(y2 - y) > 0.02 * y)
+                Fail("T12 fast-path window: inverse of %.7f returned signal %.6f, "
+                     "which forwards to %.7f (off by %.3g) - one-entry table?",
+                     y, sig, y2, fabs(y2 - y));
+        }
+    }
+
     printf("  %d inverse configurations swept\n", configs);
 }
 

--- a/tests/ColorMathTest/ColorMathTest.cpp
+++ b/tests/ColorMathTest/ColorMathTest.cpp
@@ -10,7 +10,8 @@
 // T2/T3/T4/T6 dump deterministic tables and compare them exactly against checked-in goldens.
 // Everything else is a self-contained oracle needing no golden file: T1 carries a frozen
 // copy of the legacy quantizer, T5/T7/T8/T9 assert quantizer and generator invariants,
-// T10 asserts gamut-basis consistency, and T11 asserts BT.2390 tone-map monotonicity. The .chc round-trip originally planned for the T7
+// T10 asserts gamut-basis consistency, T11 asserts BT.2390 tone-map monotonicity,
+// and T12 asserts the BT.2390 inverse LUT round-trips and never faults on an empty table. The .chc round-trip originally planned for the T7
 // slot needs app-level linkage and is deliberately still not in this console harness.
 
 #include <afx.h>
@@ -808,7 +809,9 @@ static void RunT11()
     static const double bFacts[] = { 1.0, 2.0 };          // m_BT2390_BS
     static const double e2Facts[] = { 0.0, 1.0 };         // m_BT2390_WS
 
-    const int steps = 400;
+    // Sample on the inverse LUT's own 1/1024 grid rather than a coarser one, so
+    // the oracle's resolution is not the thing that decides what it can see.
+    const int steps = 1024;
     int configs = 0;
 
     for (int a = 0; a < _countof(minMLs); a++)
@@ -844,6 +847,95 @@ static void RunT11()
 }
 
 //////////////////////////////////////////////////////////////////////////
+// T12 - BT.2390 inverse-LUT oracle (pure assertion, no golden file).
+//
+// T11 only reaches the FORWARD direct path: its getL_EOTF call passes
+// cBT2390 = false, so the second copy of the E1 clamp - the one inside the
+// branch that builds BT2390x/y - and all of case -10 had no coverage at all.
+// This closes that, and pins two things the inverse side gets wrong on its own:
+//
+// 1. MATH-008, the empty-LUT fault. case -10 builds the table by re-entering
+//    getL_EOTF with mode 5, but a valx of 0 trips the `valx == 0 && mode > 4`
+//    early return at the top of the function, which comes back BEFORE the
+//    cBT2390 branch runs. The vectors are then whatever they already held -
+//    empty on the first such call - and the nearest-neighbour search below
+//    reads BT2390y[0] out of bounds. It went unnoticed because the dead
+//    tmWhite call in the forward branch happened to leave exactly one entry
+//    behind on every forward tone-mapped call; deleting that dead code (same
+//    commit) exposed the fault, so this test is what keeps it dead.
+//    Verified by mutation: reverting the case -10 build call to a bare
+//    `getL_EOTF(valx, ...)` aborts this test with "vector subscript out of
+//    range" on the first configuration.
+//
+// 2. Round trip, stated in LUMINANCE: forward(inverse(y)) == y. Signal ->
+//    signal is the wrong invariant here, because the tone curve is not
+//    injective - the clamp deliberately maps every signal below the mastering
+//    black onto the black target, and the peak cap flattens the highlights the
+//    same way, so several signals share one luminance and the inverse is
+//    legitimately free to return any of them. What must hold is that whichever
+//    it returns lands back on the luminance asked for. The LUT stores
+//    nits/10000 while mode 5 returns nits/100, hence the /100 bridge below.
+//////////////////////////////////////////////////////////////////////////
+static void RunT12()
+{
+    printf("T12 BT.2390 inverse-LUT oracle...\n");
+
+    static const double minMLs[] = { 0.0, 0.005, 0.05 };
+    static const double maxMLs[] = { 1000.0, 4000.0 };
+    static const double minTLs[] = { 0.0, 0.005, 0.05, 0.1 };
+    static const double maxTLs[] = { 120.0, 1000.0 };
+
+    int configs = 0;
+
+    for (int a = 0; a < _countof(minMLs); a++)
+    for (int b = 0; b < _countof(maxMLs); b++)
+    for (int c = 0; c < _countof(minTLs); c++)
+    for (int d = 0; d < _countof(maxTLs); d++)
+    {
+        configs++;
+
+        // (1) MATH-008 guard. Deliberately the FIRST getL_EOTF call for this
+        // configuration, so the LUT is stale or empty exactly as it would be
+        // when something inverts before anything has run the forward curve.
+        const double zero = getL_EOTF(0.0, noDataColor, noDataColor, 0.0, 0.0, -5,
+                                      94.37844, minMLs[a], maxMLs[b], minTLs[c], maxTLs[d],
+                                      true, false, 1.2, 1.0, 0.0, 25.0);
+        if (zero != 0.0)
+            Fail("T12 MasterMin=%g MasterMax=%g TargetMin=%g TargetMax=%g: inverse of 0 "
+                 "returned %.6f, expected 0 (the signal that produces black)",
+                 minMLs[a], maxMLs[b], minTLs[c], maxTLs[d], zero);
+
+        // (2) forward -> inverse round trip over near black
+        for (int i = 0; i <= 40; i++)
+        {
+            const double sig = (double)i / 1024.0;
+            const double raw = getL_EOTF(sig, noDataColor, noDataColor, 0.0, 0.0, 5,
+                                         94.37844, minMLs[a], maxMLs[b], minTLs[c], maxTLs[d],
+                                         true, false, 1.2, 1.0, 0.0, 25.0);
+            const double y    = raw / 100.0;                  // LUT units, nits/10000
+            const double back = getL_EOTF(y, noDataColor, noDataColor, 0.0, 0.0, -5,
+                                          94.37844, minMLs[a], maxMLs[b], minTLs[c], maxTLs[d],
+                                          true, false, 1.2, 1.0, 0.0, 25.0);
+            const double y2   = getL_EOTF(back, noDataColor, noDataColor, 0.0, 0.0, 5,
+                                          94.37844, minMLs[a], maxMLs[b], minTLs[c], maxTLs[d],
+                                          true, false, 1.2, 1.0, 0.0, 25.0) / 100.0;
+            // sig sits on the LUT's own grid, so the search should land on an
+            // exact table entry; only floating-point dust is allowed.
+            const double tol = 1e-12 + 1e-6 * fabs(y);
+            if (fabs(y2 - y) > tol)
+            {
+                Fail("T12 MasterMin=%g MasterMax=%g TargetMin=%g TargetMax=%g: signal %.6f "
+                     "-> %.8f -> inverse %.6f -> %.8f (off by %.3g, tolerance %.3g)",
+                     minMLs[a], maxMLs[b], minTLs[c], maxTLs[d], sig, y, back, y2,
+                     fabs(y2 - y), tol);
+                break;      // one report per configuration
+            }
+        }
+    }
+    printf("  %d inverse configurations swept\n", configs);
+}
+
+//////////////////////////////////////////////////////////////////////////
 
 int main(int argc, char* argv[])
 {
@@ -871,6 +963,7 @@ int main(int argc, char* argv[])
     RunT9();
     RunT10();
     RunT11();
+    RunT12();
 
     if (g_failures)
     {

--- a/tests/ColorMathTest/ColorMathTest.cpp
+++ b/tests/ColorMathTest/ColorMathTest.cpp
@@ -9,8 +9,8 @@
 //
 // T2/T3/T4/T6 dump deterministic tables and compare them exactly against checked-in goldens.
 // Everything else is a self-contained oracle needing no golden file: T1 carries a frozen
-// copy of the legacy quantizer, T5/T7/T8/T9 assert quantizer and generator invariants, and
-// T10 asserts gamut-basis consistency. The .chc round-trip originally planned for the T7
+// copy of the legacy quantizer, T5/T7/T8/T9 assert quantizer and generator invariants,
+// T10 asserts gamut-basis consistency, and T11 asserts BT.2390 tone-map monotonicity. The .chc round-trip originally planned for the T7
 // slot needs app-level linkage and is deliberately still not in this console harness.
 
 #include <afx.h>
@@ -771,6 +771,79 @@ static void RunT10()
 }
 
 //////////////////////////////////////////////////////////////////////////
+// T11 - BT.2390 tone-map monotonicity oracle (pure assertion, no golden file).
+//
+// Closes the near-black half of the tone-mapping curve, which no dE-based
+// harness can see: /accuracytest runs every tone-map combo with MasterMinL and
+// TargetMinL pinned to 0, and a reference that is wrong in exactly the same way
+// as the modelled sensor still reads dE 0.000.
+//
+// The bug this pins: getL_EOTF case 10 normalises the signal against the
+// mastering display's black (E1 = (E - PQ(MinML)) / d) and then only applies
+// BT.2390's black lift when E2 landed inside [0,1]. Anything below the
+// mastering black fell out of that window and dropped to the raw, UN-tone-mapped
+// PQ curve, so the near-black targets got no lift at all while the highlights
+// were still rolled off - Y target at 0% (which returns the display black
+// target directly) could come out ABOVE Y target at 1-5%.
+//
+// The invariant is the weakest thing that catches it and stays true of any sane
+// EOTF: an electro-optical transfer function must be non-decreasing in the
+// signal. Verified by mutation - dropping the E1 clamp in Color.cpp fails 768
+// of the 1440 configurations swept here.
+//
+// The grid deliberately mixes MasterMinL above and below TargetMinL: the
+// dead zone only opens when the mastering black is nonzero, and case 10's own
+// `if (m_MinML > m_MinTL) m_MinML = m_MinTL` clamp shrinks it again from the
+// other side.
+//////////////////////////////////////////////////////////////////////////
+static void RunT11()
+{
+    printf("T11 BT.2390 tone-map monotonicity oracle...\n");
+
+    static const double minMLs[] = { 0.0, 0.0001, 0.001, 0.005, 0.05, 0.5 };
+    static const double maxMLs[] = { 1000.0, 4000.0, 10000.0 };
+    static const double minTLs[] = { 0.0, 0.005, 0.05, 0.1, 0.3 };
+    static const double maxTLs[] = { 120.0, 400.0 };
+    static const double diffuses[] = { 94.37844, 203.0 };
+    static const double bFacts[] = { 1.0, 2.0 };          // m_BT2390_BS
+    static const double e2Facts[] = { 0.0, 1.0 };         // m_BT2390_WS
+
+    const int steps = 400;
+    int configs = 0;
+
+    for (int a = 0; a < _countof(minMLs); a++)
+    for (int b = 0; b < _countof(maxMLs); b++)
+    for (int c = 0; c < _countof(minTLs); c++)
+    for (int d = 0; d < _countof(maxTLs); d++)
+    for (int e = 0; e < _countof(diffuses); e++)
+    for (int f = 0; f < _countof(bFacts); f++)
+    for (int g = 0; g < _countof(e2Facts); g++)
+    {
+        configs++;
+        double prev = -1.0;
+        for (int i = 0; i <= steps; i++)
+        {
+            const double valx = (double)i / steps;
+            const double y = getL_EOTF(valx, noDataColor, noDataColor, 0.0, 0.0, 5,
+                                       diffuses[e], minMLs[a], maxMLs[b],
+                                       minTLs[c], maxTLs[d], true, false, 1.2,
+                                       bFacts[f], e2Facts[g], 25.0) * 100.0;
+            if (y < prev - 1e-9)
+            {
+                Fail("T11 MasterMin=%g MasterMax=%g TargetMin=%g TargetMax=%g "
+                     "diffuse=%g BS=%g WS=%g: tone-mapped PQ target falls from "
+                     "%.6f to %.6f cd/m2 at signal %.4f",
+                     minMLs[a], maxMLs[b], minTLs[c], maxTLs[d], diffuses[e],
+                     bFacts[f], e2Facts[g], prev, y, valx);
+                break;      // one report per configuration
+            }
+            prev = y;
+        }
+    }
+    printf("  %d tone-map configurations swept\n", configs);
+}
+
+//////////////////////////////////////////////////////////////////////////
 
 int main(int argc, char* argv[])
 {
@@ -797,6 +870,7 @@ int main(int argc, char* argv[])
     RunT8();
     RunT9();
     RunT10();
+    RunT11();
 
     if (g_failures)
     {

--- a/tests/ColorMathTest/ColorMathTest.cpp
+++ b/tests/ColorMathTest/ColorMathTest.cpp
@@ -779,23 +779,32 @@ static void RunT10()
 // TargetMinL pinned to 0, and a reference that is wrong in exactly the same way
 // as the modelled sensor still reads dE 0.000.
 //
-// The bug this pins: getL_EOTF case 10 normalises the signal against the
-// mastering display's black (E1 = (E - PQ(MinML)) / d) and then only applies
-// BT.2390's black lift when E2 landed inside [0,1]. Anything below the
-// mastering black fell out of that window and dropped to the raw, UN-tone-mapped
-// PQ curve, so the near-black targets got no lift at all while the highlights
-// were still rolled off - Y target at 0% (which returns the display black
-// target directly) could come out ABOVE Y target at 1-5%.
+// The bug this pins: BT2390ToneMap normalises the signal against the mastering
+// display's black (E1 = (E - PQ(MinML)) / d), runs the knee, and then only
+// applies BT.2390's black lift when E2 landed inside [0,1]. Anything that fell
+// out of that window dropped to the raw, UN-tone-mapped PQ curve, so near-black
+// got no lift at all while the highlights were still rolled off - Y target at 0%
+// (which returns the display black target directly) could come out ABOVE Y
+// target at 1-5%. Two inputs land in that dead zone: a signal below the
+// mastering black (negative E1, so negative E2), and a target peak below a third
+// of the mastering range (negative KS, so the knee itself returns a negative
+// E2). The E2 floor in Color.cpp covers both.
 //
 // The invariant is the weakest thing that catches it and stays true of any sane
 // EOTF: an electro-optical transfer function must be non-decreasing in the
-// signal. Verified by mutation - dropping the forward-path E1 clamp in Color.cpp
-// fails 1440 of the 2160 configurations swept here.
+// signal. Verified by mutation - dropping the E2 floor in Color.cpp fails 2880
+// of the 4320 configurations swept here (and 54 of T12's 72). Four more
+// mutations of the same block are killed from this test: writing the floor as
+// max(E2, 0.0) fails 240 (the NaN at TargetMaxL == MasterMaxL == 10000 becomes
+// 0, so full white reads as black), clamping E1's top end fails 600 on the peak
+// check below, dropping the d > 0 guard fails 10 of the 18 degenerate configs,
+// and flooring E1 rather than E2 - the narrower fix, which covers only the
+// sub-black half - still fails 92.
 //
 // The grid deliberately mixes MasterMinL above and below TargetMinL: the
-// dead zone only opens when the mastering black is nonzero, and case 10's own
-// `if (m_MinML > m_MinTL) m_MinML = m_MinTL` clamp shrinks it again from the
-// other side.
+// sub-black dead zone only opens when the mastering black is nonzero, and
+// BT2390ToneMap's own `if (m_MinML > m_MinTL) m_MinML = m_MinTL` clamp shrinks
+// it again from the other side.
 //////////////////////////////////////////////////////////////////////////
 static void RunT11()
 {
@@ -804,10 +813,22 @@ static void RunT11()
     static const double minMLs[] = { 0.0, 0.0001, 0.001, 0.005, 0.05, 0.5 };
     static const double maxMLs[] = { 1000.0, 4000.0, 10000.0 };
     static const double minTLs[] = { 0.0, 0.005, 0.05, 0.1, 0.3 };
-    // 2000 is above the 1000-nit mastering peak on purpose: that is the
-    // EXPANSION region (a display brighter than the disc), which the original
-    // grid never entered and where a bad clamp flat-lines the top of the curve.
-    static const double maxTLs[] = { 120.0, 400.0, 2000.0 };
+    // Three of these columns exist for a specific regime, not for coverage:
+    //  - 2000 is above the 1000-nit mastering peak, the EXPANSION region (a
+    //    display brighter than the disc), where a clamp on E1's top end
+    //    flat-lines the whole top of the curve.
+    //  - 30 is low enough against these mastering peaks to drive
+    //    KS = 1.5*maxL - 0.5 NEGATIVE, which lets the Hermite knee return a
+    //    negative E2 at signal 0 and, before the E2 floor, dropped the bottom
+    //    of the curve to raw PQ - the same 0%-above-1% inversion from a second
+    //    mechanism. Without this column every config here has KS > 0.
+    //  - 10000 equals a mastering peak AND is the top of the PQ range, the one
+    //    place E1, KS and maxL all land on exactly 1 at full signal, so the knee
+    //    runs with T = 0/0 and E2 comes out NaN. That NaN has to keep falling
+    //    through to raw PQ; a floor written as max(E2, 0.0) answers 0 for it and
+    //    full white reads as black. 1000 is the same equality lower down, where
+    //    PQ(MasterMaxL) < 1 keeps E1 away from the singular point.
+    static const double maxTLs[] = { 30.0, 120.0, 400.0, 1000.0, 2000.0, 10000.0 };
     static const double diffuses[] = { 94.37844, 203.0 };
     static const double bFacts[] = { 1.0, 2.0 };          // m_BT2390_BS
     static const double e2Facts[] = { 0.0, 1.0 };         // m_BT2390_WS
@@ -865,28 +886,74 @@ static void RunT11()
                  bFacts[f], e2Facts[g], peak, maxTLs[d]);
     }
     printf("  %d tone-map configurations swept\n", configs);
+
+    // Degenerate mastering metadata. MasterMaxL = 0 - blank ST.2086 fields typed
+    // in as 0 - makes the PQ span d zero or negative, so E1, minL and maxL all
+    // come out +/-inf or NaN. The E2 floor has to stay OFF for those: an infinite
+    // b turns the black lift into a NaN, and min(NaN, cap) resolves to the full
+    // target peak, so a signal of 1e-7 returned the whole 1000-nit target peak
+    // while 1e-5 next door returned 4e-9. Sampled on a sub-grid ladder because
+    // that is where it lives - the coarsest failing signal is well under 1/1024 -
+    // and starting above 0, since x = 0 takes the early return at the top of
+    // getL_EOTF and is the separate, pre-existing 0%-above-1% case this does not
+    // touch.
+    {
+        static const double degenMinMLs[] = { 0.0, 0.05, 0.5 };
+        static const double degenMinTLs[] = { 0.0, 0.005, 0.05 };
+        static const double degenMaxTLs[] = { 120.0, 1000.0 };
+        static const double ladder[] = { 1e-9, 1e-8, 1e-7, 1e-6, 1e-5, 1e-4, 1e-3 };
+        int degen = 0;
+        for (int a = 0; a < _countof(degenMinMLs); a++)
+        for (int c = 0; c < _countof(degenMinTLs); c++)
+        for (int d = 0; d < _countof(degenMaxTLs); d++)
+        {
+            degen++;
+            double prev = -1.0;
+            for (int i = 0; i < _countof(ladder); i++)
+            {
+                const double y = getL_EOTF(ladder[i], noDataColor, noDataColor, 0.0, 0.0, 5,
+                                           94.37844, degenMinMLs[a], 0.0,
+                                           degenMinTLs[c], degenMaxTLs[d], true, false, 1.2,
+                                           1.0, 0.0, 25.0) * 100.0;
+                if (y < prev - 1e-12)
+                {
+                    Fail("T11 degenerate MasterMin=%g MasterMax=0 TargetMin=%g TargetMax=%g: "
+                         "target falls from %.9f to %.9f cd/m2 at signal %g",
+                         degenMinMLs[a], degenMinTLs[c], degenMaxTLs[d], prev, y, ladder[i]);
+                    break;
+                }
+                prev = y;
+            }
+        }
+        printf("  %d degenerate-metadata configurations swept\n", degen);
+    }
 }
 
 //////////////////////////////////////////////////////////////////////////
 // T12 - BT.2390 inverse-LUT oracle (pure assertion, no golden file).
 //
-// T11 only reaches the FORWARD direct path: its getL_EOTF call passes
-// cBT2390 = false, so the second copy of the E1 clamp - the one inside the
-// branch that builds BT2390x/y - and all of case -10 had no coverage at all.
-// This closes that, and pins two things the inverse side gets wrong on its own:
+// T11 only reaches the FORWARD direction: its getL_EOTF call passes a positive
+// mode, so case -10 - the LUT build and the nearest-neighbour search over it -
+// had no coverage at all. This closes that. The per-signal math is now one
+// shared BT2390ToneMap, so both oracles pin the same curve rather than two
+// copies of it, but everything around it on the inverse side is only reachable
+// from here, and it gets two things wrong on its own:
 //
-// 1. MATH-008, the empty-LUT fault. case -10 builds the table by re-entering
-//    getL_EOTF with mode 5, but a valx of 0 trips the `valx == 0 && mode > 4`
-//    early return at the top of the function, which comes back BEFORE the
-//    cBT2390 branch runs. The vectors are then whatever they already held -
-//    empty on the first such call - and the nearest-neighbour search below
-//    reads BT2390y[0] out of bounds. It went unnoticed because the dead
-//    tmWhite call in the forward branch happened to leave exactly one entry
-//    behind on every forward tone-mapped call; deleting that dead code (same
-//    commit) exposed the fault, so this test is what keeps it dead.
-//    Verified by mutation: reverting the case -10 build call to a bare
-//    `getL_EOTF(valx, ...)` aborts this test with "vector subscript out of
-//    range" on the first configuration.
+// 1. MATH-008, the empty-LUT fault. case -10 used to build the table by
+//    re-entering getL_EOTF with mode 5 and cBT2390 = TRUE, which meant the
+//    build had to survive the guards at the top of that function and the
+//    `ToneMap && mode == 5` promotion to case 10. Two ways through without a
+//    table: a valx of 0 tripped the `valx == 0 && mode > 4` early return and
+//    came back BEFORE the cBT2390 branch ran, and a caller arriving at mode
+//    -10 with ToneMap false skipped the promotion entirely. Either way the
+//    vectors held whatever they held - empty on the first such call - and the
+//    nearest-neighbour search read BT2390y[0] out of bounds. It went unnoticed
+//    because the dead tmWhite call in the forward branch happened to leave
+//    exactly one entry behind on every forward tone-mapped call; deleting that
+//    dead code (same commit) exposed the fault, so this test is what keeps it
+//    dead. case -10 now calls BuildBT2390Table directly, past both guards.
+//    Verified by mutation: deleting that build call aborts this test with
+//    "vector subscript out of range" on the first configuration.
 //
 // 2. Round trip, stated in LUMINANCE: forward(inverse(y)) == y. Signal ->
 //    signal is the wrong invariant here, because the tone curve is not
@@ -904,7 +971,11 @@ static void RunT12()
     static const double minMLs[] = { 0.0, 0.005, 0.05 };
     static const double maxMLs[] = { 1000.0, 4000.0 };
     static const double minTLs[] = { 0.0, 0.005, 0.05, 0.1 };
-    static const double maxTLs[] = { 120.0, 1000.0 };
+    // 30 against a 1000/4000-nit master is the KS < 0 regime, where the forward
+    // curve is deliberately flat across the bottom - the inverse is then free to
+    // return any signal in that run, which is exactly why the round trip below is
+    // stated in luminance.
+    static const double maxTLs[] = { 30.0, 120.0, 1000.0 };
 
     int configs = 0;
 


### PR DESCRIPTION
Reported by Dominic against v4.1.0: *"It tone-maps the highlights, but not the near-black values, so one could end up with a Y Target that's higher at 0% than at 5%."* Confirmed and fixed — and there turned out to be two separate ways into it.

## Root cause

`getL_EOTF` case 10 normalises the signal against the mastering display's black:

```
E1 = (E - PQ(MasterMinL)) / d
```

runs BT.2390's knee to get `E2`, and then applies the black lift `E3 = E2 + b(1-E2)^p` **only** inside `if (E2 >= 0.0 && E2 <= 1.0)`. Anything landing outside that window falls into the `else` branch — the raw, **un-tone-mapped** PQ curve. So the highlights get rolled off while near-black gets no lift at all, and since `valx == 0` returns `m_TargetMinL` directly at the top of the function, 0% sits on the tone-mapped curve while 1–5% sit on the un-mapped one.

Two different inputs reach that dead zone:

1. **A signal below the mastering black** makes `E1` negative, and with the knee not firing, `E2` with it. Pre-fix, default BT.2390 sliders, only the luminance fields changed:

   | signal | Y target (cd/m²) |
   |---|---|
   | 0% | 0.050 &nbsp;&larr; *above the next five* |
   | 2% | 0.007 |
   | 4% | 0.039 |
   | 6% | 0.089 |
   | 8% | 0.196 |
   | 10% | 0.328 |

2. **A target peak below a third of the mastering range** drives `KS = 1.5*maxL - 0.5` negative, so `E1 = 0` clears `E1 >= KS`, enters the Hermite knee, and the *spline itself* returns a negative `E2`. A 30-nit target off a 10000-nit master read `0.300` cd/m² at 0% and `0.000040` at 1/1024 — same shape, different mechanism. This one needs no mastering-black entry at all.

## Fix

**One floor, on `E2`, guarded on `d > 0`.** `E2 = 0` feeds the black lift `E3 = b`, so the bottom of the curve lands on the display's black target instead of falling through, and the curve is monotonic and continuous with the `valx == 0` return. Flooring `E1` instead covers only mechanism 1; once the `E2` floor exists it is measurably inert (4.51M points, zero rows differ with it removed, no mutation of it killable), so there is one clamp rather than two.

Three things the floor deliberately does **not** do:

- **It does not touch the top end.** When `TargetMaxL > MasterMaxL` — a display brighter than the disc, both fields user-editable — `maxL > 1`, so `KS > 1` and the knee never fires. Capping `E1` at 1 there pins every signal above the mastering peak to `PQ(MasterMaxL)`: a 1000-nit-mastered disc on a 4000-nit target flat-lined the whole top quarter of the grid at 1000. The fall-through returns true PQ capped at `m_MaxTL`, which is what the expansion region wants.
- **It stays off for degenerate mastering metadata.** A `MasterMaxL` at or below the mastering black makes `d` zero or negative, so `E1`, `minL` and `maxL` are all `±inf` or `NaN`. Flooring a sub-black `-inf` to 0 routes a near-zero signal into the tone-map branch, where an infinite `b` yields a `NaN` that `min(NaN, cap)` resolves to the **full target peak**: a signal of `1e-7` returning 1000 cd/m². Guarded on `d > 0`, those keep falling through to raw PQ exactly as on `main`. The References page cannot produce `d <= 0`: it validates `MasterMaxL` to `[100, 10000]` and `MasterMinL` to `[0, 0.5]`, and over the corners of all four luminance fields (`DiffuseL`'s `[1, 200]` included) the smallest `d` is **0.0733**. The guard covers a hand-edited INI, which `ColorHCFRConfig.cpp:566` reads back with `GetProfileDouble` and does not re-validate, or a direct caller of the public `getL_EOTF`. (An earlier revision of this description called that case "blank ST.2086 fields entered as `0`" — wrong, the page rejects `0` for `MasterMaxL`; the `0` default belongs to `MasterMinL`.)
- **It is written as a comparison, not `max()`.** The MSVC `max` macro answers its second operand for a `NaN`, and that `NaN` is load-bearing: `TargetMaxL == MasterMaxL == 10000` puts `E1`, `KS` and `maxL` all on exactly 1 at full signal, so the knee runs with `T = 0/0`. That `NaN` has to keep failing the `[0,1]` gate to reach raw PQ, which is what returns the display peak at 100%. As `max(E2, 0.0)` it floors to 0 and **white reads as black**.

## Why it survived to v4.1.0

Mechanism 1 needs `MasterMinL > 0` **and** `TargetMinL > 0` — unreachable at the shipped `MasterMinL` default of `0`. But the field is editable whenever the transfer function is PQ or HLG, and entering a disc's ST.2086 mastering min luminance is exactly what it's for. With all three BT.2390 sliders at defaults and only the luminance fields varied, **48 of 192** configurations were non-monotonic. Mechanism 2 needs only a dim target against bright-mastered content.

## Also in this PR

- **One definition of the tone map.** The per-signal math existed as two verbatim copies — the scalar path and the inverse-LUT builder — and they had already drifted: the knee gate read `E1 <= 1.0` in one and `E1 <= 1.2` in the other. Extracted to a single static `BT2390ToneMap`, so a fix lands once and the forward oracle (T11) and inverse oracle (T12) cover the same code. Unified on the spec's own domain, `E1 <= 1.0`: over 14.2M points the two gates are **bit-identical**, because above `E1 = 1` the extrapolated knee always exceeds the peak cap. The slope mod is bounded at 1 for the same reason, which keeps `pow(negative, 0.75) = NaN` out of the arithmetic — also bit-identical over that sweep.
- **`case -10` builds its table directly.** It used to re-enter `getL_EOTF` with `mode 5, cBT2390 = TRUE`, which made the build depend on clearing the top-of-function guards *and* on `ToneMap && mode == 5` promoting to case 10. Two ways through with no table: `valx == 0` tripped the `valx == 0 && mode > 4` early return, and a direct `mode = -10, ToneMap = false` call skipped the promotion — either way the nearest-neighbour search indexed `BT2390y[0]` on an empty vector. That's the logged **MATH-008**. Calling `BuildBT2390Table` directly removes the dependency, along with the 17-argument self-call and the sentinel signal it had to pass. The `cBT2390` branch that remains is only the public API's way in, and its comment now states what reaching it still costs: it is gated on the *signal* as well as on the promotion, so a rebuild requested at `valx == 0` takes the early return and builds nothing.
- **Dead code removed.** The `tmWhite` local in the same branch was assigned and never read, and was called without `E2_fact1` so it silently used the header default `1.1` instead of the configured value. It re-entered the LUT branch on every forward tone-mapped call, clearing and repopulating the global `BT2390x`/`BT2390y` vectors for a value nothing consumed — which is what had been masking MATH-008, by always leaving exactly one entry behind. Removed along with the two commented-out 2018 lines in case -10 that were its abandoned experiment. **~2× faster** on the tone-mapped path. The diffuse-white fast path went with it: with `tmWhite` gone, `case -10` is the only caller and it always needs the full curve, and the fast path was a live hazard — a caller inverting a luminance inside its window got a one-entry table and a search that handed back its own input.
- **Regression tests `ColorMathTest` T11 and T12.** `/accuracytest` structurally cannot cover this fix: it pins `MasterMinL` and `TargetMinL` to `0`, so the dead zone is unreachable there, and a reference wrong in the same way as the modelled sensor still reads dE 0.000. T11 is a monotonicity oracle over **4320** tone-map configurations plus an 18-config degenerate-metadata block; its target column set is chosen per regime rather than for volume — 30 nits for `KS < 0`, 2000 for the expansion region, 1000 and 10000 for `TargetMaxL == MasterMaxL` below and *at* the PQ top. The degenerate block samples a sub-grid ladder from `1e-9`, since the failing signals sit well under 1/1024. T12 is the inverse-LUT oracle, reaching `case -10` and the search over the table, which T11 structurally cannot; it asserts `forward(inverse(y)) == y` in **luminance, not signal**, because the curve is deliberately non-injective, plus an inverse-of-zero guard for MATH-008.

## Verification

**Mutation** — every load-bearing line in the fix is killed by this suite:

| mutation | killed by |
|---|---|
| drop the E2 floor | T11 2880 / 4320, T12 54 / 72 |
| write the floor as `max(E2, 0.0)` | T11 240 |
| clamp E1's top end | T11 600, on the peak-reach check |
| drop the `d > 0` guard | T11-degenerate 10 / 18 |
| floor E1 instead of E2 | T11 92 |
| delete the LUT build call | T12 aborts, `vector subscript out of range` |

**Differential dumps**, every changed row classified rather than sampled:

- 307k rows against `main` for the original fix: only near-black rows (signal ≤ 9.5%) change, every one upward; highlights and the default config bit-identical.
- 4,510,080 rows against the pre-review head: **6480 rows change, all in exactly two classes** — 2112 degenerate `d <= 0` (reverting to `main`) and 4368 `KS < 0` (mechanism 2), nothing else. No configuration that was monotonic became non-monotonic; 896 became monotonic.

**Probe linked against the real `libHCFR`**, reproducing the grid's displayed `Y Target` (`GetItemText` "Display reference Y") across the References page's full `DDV_MinMaxDouble` ranges:

| | non-monotonic near-black |
|---|---|
| pre-fix | 2592 / 10368 realistic configs |
| pre-fix, `MasterMinL = 0` | **0 / 2592** |
| post-fix | **0 / 10368** |

Every pre-fix failure in the realistic space had `MasterMinL > 0`.

**`/accuracytest` full matrix**: 2076 report lines, 834 combos, **648 pass, 0 FAIL, 186 known-fail** — unchanged from clean `HEAD`. `ColorMathTest verify` green.

## Known remaining (pre-existing, not touched)

Three non-monotonic bands survive this PR. All three are byte-identical to `main`.

Two of them come from the `valx == 0` early return still not being bounded by the curve it is meant to join:

- **Degenerate `MasterMaxL = 0`**, where that return sits above a raw PQ curve. The `d > 0` guard above deliberately restores this rather than tone-mapping it.
- **Extreme entries the UI permits** — `DiffuseL = 1` (range starts at 1, default 94.4) or `TargetMinL` of 5–100 nits.

The third is the black lift's own exponent, and unlike those two it turns the curve over **mid-scale** rather than near black — which is why neither of the bands above covers it:

- **`p = min(1/b, 4 * BS) < 1`.** The slope of `E3 = E2 + b(1-E2)^p` diverges as `E2 → 1`, so the curve rolls back down partway up the scale. Two entrances the References page allows: a **Black Slope below 0.25** (`4 * b_fact < 1`), or `b > 1` from a high `TargetMinL` against a low `DiffuseL`. **225 of 5760** UI-reachable configurations are non-monotonic, every one at `BS = 0.1`; none of the 225 were monotonic before this PR either, and nothing fires at `BS ≥ 0.5` with the default diffuse white. Two measured entrances:

  | config | signal | Y target |
  |---|---|---|
  | `BS 0.1`, master `0` / `1000`, target `0.05` / `4000` | 0.750000 → 0.750977 | 1021.537 → 1020.442 cd/m² |
  | `BS 1.0`, master `0.5` / `100`, target `100` / `400`, `DiffuseL 1` | 0.507812 → 0.508789 | 13.169080 → 1.067091 cd/m² |

  Bounding `p` at 1 clears all 225, but moves **407,442 of 5,904,000** rows by up to **6617 cd/m²** — a change to the shipped tone curve rather than a bug fix, so it stays out of this PR. T11 pins `BS` to `{1.0, 2.0}` and `DiffuseL` to `{94.37844, 203}` to sit clear of both entrances, and now says so in the test.

Separate issues, neither caused nor fixed here.

No user-facing strings added, so no localization changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

