### PR TITLE
Fix Go/Stop toggle and Stop responsiveness on color checker sweeps

### DIFF
--- a/Measure.cpp
+++ b/Measure.cpp
@@ -96,11 +96,18 @@ struct SweepActiveGuard
     // Clearing m_binMeasure here covers every early return (ESC cancel, sensor
     // abort, init failure); success paths still clear it explicitly before
     // their final UpdateViews so views repaint with the flag already down.
+    // m_bAbortSweep is cleared for the same reason: an abort request belongs to
+    // the sweep it interrupted. Clearing it only on the NEXT sweep's entry left
+    // it TRUE in between, which was harmless while it was read only inside sweep
+    // loops but is not now that WaitForDynamicIris consults it -- that runs
+    // outside any sweep as well (PerformSimultaneousMeasures, MultiFrm), where a
+    // stale TRUE would cancel the next measurement before it started.
     ~SweepActiveGuard()
     {
         if (m_owned)
         {
             m_pMeasure->m_binMeasure = FALSE;
+            m_pMeasure->m_bAbortSweep = FALSE;
             g_bMeasureSweepActive = FALSE;
         }
     }
@@ -4082,7 +4089,15 @@ bool CMeasure::MeasureProfileDriftAnchor(CAsyncMeasurer & am, CSensor * pSensor,
 	if ( ! pGenerator->DisplayRGBColor ( whiteRGB, CGenerator::MT_SAT_CC24_USER, patchIdx, TRUE ) )
 		return false;
 	if ( WaitForDynamicIris ( FALSE, pDoc ) )
+	{
+		// Aborted mid-settle: return without reading. Measuring anyway yielded an
+		// unsettled anchor that, if it passed the validity gate below, became the
+		// drift factor and retroactively rescaled the whole previous segment --
+		// corrupting the partial capture the abort is meant to preserve. The
+		// caller breaks on m_bAbortSweep right after this returns.
 		m_bAbortSweep = TRUE;
+		return true;
+	}
 	CColor anchor = PumpedRead ( am, pSensor, whiteRGB, displaymode );
 	if ( ! pSensor->IsMeasureValid() || ! anchor.isValid() || anchor.GetY() <= 0.0 )
 		return true;

--- a/Measure.cpp
+++ b/Measure.cpp
@@ -4083,12 +4083,20 @@ void CMeasure::ApplyProfileDriftSegment(int fromIdx, int toIdx, double fFrom, do
 // closes the previous segment (retroactive correction) and becomes the new
 // segment start; an invalid sensor read is skipped rather than aborting an
 // hours-long capture. Returns false only when the generator itself fails.
-bool CMeasure::MeasureProfileDriftAnchor(CAsyncMeasurer & am, CSensor * pSensor, CGenerator * pGenerator, CDataSetDoc * pDoc, int patchIdx, double & firstAnchorY, double & prevFactor, int & prevIdx)
+// bIgnoreAbort is for the closing anchor after a Stop, which must still run:
+// m_bAbortSweep is TRUE there until the SweepActiveGuard destructor, so the
+// settle below would return immediately and the anchor would be skipped,
+// leaving the last segment raw while every earlier one is drift-corrected.
+// It also makes the settle itself uninterruptible, which is required -- an
+// anchor read before the display settles becomes the drift factor and
+// rescales the whole previous segment, the very corruption the abort check
+// below exists to prevent. One latency window, on the last patch of a run.
+bool CMeasure::MeasureProfileDriftAnchor(CAsyncMeasurer & am, CSensor * pSensor, CGenerator * pGenerator, CDataSetDoc * pDoc, int patchIdx, double & firstAnchorY, double & prevFactor, int & prevIdx, BOOL bIgnoreAbort)
 {
 	ColorRGBDisplay whiteRGB ( 100.0, 100.0, 100.0 );
 	if ( ! pGenerator->DisplayRGBColor ( whiteRGB, CGenerator::MT_SAT_CC24_USER, patchIdx, TRUE ) )
 		return false;
-	if ( WaitForDynamicIris ( FALSE, pDoc ) )
+	if ( WaitForDynamicIris ( bIgnoreAbort, pDoc ) )
 	{
 		// Aborted mid-settle: return without reading. Measuring anyway yielded an
 		// unsettled anchor that, if it passed the validity gate below, became the
@@ -4213,11 +4221,21 @@ BOOL CMeasure::MeasureDisplayProfile(CSensor *pSensor, CGenerator *pGenerator, C
 		ColorRGBDisplay whRGB ( 100.0, 100.0, 100.0 );
 		if ( pGenerator->DisplayRGBColor ( whRGB, nPattern, 0, TRUE ) )
 		{
+			// Aborted mid-settle: skip the read. An unsettled reading still passes
+			// the validity gate below and permanently replaces the app-wide
+			// reference -- the nDone == 0 path calls ClearProfileMeasures() but
+			// does not restore the white, so it stays "valid", a later profile run
+			// will not re-measure it, and ComputeProfileDE, the 3D viewer, the
+			// RGB-levels widget and the export paths all normalize to it. Leaving
+			// it invalid makes the next run measure it properly.
 			if ( WaitForDynamicIris ( FALSE, pDoc ) )
 				m_bAbortSweep = TRUE;
-			CColor wh = PumpedRead ( asyncMeasure, pSensor, whRGB, displaymode );
-			if ( pSensor->IsMeasureValid() && wh.isValid() && wh.GetY() > 0.0 )
-				m_OnOffWhite = wh;
+			else
+			{
+				CColor wh = PumpedRead ( asyncMeasure, pSensor, whRGB, displaymode );
+				if ( pSensor->IsMeasureValid() && wh.isValid() && wh.GetY() > 0.0 )
+					m_OnOffWhite = wh;
+			}
 		}
 	}
 	if ( ! m_bAbortSweep && ! m_OnOffBlack.isValid() )
@@ -4225,11 +4243,16 @@ BOOL CMeasure::MeasureDisplayProfile(CSensor *pSensor, CGenerator *pGenerator, C
 		ColorRGBDisplay bkRGB ( 0.0, 0.0, 0.0 );
 		if ( pGenerator->DisplayRGBColor ( bkRGB, nPattern, 0, TRUE ) )
 		{
+			// Same as the white above: an unsettled black would stick as the
+			// app-wide reference and never be re-measured.
 			if ( WaitForDynamicIris ( FALSE, pDoc ) )
 				m_bAbortSweep = TRUE;
-			CColor bk = PumpedRead ( asyncMeasure, pSensor, bkRGB, displaymode );
-			if ( pSensor->IsMeasureValid() && bk.isValid() )
-				m_OnOffBlack = bk;
+			else
+			{
+				CColor bk = PumpedRead ( asyncMeasure, pSensor, bkRGB, displaymode );
+				if ( pSensor->IsMeasureValid() && bk.isValid() )
+					m_OnOffBlack = bk;
+			}
 		}
 	}
 
@@ -4367,9 +4390,12 @@ BOOL CMeasure::MeasureDisplayProfile(CSensor *pSensor, CGenerator *pGenerator, C
 		}
 	}
 
-	// final drift anchor closes the last open segment (also after Stop)
+	// Final drift anchor closes the last open segment (also after Stop, hence
+	// bIgnoreAbort -- see the helper: m_bAbortSweep is still TRUE here and would
+	// otherwise short-circuit this call into a no-op, and ESC would take the
+	// anchor while Stop would not, giving the same user intent different data).
 	if ( bDriftComp && firstAnchorY > 0.0 && nDone > prevAnchorIdx )
-		MeasureProfileDriftAnchor ( asyncMeasure, pSensor, pGenerator, pDoc, nDone, firstAnchorY, prevAnchorFactor, prevAnchorIdx );
+		MeasureProfileDriftAnchor ( asyncMeasure, pSensor, pGenerator, pDoc, nDone, firstAnchorY, prevAnchorFactor, prevAnchorIdx, TRUE );
 
 	pSensor->Release();
 	pGenerator->Release();

--- a/Measure.cpp
+++ b/Measure.cpp
@@ -6391,6 +6391,17 @@ BOOL CMeasure::WaitForDynamicIris ( BOOL bIgnoreEscape, CDataSetDoc *pDoc )
 				TranslateMessage ( & Msg );
 				DispatchMessage ( & Msg );
 			}
+
+			// A Stop-button click dispatched just above sets the abort flag;
+			// honor it here exactly like ESC. Without this the wait ran its full
+			// latency window and the sweep still displayed and measured the
+			// current patch before noticing the abort, so Stop felt unresponsive
+			// (and invited repeat presses) where ESC was immediate. Gated on
+			// bIgnoreEscape so the callers that opt out of user interruption
+			// keep their current behavior.
+			if ( ! bIgnoreEscape && m_bAbortSweep )
+				bEscape = TRUE;
+
 			dwNow = GetTickCount();
 		}
 	}

