### PR TITLE
Incremental grid update during color checker sweeps, and salvage partial data on abort

### DIFF
--- a/Measure.cpp
+++ b/Measure.cpp
@@ -4054,18 +4054,29 @@ BOOL CMeasure::MeasureCC24SatScale(CSensor *pSensor, CGenerator *pGenerator, CDa
 	if (bPatternRetry)
 		AfxMessageBox(pGenerator->GetRetryMessage(), MB_OK | MB_ICONWARNING);
 
+	int iCC=GetConfig()->m_CCMode;
+
 	for(int i=0;i<size;i++)
 	{
 		m_cc24SatMeasureArray[i] = measuredColor[i];
+		// measuredColor and the live array are addressed by SLOT (see nSlot in
+		// the sweep loop), but measuredLux is filled by ITERATION, and MCD
+		// permutes the two. Reading measuredLux straight through paired every
+		// patch with another patch's lux: a six-position shift for slots 6-23,
+		// reversed for slots 0-5. Invert the permutation with the same expression
+		// SalvageCC24SatPartial uses, so an aborted sweep and a completed one
+		// agree on the lux column. (Unlike the salvage this loop needs no
+		// "lux canceled" test: LUX_CANCELED sets bEscape, which returns through
+		// the salvage path and never reaches here.)
+		int nIter = ( iCC != MCD ) ? i : ( i >= 6 ? i - 6 : 23 - i );
 		if ( bUseLuxValues )
-			m_cc24SatMeasureArray[i].SetLuxValue ( measuredLux[i] );
+			m_cc24SatMeasureArray[i].SetLuxValue ( measuredLux[nIter] );
 		else
 			m_cc24SatMeasureArray[i].ResetLuxValue ();
 	}
 
 	GetConfig()->m_isSettling = doSettling;
 
-	int iCC=GetConfig()->m_CCMode;
 	if (iCC < RANDOM250)
 		for (int i=0+100*iCC;i<100*(iCC+1);i++)
 				m_cc24SatMeasureArray_master[i] = m_cc24SatMeasureArray[i-iCC*100];

--- a/Measure.cpp
+++ b/Measure.cpp
@@ -3975,6 +3975,10 @@ BOOL CMeasure::MeasureCC24SatScale(CSensor *pSensor, CGenerator *pGenerator, CDa
 			{
 				if ( SalvageCC24SatPartial ( bUseLuxValues, measuredLux ) && pDoc )
 					pDoc->SetModifiedFlag ( TRUE );
+				// the loop clears m_isSettling from patch 1 on and the config is
+				// persisted, so an abort that skipped this left the user's settling
+				// preference permanently off (completion path restores it below)
+				GetConfig()->m_isSettling = doSettling;
 				pSensor->Release();
 				pGenerator->Release();
 				strMsg.LoadString ( IDS_MEASURESCANCELED );
@@ -3994,6 +3998,7 @@ BOOL CMeasure::MeasureCC24SatScale(CSensor *pSensor, CGenerator *pGenerator, CDa
 					m_cc24SatMeasureArray[nSlot] = noDataColor;
 					if ( SalvageCC24SatPartial ( bUseLuxValues, measuredLux ) && pDoc )
 						pDoc->SetModifiedFlag ( TRUE );
+					GetConfig()->m_isSettling = doSettling;
 					pSensor->Release();
 					pGenerator->Release();
 					return FALSE;
@@ -4007,7 +4012,12 @@ BOOL CMeasure::MeasureCC24SatScale(CSensor *pSensor, CGenerator *pGenerator, CDa
 			else
 			{
 				previousColor = lastColor;			
-				lastColor = measuredColor[i];
+				// same permutation as nSlot: the unpermuted [i] handed the selected-
+				// color widget (UpdateViews -> SetSelectedColor) and the generator's
+				// pattern-change check a default-constructed color for MCD's first
+				// six patches -- two of those in a row read as "pattern unchanged"
+				// and forced a retry on input that had in fact changed
+				lastColor = measuredColor[nSlot];
 	
 				if(i != 0)
 				{
@@ -4023,6 +4033,7 @@ BOOL CMeasure::MeasureCC24SatScale(CSensor *pSensor, CGenerator *pGenerator, CDa
 		{
 			if ( SalvageCC24SatPartial ( bUseLuxValues, measuredLux ) && pDoc )
 				pDoc->SetModifiedFlag ( TRUE );
+			GetConfig()->m_isSettling = doSettling;
 			pSensor->Release();
 			pGenerator->Release();
 			return FALSE;
@@ -7382,26 +7393,34 @@ CColor CMeasure::GetCC24Sat(int i)
 // when realtime display was off).
 BOOL CMeasure::SalvageCC24SatPartial(BOOL bUseLuxValues, const CArray<double,int> & measuredLux)
 {
+	int iCC = GetConfig()->m_CCMode;
+
 	// Nothing measured -> leave the master untouched. Publishing the freshly
 	// wiped live band on a zero-progress abort (generator failure at patch 0,
 	// escape during the first iris wait) would destroy the set's previous
 	// completed run for no salvageable data.
 	BOOL bAnyValid = FALSE;
-	for (int i = 0; i < measuredLux.GetSize() && i < m_cc24SatMeasureArray.GetSize(); i++)
+	for (int i = 0; i < m_cc24SatMeasureArray.GetSize(); i++)
 	{
 		if ( ! m_cc24SatMeasureArray[i].isValid() )
 			continue;
 		bAnyValid = TRUE;
+		// measuredLux is filled by ITERATION index while the live array is
+		// addressed by SLOT index, and MCD permutes the two (iteration j lands
+		// in slot j+6 / 23-j). Invert that permutation here: reading straight
+		// through paired each salvaged patch with another patch's lux and, past
+		// the point the sweep reached, stamped the zero-filled tail (CArray
+		// SetSize zero-fills doubles) as a real 0.0 reading.
+		int nIter = ( iCC != MCD ) ? i : ( i >= 6 ? i - 6 : 23 - i );
 		// measuredLux < 0 marks a patch whose lux capture was canceled
-		if ( bUseLuxValues && measuredLux[i] >= 0.0 )
-			m_cc24SatMeasureArray[i].SetLuxValue ( measuredLux[i] );
+		if ( bUseLuxValues && nIter < measuredLux.GetSize() && measuredLux[nIter] >= 0.0 )
+			m_cc24SatMeasureArray[i].SetLuxValue ( measuredLux[nIter] );
 		else
 			m_cc24SatMeasureArray[i].ResetLuxValue ();
 	}
 	if ( ! bAnyValid )
 		return FALSE;
 
-	int iCC = GetConfig()->m_CCMode;
 	if (iCC < RANDOM250)
 		for (int i=0+100*iCC;i<100*(iCC+1);i++)
 				m_cc24SatMeasureArray_master[i] = m_cc24SatMeasureArray[i-iCC*100];

--- a/Measure.cpp
+++ b/Measure.cpp
@@ -3920,7 +3920,15 @@ BOOL CMeasure::MeasureCC24SatScale(CSensor *pSensor, CGenerator *pGenerator, CDa
 			UpdateTstWnd(pDoc, -1);
 		if( pGenerator->DisplayRGBColor(GenColors[i], nPattern , i, !bRetry))
 		{
-			UpdateTstWnd(pDoc, i);
+			// UpdateTstWnd drives GRID-side state: minCol/last_minCol (which feed
+			// the realtime refresh column and the comparator's reference pick),
+			// the measuring-column highlight, and CTargetWnd::Refresh -- and all
+			// of those index by SLOT (TargetWnd's mode-11 branch takes a slot
+			// column and derives the display index with the inverse of the
+			// permutation below). Passing the ITERATION put every one of them six
+			// columns off under MCD and made TargetWnd permute an already-
+			// permuted index. The generator still gets the display index i.
+			UpdateTstWnd(pDoc, nSlot);
 			bEscape = WaitForDynamicIris (FALSE, pDoc);
 			bRetry = FALSE;
 

--- a/Measure.cpp
+++ b/Measure.cpp
@@ -3963,6 +3963,7 @@ BOOL CMeasure::MeasureCC24SatScale(CSensor *pSensor, CGenerator *pGenerator, CDa
 
 			if ( bEscape )
 			{
+				SalvageCC24SatPartial ( bUseLuxValues, measuredLux );
 				pSensor->Release();
 				pGenerator->Release();
 				strMsg.LoadString ( IDS_MEASURESCANCELED );
@@ -3977,6 +3978,7 @@ BOOL CMeasure::MeasureCC24SatScale(CSensor *pSensor, CGenerator *pGenerator, CDa
 				int result=GetColorApp()->InMeasureMessageBox(strMsg+pSensor->GetErrorString(),Title,MB_ABORTRETRYIGNORE | MB_ICONERROR);
 				if(result == IDABORT)
 				{
+					SalvageCC24SatPartial ( bUseLuxValues, measuredLux );
 					pSensor->Release();
 					pGenerator->Release();
 					return FALSE;
@@ -4004,6 +4006,7 @@ BOOL CMeasure::MeasureCC24SatScale(CSensor *pSensor, CGenerator *pGenerator, CDa
 		}
 		else
 		{
+			SalvageCC24SatPartial ( bUseLuxValues, measuredLux );
 			pSensor->Release();
 			pGenerator->Release();
 			return FALSE;
@@ -7347,6 +7350,41 @@ CColor CMeasure::GetCC24Sat(int i)
 
 	return m_cc24SatMeasureArray_master[i + (iCC<=RANDOM250?(iCC * 100):(iCC==RANDOM500?PATTERN_SIZE+250:PATTERN_SIZE+250+500))];  //index increments by 100 until slot 19 (then 250 & 500 & user MAX_USER_CC_PATCH_SIZE & 2020_50)
 } 
+
+// An aborted color-checker sweep leaves its measured patches only in the live
+// array: SweepActiveGuard clears m_binMeasure on every early return, after
+// which GetCC24Sat reads the per-set master array -- whose band is copied from
+// the live array only on sweep COMPLETION. The partial data was therefore
+// unreachable (grid went blank on stop). Publish the live band to the master
+// before an abort return; unmeasured entries are noDataColor, so the set's
+// stale remainder is wiped exactly like the sweep start wiped the live array.
+// Band mapping mirrors the completion copy at the end of MeasureCC24SatScale.
+void CMeasure::SalvageCC24SatPartial(BOOL bUseLuxValues, const CArray<double,int> & measuredLux)
+{
+	for (int i = 0; i < measuredLux.GetSize() && i < m_cc24SatMeasureArray.GetSize(); i++)
+	{
+		if ( ! m_cc24SatMeasureArray[i].isValid() )
+			continue;
+		if ( bUseLuxValues )
+			m_cc24SatMeasureArray[i].SetLuxValue ( measuredLux[i] );
+		else
+			m_cc24SatMeasureArray[i].ResetLuxValue ();
+	}
+
+	int iCC = GetConfig()->m_CCMode;
+	if (iCC < RANDOM250)
+		for (int i=0+100*iCC;i<100*(iCC+1);i++)
+				m_cc24SatMeasureArray_master[i] = m_cc24SatMeasureArray[i-iCC*100];
+	else if (iCC == RANDOM250)
+		for (int i=PATTERN_SIZE;i<PATTERN_SIZE+250;i++)
+				m_cc24SatMeasureArray_master[i] = m_cc24SatMeasureArray[i-PATTERN_SIZE];
+	else if (iCC == RANDOM500)
+		for (int i=PATTERN_SIZE+250;i<PATTERN_SIZE+250+500;i++)
+				m_cc24SatMeasureArray_master[i] = m_cc24SatMeasureArray[i-(PATTERN_SIZE+250)];
+	else if (iCC == USER)
+		for (int i=PATTERN_SIZE+250+500;i<PATTERN_SIZE+250+500+MAX_USER_CC_PATCH_SIZE;i++)
+				m_cc24SatMeasureArray_master[i] = m_cc24SatMeasureArray[i-(PATTERN_SIZE+250+500)];
+}
 
 CString CMeasure::GetCCStr() const
 {

--- a/Measure.cpp
+++ b/Measure.cpp
@@ -7492,8 +7492,21 @@ CString CMeasure::GetCCStr() const
 	for (int i=0;i<=USER;i++)
 	{
 		if (i<RANDOM250)
-			if (m_cc24SatMeasureArray_master[i*100].isValid())
-				mStr+=sweeps[i];
+		{
+			// ANY measured patch marks the set as present. Probing only the
+			// band's first slot missed MCD, which stores its darkest gray there
+			// and writes it on the sweep's LAST iteration: a sweep stopped
+			// partway salvaged real data that this string then denied. Same
+			// patch-0 assumption the grid's dE header carried. The band is 100
+			// slots wide, matching the copy that fills it; every slot past the
+			// set size is noDataColor from the sweep-start wipe.
+			for (int j=0;j<100;j++)
+				if (m_cc24SatMeasureArray_master[i*100+j].isValid())
+				{
+					mStr+=sweeps[i];
+					break;
+				}
+		}
 		if (i==RANDOM250)
 			if (m_cc24SatMeasureArray_master[2300+100].isValid())
 				mStr+=sweeps[i];

--- a/Measure.cpp
+++ b/Measure.cpp
@@ -3973,7 +3973,8 @@ BOOL CMeasure::MeasureCC24SatScale(CSensor *pSensor, CGenerator *pGenerator, CDa
 
 			if ( bEscape )
 			{
-				SalvageCC24SatPartial ( bUseLuxValues, measuredLux );
+				if ( SalvageCC24SatPartial ( bUseLuxValues, measuredLux ) && pDoc )
+					pDoc->SetModifiedFlag ( TRUE );
 				pSensor->Release();
 				pGenerator->Release();
 				strMsg.LoadString ( IDS_MEASURESCANCELED );
@@ -3991,7 +3992,8 @@ BOOL CMeasure::MeasureCC24SatScale(CSensor *pSensor, CGenerator *pGenerator, CDa
 					// the reading that raised this dialog is known bad; only an
 					// explicit Ignore keeps it -- drop it before salvage publishes
 					m_cc24SatMeasureArray[nSlot] = noDataColor;
-					SalvageCC24SatPartial ( bUseLuxValues, measuredLux );
+					if ( SalvageCC24SatPartial ( bUseLuxValues, measuredLux ) && pDoc )
+						pDoc->SetModifiedFlag ( TRUE );
 					pSensor->Release();
 					pGenerator->Release();
 					return FALSE;
@@ -4019,7 +4021,8 @@ BOOL CMeasure::MeasureCC24SatScale(CSensor *pSensor, CGenerator *pGenerator, CDa
 		}
 		else
 		{
-			SalvageCC24SatPartial ( bUseLuxValues, measuredLux );
+			if ( SalvageCC24SatPartial ( bUseLuxValues, measuredLux ) && pDoc )
+				pDoc->SetModifiedFlag ( TRUE );
 			pSensor->Release();
 			pGenerator->Release();
 			return FALSE;
@@ -7372,7 +7375,12 @@ CColor CMeasure::GetCC24Sat(int i)
 // before an abort return; unmeasured entries are noDataColor, so the set's
 // stale remainder is wiped exactly like the sweep start wiped the live array.
 // Band mapping mirrors the completion copy at the end of MeasureCC24SatScale.
-void CMeasure::SalvageCC24SatPartial(BOOL bUseLuxValues, const CArray<double,int> & measuredLux)
+// Returns TRUE when partial data was published (the caller then owns marking
+// the DOCUMENT modified -- the measure-level m_isModified set below never
+// reaches the doc on an aborted sweep, whose FALSE return skips the doc's
+// SetModifiedFlag call, so without this the salvaged data drew no save prompt
+// when realtime display was off).
+BOOL CMeasure::SalvageCC24SatPartial(BOOL bUseLuxValues, const CArray<double,int> & measuredLux)
 {
 	// Nothing measured -> leave the master untouched. Publishing the freshly
 	// wiped live band on a zero-progress abort (generator failure at patch 0,
@@ -7391,7 +7399,7 @@ void CMeasure::SalvageCC24SatPartial(BOOL bUseLuxValues, const CArray<double,int
 			m_cc24SatMeasureArray[i].ResetLuxValue ();
 	}
 	if ( ! bAnyValid )
-		return;
+		return FALSE;
 
 	int iCC = GetConfig()->m_CCMode;
 	if (iCC < RANDOM250)
@@ -7412,6 +7420,7 @@ void CMeasure::SalvageCC24SatPartial(BOOL bUseLuxValues, const CArray<double,int
 	// sweeps-active info string must reflect the new contents.
 	m_isModified = TRUE;
 	m_CCStr = GetCCStr();
+	return TRUE;
 }
 
 CString CMeasure::GetCCStr() const

--- a/Measure.cpp
+++ b/Measure.cpp
@@ -3907,6 +3907,13 @@ BOOL CMeasure::MeasureCC24SatScale(CSensor *pSensor, CGenerator *pGenerator, CDa
 		else
 			doSettling = GetConfig()->m_isSettling;
 
+		// MCD displays its patches permuted: iteration i's reading lands in
+		// measuredColor slot i+6 / 23-i. All per-patch live-array traffic must
+		// use THAT slot -- the unpermuted [i] mirrored a default-constructed
+		// (thus "valid") placeholder for slots 0-5, which the live display
+		// showed mid-sweep and the abort salvage would publish.
+		int nSlot = (GetConfig()->m_CCMode != MCD) ? i : (i < 18 ? i + 6 : 23 - i);
+
 		UpdateViews(pDoc, 11);
 
 		if (!i && GetConfig()->GetProfileInt("GDIGenerator","DisplayMode",DISPLAY_DEFAULT_MODE) == DISPLAY_GDI_Hide)
@@ -3933,7 +3940,7 @@ BOOL CMeasure::MeasureCC24SatScale(CSensor *pSensor, CGenerator *pGenerator, CDa
 						measuredColor[23-i] = PumpedRead(asyncMeasure, pSensor, GenColors[i], displaymode);
 				}
 
-				m_cc24SatMeasureArray[i] = measuredColor[i];
+				m_cc24SatMeasureArray[nSlot] = measuredColor[nSlot];
 
 				if ( bUseLuxValues )
 				{
@@ -3948,6 +3955,9 @@ BOOL CMeasure::MeasureCC24SatScale(CSensor *pSensor, CGenerator *pGenerator, CDa
 							 break;
 
 						case LUX_CANCELED:
+							 // no lux captured for this patch; keep salvage from
+							 // stamping the array-default 0.0 on it
+							 measuredLux[i] = -1.0;
 							 bEscape = TRUE;
 							 break;
 					}
@@ -3978,6 +3988,9 @@ BOOL CMeasure::MeasureCC24SatScale(CSensor *pSensor, CGenerator *pGenerator, CDa
 				int result=GetColorApp()->InMeasureMessageBox(strMsg+pSensor->GetErrorString(),Title,MB_ABORTRETRYIGNORE | MB_ICONERROR);
 				if(result == IDABORT)
 				{
+					// the reading that raised this dialog is known bad; only an
+					// explicit Ignore keeps it -- drop it before salvage publishes
+					m_cc24SatMeasureArray[nSlot] = noDataColor;
 					SalvageCC24SatPartial ( bUseLuxValues, measuredLux );
 					pSensor->Release();
 					pGenerator->Release();
@@ -7361,15 +7374,24 @@ CColor CMeasure::GetCC24Sat(int i)
 // Band mapping mirrors the completion copy at the end of MeasureCC24SatScale.
 void CMeasure::SalvageCC24SatPartial(BOOL bUseLuxValues, const CArray<double,int> & measuredLux)
 {
+	// Nothing measured -> leave the master untouched. Publishing the freshly
+	// wiped live band on a zero-progress abort (generator failure at patch 0,
+	// escape during the first iris wait) would destroy the set's previous
+	// completed run for no salvageable data.
+	BOOL bAnyValid = FALSE;
 	for (int i = 0; i < measuredLux.GetSize() && i < m_cc24SatMeasureArray.GetSize(); i++)
 	{
 		if ( ! m_cc24SatMeasureArray[i].isValid() )
 			continue;
-		if ( bUseLuxValues )
+		bAnyValid = TRUE;
+		// measuredLux < 0 marks a patch whose lux capture was canceled
+		if ( bUseLuxValues && measuredLux[i] >= 0.0 )
 			m_cc24SatMeasureArray[i].SetLuxValue ( measuredLux[i] );
 		else
 			m_cc24SatMeasureArray[i].ResetLuxValue ();
 	}
+	if ( ! bAnyValid )
+		return;
 
 	int iCC = GetConfig()->m_CCMode;
 	if (iCC < RANDOM250)
@@ -7384,6 +7406,12 @@ void CMeasure::SalvageCC24SatPartial(BOOL bUseLuxValues, const CArray<double,int
 	else if (iCC == USER)
 		for (int i=PATTERN_SIZE+250+500;i<PATTERN_SIZE+250+500+MAX_USER_CC_PATCH_SIZE;i++)
 				m_cc24SatMeasureArray_master[i] = m_cc24SatMeasureArray[i-(PATTERN_SIZE+250+500)];
+
+	// Same bookkeeping as the completion path: the master changed, so the
+	// document must learn it is modified (save prompt on close) and the
+	// sweeps-active info string must reflect the new contents.
+	m_isModified = TRUE;
+	m_CCStr = GetCCStr();
 }
 
 CString CMeasure::GetCCStr() const

--- a/Measure.h
+++ b/Measure.h
@@ -266,7 +266,7 @@ public:
 	CString GetCCStr() const;
 	// Publish an aborted color-checker sweep's partial live data to the
 	// per-set master array (the post-sweep read source); see Measure.cpp.
-	void SalvageCC24SatPartial(BOOL bUseLuxValues, const CArray<double,int> & measuredLux);
+	BOOL SalvageCC24SatPartial(BOOL bUseLuxValues, const CArray<double,int> & measuredLux);
 
 	// Display profile capture
 	CColor GetProfileMeasure(int i) const;

--- a/Measure.h
+++ b/Measure.h
@@ -264,6 +264,9 @@ public:
 	CColor GetCC24MasterSat(int i) const;
 	void SetCC24MasterSat(int i,const CColor & aColor) {m_cc24SatMeasureArray_master[i]=aColor; m_isModified=TRUE; }
 	CString GetCCStr() const;
+	// Publish an aborted color-checker sweep's partial live data to the
+	// per-set master array (the post-sweep read source); see Measure.cpp.
+	void SalvageCC24SatPartial(BOOL bUseLuxValues, const CArray<double,int> & measuredLux);
 
 	// Display profile capture
 	CColor GetProfileMeasure(int i) const;

--- a/Views/MainView.cpp
+++ b/Views/MainView.cpp
@@ -639,6 +639,8 @@ CMainView::CMainView()
 	dEcnt=0;
 	dE10=0.;
 	dE10min=0.;
+	m_nGridIncrCol = -1;
+	m_nGridLastRTCol = -1;
 	m_userBlack = FALSE;
 	m_oldBlackGS = noDataColor;
 	m_oldBlackNB = noDataColor;
@@ -2753,8 +2755,17 @@ void CMainView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 			}
 		}
 
+		// Color checker / user sequences store exactly one new patch per realtime
+		// hint, so ask UpdateGrid for an incremental pass over just that column
+		// (plus any the catch-up window covers) instead of repopulating all N --
+		// a large custom sequence otherwise costs O(N^2) grid work per sweep.
+		// Single-shot request: UpdateGrid consumes it and falls back to a full
+		// rebuild unless its column cache matches the current patch count.
+		if ( m_displayMode == 11 && minCol >= 1 && m_pGrayScaleGrid )
+			m_nGridIncrCol = minCol;
 		RefreshSelection(FALSE); //this will update grid
-		
+		m_nGridIncrCol = -1;
+
 		if ( m_pInfoWnd ) //in case colorchecker slot is updated
 		{
 				m_pInfoWnd -> SetWindowTextA(GetDocument()->GetMeasure()->GetInfoString());
@@ -3180,6 +3191,18 @@ CString CMainView::GetItemText(CColor & aMeasure, double YWhite, CColor & aRefer
 					dLavg+=(isNan(dL)?dLavg:dL);
 					dCavg+=(isNan(dC)?dCavg:dC);
 					dHavg+=(isNan(dH)?dHavg:dH);
+
+					// Per-column cache backing the incremental sweep path's summary
+					// re-aggregation (UpdateGrid). Valid dE only: a NaN dE (broken
+					// reading) stays at the -1 sentinel and is excluded there, where
+					// the classic accumulation above pushed a garbage running sum.
+					if ( m_displayMode == 11 && nCol >= 1 && nCol <= (int)m_ccDECache.size() && !isNan(dE) )
+					{
+						m_ccDECache[nCol-1] = dE;
+						m_ccDLCache[nCol-1] = dL;
+						m_ccDCCache[nCol-1] = dC;
+						m_ccDHCache[nCol-1] = dH;
+					}
 
 					if (nCol == minCol)
 					{
@@ -3644,6 +3667,11 @@ LPSTR CMainView::GetGridRowLabel(int aComponentNum)
 
 void CMainView::UpdateGrid()
 {
+	// Single-shot incremental request from the realtime sweep path (OnUpdate);
+	// consumed here so every other caller keeps full-rebuild semantics.
+	int nIncrCol = m_nGridIncrCol;
+	m_nGridIncrCol = -1;
+
 	// display profile (mode 13): the grid is hidden and the pane owns that area,
 	// so skip the grid population -- but still fall through to the View-pane info
 	// line at the end of this function. That line must track reference / EOTF
@@ -3964,7 +3992,41 @@ void CMainView::UpdateGrid()
 					
 		YWhite_for_color_comp = YWhite;
 
-		for( int j = 0 ; j < nCount ; j ++ )
+		// Incremental pass eligibility: mode 11 with a column cache built by a
+		// prior full pass over the SAME patch count. Anything else (first pass,
+		// CC set switched, manual edits) takes the full rebuild, which (re)sizes
+		// the cache -- the grid analog of the 3D viewer's stale-scene guard.
+		int jFirst = 0, jLast = nCount - 1;
+		bool bIncrPass = ( nIncrCol >= 1 && nIncrCol <= nCount &&
+						   m_displayMode == 11 && (int)m_ccDECache.size() == nCount );
+		if ( bIncrPass )
+		{
+			// Catch-up window: refresh every column measured since the last
+			// incremental pass. A sensor/pattern retry steps the sweep index
+			// back, so span from the older of (last refreshed, requested).
+			jFirst = nIncrCol - 1;
+			if ( m_nGridLastRTCol >= 1 && m_nGridLastRTCol <= nCount && m_nGridLastRTCol < nIncrCol )
+				jFirst = m_nGridLastRTCol - 1;
+			jLast = nIncrCol - 1;
+			m_nGridLastRTCol = nIncrCol;
+			for ( int j = jFirst ; j <= jLast ; j ++ )
+			{
+				m_ccDECache[j] = -1.0;
+				m_ccDLCache[j] = -1.0;
+				m_ccDCCache[j] = -1.0;
+				m_ccDHCache[j] = -1.0;
+			}
+		}
+		else if ( m_displayMode == 11 )
+		{
+			m_ccDECache.assign ( nCount, -1.0 );
+			m_ccDLCache.assign ( nCount, -1.0 );
+			m_ccDCCache.assign ( nCount, -1.0 );
+			m_ccDHCache.assign ( nCount, -1.0 );
+			m_nGridLastRTCol = -1;
+		}
+
+		for( int j = jFirst ; j <= jLast ; j ++ )
 		{
             int i = GetDocument() -> GetMeasure () -> GetGrayScaleSize ();
             ColorxyY tmpColor(GetColorReference().GetWhite());
@@ -4412,6 +4474,37 @@ void CMainView::UpdateGrid()
 			}
 		}
 		
+		// Mode 11 summary stats are re-aggregated from the per-column cache so a
+		// narrowed (incremental) pass yields the identical summary a full rebuild
+		// would: reset the classic accumulators GetItemText just fed and refill
+		// in column order, reproducing the full-loop fill exactly. Plain float
+		// adds over N entries -- no colorimetric math, no grid access.
+		if ( m_displayMode == 11 && (int)m_ccDECache.size() == nCount )
+		{
+			dEavg = 0.0; dLavg = 0.0; dCavg = 0.0; dHavg = 0.0;
+			dEmax = 0.0; dEcnt = 0; dE10 = 0.0;
+			dEvector.clear();
+			dLvector.clear();
+			dCvector.clear();
+			dHvector.clear();
+			for ( int j = 0 ; j < nCount ; j ++ )
+			{
+				if ( m_ccDECache[j] < 0.0 )
+					continue;
+				dEvector.push_back ( m_ccDECache[j] );
+				dLvector.push_back ( m_ccDLCache[j] );
+				dCvector.push_back ( m_ccDCCache[j] );
+				dHvector.push_back ( m_ccDHCache[j] );
+				dEavg += m_ccDECache[j];
+				dLavg += m_ccDLCache[j];
+				dCavg += m_ccDCCache[j];
+				dHavg += m_ccDHCache[j];
+				if ( m_ccDECache[j] > dEmax )
+					dEmax = m_ccDECache[j];
+				dEcnt ++;
+			}
+		}
+
 		if ( bAddedCol )
 		{
 			int width = m_pGrayScaleGrid -> GetColumnWidth ( 0 );

--- a/Views/MainView.cpp
+++ b/Views/MainView.cpp
@@ -3199,9 +3199,12 @@ CString CMainView::GetItemText(CColor & aMeasure, double YWhite, CColor & aRefer
 					if ( m_displayMode == 11 && nCol >= 1 && nCol <= (int)m_ccDECache.size() && !isNan(dE) )
 					{
 						m_ccDECache[nCol-1] = dE;
-						m_ccDLCache[nCol-1] = dL;
-						m_ccDCCache[nCol-1] = dC;
-						m_ccDHCache[nCol-1] = dH;
+						// a NaN component with a finite dE (degenerate XYZ under some
+						// dE forms) must not poison the re-aggregated averages into
+						// "nan"; contribute zero for that component instead
+						m_ccDLCache[nCol-1] = isNan(dL) ? 0.0 : dL;
+						m_ccDCCache[nCol-1] = isNan(dC) ? 0.0 : dC;
+						m_ccDHCache[nCol-1] = isNan(dH) ? 0.0 : dH;
 					}
 
 					if (nCol == minCol)

--- a/Views/MainView.cpp
+++ b/Views/MainView.cpp
@@ -2784,6 +2784,38 @@ void CMainView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 		if ( !( (lHint >= UPD_PRIMARIES && lHint <= UPD_FREEMEASURES) || lHint == UPD_CC24SAT ) )
 			CFormView::OnUpdate(pSender, lHint, pHint);
 
+		// m_CCStr is rebuilt when a color checker sweep ends -- on completion,
+		// and on the abort salvage. Both are AFTER the sweep's last realtime
+		// hint, and UPD_CC24SAT (25) is below UPD_REALTIME (26), so the summary
+		// pane's only other refresh (in the realtime branch above) never saw the
+		// new string: the sweeps-active list stayed as it was when the pane was
+		// last created. Refresh it here, and only when the text really changed,
+		// so a summary the user is part-way through typing is left alone.
+		// Only info display entry 0 owns this text: m_pInfoWnd is a CTargetWnd,
+		// CSpectrumWnd or CSubFrame for every other entry, and those return empty
+		// window text -- so an ungated write would never compare equal and would
+		// retitle and repaint an unrelated widget on every sweep end. Gate on the
+		// downcast rather than testing it after the write.
+		if ( lHint == UPD_CC24SAT && m_pInfoWnd )
+		{
+			CEditEx * pSummaryEdit = DYNAMIC_DOWNCAST ( CEditEx, m_pInfoWnd );
+			if ( pSummaryEdit )
+			{
+				CString strNew = GetDocument()->GetMeasure()->GetInfoString();
+				CString strOld;
+				pSummaryEdit -> GetWindowText ( strOld );
+				if ( strOld != strNew )
+				{
+					pSummaryEdit -> SetWindowTextA ( strNew );
+					// the text came from the document, so the control's recorded
+					// commands describe text that is no longer there
+					pSummaryEdit -> EmptyUndoBuffer ();
+					pSummaryEdit -> Invalidate ();
+					pSummaryEdit -> UpdateWindow ();
+				}
+			}
+		}
+
 		if ( m_displayType == HCFR_SENSORRGB_VIEW )
 		{
 			m_displayType = HCFR_xyY_VIEW;

--- a/Views/MainView.cpp
+++ b/Views/MainView.cpp
@@ -4529,7 +4529,18 @@ void CMainView::UpdateGrid()
 		case 8: bHasMeas = GetDocument()->GetMeasure()->GetYellowSat(0).isValid(); break;
 		case 9: bHasMeas = GetDocument()->GetMeasure()->GetCyanSat(0).isValid(); break;
 		case 10: bHasMeas = GetDocument()->GetMeasure()->GetMagentaSat(0).isValid(); break;
-		case 11: bHasMeas = GetDocument()->GetMeasure()->GetCC24Sat(0).isValid(); break;
+		case 11:
+			// Color checker sets are not filled front to back: MCD measures its
+			// patches permuted (slot 0 lands on the LAST iteration) and an
+			// aborted sweep salvages only the slots it reached, so probing patch
+			// 0 alone reported "no measurements" -- zeroing the dE header below
+			// -- next to visibly populated columns. The per-column cache this
+			// same UpdateGrid pass just built answers it for the whole set, and
+			// costs no extra GetCC24Sat call (whose i == 0 branch drives the
+			// pre-3.3.0 load prompt and its retry counter).
+			for ( int j = 0 ; ! bHasMeas && j < (int)m_ccDECache.size() ; j ++ )
+				bHasMeas = ( m_ccDECache[j] >= 0.0 );
+			break;
 		}
 		if ( ! bHasMeas )
 		{

--- a/Views/MainView.cpp
+++ b/Views/MainView.cpp
@@ -2638,10 +2638,11 @@ void CMainView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 				 break;
 
 			case UPD_CC24SAT:
+				 // The grid refresh this used to do here (a bare UpdateGrid) now
+				 // happens in the rebuild block below, which pairs it with InitGrid;
+				 // see the comment there for why the InitGrid is the load-bearing part.
 				 if ( m_displayMode != 11 )
 					nForceMode = 11;
-				 else
-					 UpdateGrid();
 				 break;
 
 			case UPD_ALLSATURATIONS:
@@ -2826,7 +2827,24 @@ void CMainView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 		GetDlgItem ( IDC_SENSORRGB_RADIO ) -> EnableWindow ( FALSE );
 
 
-		if ( ( lHint >= UPD_EVERYTHING && lHint <= UPD_FREEMEASURES ) || lHint == UPD_ARRAYSIZES || lHint == UPD_GENERALREFERENCES || lHint == UPD_DATAREFDOC || lHint == UPD_REFERENCEDATA )
+		// UPD_CC24SAT is the color checker sweep's end-of-run hint (sent on BOTH
+		// completion and abort by CDataSetDoc::MeasureCC24SatScale, and also by the
+		// background CC validation and the MultiFrm "colorchecker" command). It was
+		// already getting a full column repaint -- the switch above called
+		// UpdateGrid, and by sweep end the single-shot incremental request has been
+		// consumed, so that pass covers all N columns. What it never got was
+		// InitGrid, which owns the grid's ROW count (the only SetRowCount call).
+		//
+		// That matters because a sweep can change the row count. GetCC24Sat reads
+		// the live array while m_binMeasure is TRUE and the per-set master array
+		// afterwards, and lux values are stamped onto the array only at the end of
+		// the sweep -- so with a lux meter attached bHasLuxValues is FALSE for the
+		// whole sweep and TRUE once it ends, and InitGrid's nRows grows by one.
+		// With no InitGrid on this path the grid kept the row count it was built
+		// with and the Lux row never appeared, on completion or on abort.
+		// Running the rebuild block also drops the duplicate pass the switch used
+		// to make, so a sweep end still costs exactly one grid rebuild.
+		if ( ( lHint >= UPD_EVERYTHING && lHint <= UPD_FREEMEASURES ) || lHint == UPD_ARRAYSIZES || lHint == UPD_GENERALREFERENCES || lHint == UPD_DATAREFDOC || lHint == UPD_REFERENCEDATA || lHint == UPD_CC24SAT )
 		{
 			if ( lHint == UPD_EVERYTHING || lHint == UPD_ARRAYSIZES )
 			{

--- a/Views/MainView.h
+++ b/Views/MainView.h
@@ -210,6 +210,17 @@ public:
 
 	std::vector<double> dEvector, dLvector, dCvector, dHvector;
 
+	// Per-column dE/L/C/H cache for the color checker grid (mode 11); -1 =
+	// no valid dE. Lets the realtime sweep path refresh only the just-measured
+	// column and re-aggregate the summary from here instead of recomputing all
+	// N columns per patch -- same incremental idea as the 3D viewer's
+	// UPD_REALTIME+13 path. m_nGridIncrCol is the single-shot column request
+	// consumed by UpdateGrid; m_nGridLastRTCol bounds its catch-up window
+	// (a sensor retry steps the sweep index back).
+	std::vector<double> m_ccDECache, m_ccDLCache, m_ccDCCache, m_ccDHCache;
+	int m_nGridIncrCol;
+	int m_nGridLastRTCol;
+
 	CBrush *m_pBgBrush;
 	CRect  m_rcButtonPanel;	// solid panel behind the Display dropdown + action buttons
 


### PR DESCRIPTION
## What this does

Two user-visible changes to color checker / custom-sequence sweeps:

1. **The grid updates incrementally.** Previously every realtime hint repopulated all
   N columns, so a sweep cost O(N^2) grid work -- painful on large custom sequences.
   `UpdateGrid` now refreshes only the column that changed, and re-aggregates the
   mode-11 summary from a per-column dE/L/C/H cache so a narrowed pass yields the
   identical summary a full rebuild would.
2. **An aborted sweep keeps its data.** Stopping a sweep used to discard everything
   measured: the readings live only in the per-set live array, and the master array
   the grid reads after a sweep is copied only on completion, so the grid went blank
   on stop. `SalvageCC24SatPartial` publishes the partial band before every abort
   return, and flags the document modified so the data draws a save prompt.

276 insertions, 8 deletions, 4 files.

## Scope note

Three of the seven commits are wholly or partly fixes to **pre-existing** bugs rather
than to this branch's own work. They came up while testing this change, and they're
here because this branch either exposed them or made them load-bearing -- leaving
them out would ship a feature that visibly misbehaves on the MCD chart:

- `46745785` -- the sweep passed an **iteration** index where the grid, the
  measuring-column highlight, and `CTargetWnd::Refresh` all expect a **slot**. Under
  MCD those differ by six. Before this branch a wrong `minCol` only misplaced the
  highlight; once the incremental path used `minCol` to choose which column to
  repaint, the same wrong value started hiding data.
- `a28ea79d` -- `m_CCStr` is rebuilt when a sweep ends, but `UPD_CC24SAT` (25) sits
  below `UPD_REALTIME` (26), so the summary pane's only refresh never saw it. The
  pane showed the previous sweep's result, painted at the start of the next one.
- `28a2e529` -- two of its four findings (`lastColor` unpermuted; `m_isSettling` not
  restored on abort) are pre-existing.

If you'd rather these landed separately, I can split them out -- say so and I'll
restructure rather than have you review a diff that's broader than the title.

## Commits

| | |
|---|---|
| `097fcf25` | MainView: incremental grid update during CC/user-sequence sweeps |
| `2ce10b10` | Measure: salvage partial CC sweep data on abort |
| `79866e49` | Apply the /code-review findings to the sweep salvage and grid cache |
| `9619070c` | Flag the document modified when an aborted sweep salvages data |
| `28a2e529` | Apply the code review findings to the sweep salvage |
| `46745785` | Color checker sweep: a grid column is a slot, not an iteration |
| `a28ea79d` | Show the sweeps-active summary when a color checker sweep ends |

## Verification

Reviewed at `/code-review high` twice -- once over the first four commits, then scoped
separately over the last three. Eight findings across both passes: six fixed, two
deferred (below), one refuted by measurement.

Debug and Release both build clean, Win32. `ColorMathTest verify` exits 0.

Behavior was checked on real hardware with before/after builds, on MCD (the only
permuted chart, so the only one that exercises the ordering fixes), with GCD and a
completed-sweep pass as controls:

- dE header tracks from the first measured patch, live and after a stop -- previously
  all zeros for the entire sweep beside populated columns.
- Grid columns fill in step with the patch on screen, grayscale row included.
- Selected-color widget follows the first six patches.
- Summary lists each chart the moment its sweep ends, including a stopped sweep.
- `m_isSettling` survives an abort (checked through the INI -- that control is
  `NOT WS_VISIBLE | WS_DISABLED` in all five language resources).

**No ColorMathTest oracle accompanies this.** `Measure.cpp` and `Views/MainView.cpp`
are in the MFC app project; the harness links `libHCFR` only, so none of these paths
are reachable from it. Verification is the hardware runs above, not a test.

**One fix is not verifiable here and is labeled as such in its commit message:** the
lux permutation in `SalvageCC24SatPartial`. With no lux meter configured, the meter
thread never starts, `GetLuxMeasure` returns `LUX_NOMEASURE` on patch 0, and
`bUseLuxValues` short-circuits every later lux path including the changed line. It's
the same permutation applied two hunks above it, but it is reasoned, not measured.

## Deliberately out of scope

`GetCCStr` has two further pre-existing defects, found while fixing its patch-0 probe
and left for their own PRs so this one doesn't turn into a rewrite of set
identification:

- **Stale band offsets.** It probes `master[2300+100]` for Random-250, but
  `RANDOM250 = 34`, so that band starts at `3400` (`GetCC24Sat` uses `iCC*100`).
  Index `2400` is LGUK65XX's slot 0 -- an LG_UK65xx_2018 sweep is credited to
  "Random 250", and a real Random 250/500/User sweep is never listed at all.
- **Name-table drift.** `sweeps[7]` reads "CalMAN 10 pt Lum." but enum 7 is `AXIS`,
  duplicating index 10.

## Where to look

The load-bearing convention is that **a grid column is a slot, not an iteration**.
`CTargetWnd::Refresh`'s mode-11 branch documents it implicitly: it takes a slot
column and inverse-permutes to reach the display index. Everything MCD-related in
this branch follows from getting that right. `m_currentIndex` is now slot-based
during color checker sweeps, which is worth a second pair of eyes.