--- a/Measure.h
+++ b/Measure.h
@@ -299,7 +299,7 @@ public:
 	double m_profileCurrentDrift;	// last anchor's drift factor minus 1.0
 
 protected:
-	bool MeasureProfileDriftAnchor(CAsyncMeasurer & am, CSensor * pSensor, CGenerator * pGenerator, CDataSetDoc * pDoc, int patchIdx, double & firstAnchorY, double & prevFactor, int & prevIdx);
+	bool MeasureProfileDriftAnchor(CAsyncMeasurer & am, CSensor * pSensor, CGenerator * pGenerator, CDataSetDoc * pDoc, int patchIdx, double & firstAnchorY, double & prevFactor, int & prevIdx, BOOL bIgnoreAbort = FALSE);
 	void ApplyProfileDriftSegment(int fromIdx, int toIdx, double fFrom, double fTo);
 public:
 

--- a/datasetdoc.cpp
+++ b/datasetdoc.cpp
@@ -1281,6 +1281,8 @@ void CDataSetDoc::MeasureMagentaSatScale()
 void CDataSetDoc::MeasureCC24SatScale() 
 {
 	StopBackgroundMeasures ();
+	MeasureButtonStopScope _btn(this);
+
 	if(m_measure.MeasureCC24SatScale(m_pSensor,m_pGenerator,this))
 		SetModifiedFlag(m_measure.IsModified());
 	UpdateAllViews(NULL, UPD_CC24SAT);


### PR DESCRIPTION
Two stock defects found while testing large custom patch sequences. Both are pre-existing on `main` and independent of any feature work — this branch is cut from `main` so it can land, or be reported upstream, on its own.

**1. The Go/Stop caption never tracked a color checker sweep.**

`CDataSetDoc::MeasureCC24SatScale` was the only one of the twenty document-level sweep entry points without the `MeasureButtonStopScope` RAII guard that turns the button red on entry and restores "Go" on exit — #171/#174 added it everywhere else and missed this one.

That made the symptom intermittent in both directions, which is what made it awkward to pin down. The button turned red only by accident, via the repair in `OnSelchangeComboMode` (`if (IsMeasureSweepActive()) SetMeasureButtonStop(TRUE)`), which runs only when the sweep *forces* a display-mode change — i.e. only when the sweep is started from some other view. Start it while already on the Color Checker view and the button stayed "Go" for the whole run. And since `SetMeasureButtonStop(FALSE)` is reachable only from that guard's destructor, a sweep that *did* turn red stayed red afterwards until an unrelated sweep type ran. A stuck red button is a live hazard too: pressing it starts a **new** sweep, because the handler branches on `IsMeasureSweepActive()` rather than on the caption.

**2. Stop took effect a full patch late.**

`WaitForDynamicIris` dispatches the Stop click and `AbortMeasure` sets the flag, but the wait's own exit condition consulted `VK_ESCAPE` only — so it ran its whole latency window and the sweep still displayed and measured the current patch before noticing. With a long latency plus settling that is seconds of apparent nothing, which invites repeated presses; Escape was immediate by comparison. The wait now treats the abort flag exactly like Escape, gated on `bIgnoreEscape` so the callers that opt out of user interruption are untouched.

**Follow-up commit** applies two review findings, both consequences of giving `m_bAbortSweep` its first reader outside a sweep. The flag is now cleared in `SweepActiveGuard`'s destructor so an abort request cannot outlive the sweep it interrupted — previously it was cleared only on the *next* sweep's entry, which would have made the next manual calibration or simultaneous measure cancel itself instantly. And an aborted drift anchor now returns without measuring, instead of applying an unsettled reading as a drift factor that retroactively rescaled the preceding capture segment.

The two commits are kept separate so the review findings stay visible in the history.

**Testing** (hardware, i1Pro2). The button toggles correctly in both directions with realtime display on *and* off, and Stop is responsive. Stop-then-manual-calibration measures normally, confirming the abort flag no longer leaks past its sweep. The aborted-drift-anchor path was exercised on a profile capture with drift compensation enabled; the profile view shows no per-point values, so the evidence there is indirect — the running dE tally was unchanged, consistent with no retroactive rescale. Debug and Release both build; `ColorMathTest verify` passes.

**Note on a related symptom:** patches measured before a Stop still display blank afterwards, in both realtime-display modes. That is a *different* pre-existing bug — an aborted sweep leaves its data in the live array while post-sweep reads come from the per-set master array — and it is fixed on a separate branch. Worth sequencing that one alongside this, since making Stop more responsive routes more runs through the abort path where the data loss shows.
