### PR TITLE
Save the meter correction file into a folder that exists

### DIFF
--- a/CHCFR21_DEUTSCH.rc
+++ b/CHCFR21_DEUTSCH.rc
@@ -3247,6 +3247,7 @@ BEGIN
     IDS_ERRSENSOR           "Sensorfehler"
     IDS_INVALIDSENSORMATRIX "Ungültige Sensormatrix"
     IDS_MUSTSAVEINSUBDIR    "Sie müssen diese Datei im aktuellen Ordner speichern um sie später zu benutzen."
+    IDS_THC_SAVE_FAILED     "Die Korrekturdatei konnte nicht gespeichert werden.\n\n%s"
     IDS_RUNCONTINUOUS       "Kontinuierliche Messungen ausführen - F8"
     IDS_ONEMEASURE          "Eine Messung ausführen - F7"
     IDS_CONFIGURESENSOR     "Sensor konfigurieren"

--- a/CHCFR21_DEUTSCH.rc
+++ b/CHCFR21_DEUTSCH.rc
@@ -3248,6 +3248,7 @@ BEGIN
     IDS_INVALIDSENSORMATRIX "Ungültige Sensormatrix"
     IDS_MUSTSAVEINSUBDIR    "Sie müssen diese Datei im aktuellen Ordner speichern um sie später zu benutzen."
     IDS_THC_SAVE_FAILED     "Die Korrekturdatei konnte nicht gespeichert werden.\n\n%s"
+    IDS_THC_LOAD_FAILED     "Die Korrekturdatei konnte nicht gelesen werden.\n\n%s"
     IDS_RUNCONTINUOUS       "Kontinuierliche Messungen ausführen - F8"
     IDS_ONEMEASURE          "Eine Messung ausführen - F7"
     IDS_CONFIGURESENSOR     "Sensor konfigurieren"

--- a/CHCFR21_ENGLISH.rc
+++ b/CHCFR21_ENGLISH.rc
@@ -3235,6 +3235,7 @@ BEGIN
     IDS_ERRSENSOR           "Sensor error"
     IDS_INVALIDSENSORMATRIX "Invalid sensor matrix"
     IDS_MUSTSAVEINSUBDIR    "You must save this file in current directory to use it later."
+    IDS_THC_SAVE_FAILED     "The correction file could not be saved.\n\n%s"
     IDS_RUNCONTINUOUS       "Run continuous measures - F8"
     IDS_ONEMEASURE          "Take a measurement - F7"
     IDS_CONFIGURESENSOR     "Configure sensor"

--- a/CHCFR21_ENGLISH.rc
+++ b/CHCFR21_ENGLISH.rc
@@ -3236,6 +3236,7 @@ BEGIN
     IDS_INVALIDSENSORMATRIX "Invalid sensor matrix"
     IDS_MUSTSAVEINSUBDIR    "You must save this file in current directory to use it later."
     IDS_THC_SAVE_FAILED     "The correction file could not be saved.\n\n%s"
+    IDS_THC_LOAD_FAILED     "The correction file could not be read.\n\n%s"
     IDS_RUNCONTINUOUS       "Run continuous measures - F8"
     IDS_ONEMEASURE          "Take a measurement - F7"
     IDS_CONFIGURESENSOR     "Configure sensor"

--- a/CHCFR21_ESPANOL.rc
+++ b/CHCFR21_ESPANOL.rc
@@ -3353,6 +3353,7 @@ BEGIN
     IDS_ERRSENSOR           "Error del sensor"
     IDS_INVALIDSENSORMATRIX "La matriz del sensor no es válida"
     IDS_MUSTSAVEINSUBDIR    "Debe guardar este archivo en el directorio actual para poder usarlo después."
+    IDS_THC_SAVE_FAILED     "No se pudo guardar el archivo de corrección.\n\n%s"
     IDS_RUNCONTINUOUS       "Iniciar las medidas continuas - F8"
     IDS_ONEMEASURE          "Tomar una medida - F7"
     IDS_CONFIGURESENSOR     "Configurar el sensor"

--- a/CHCFR21_ESPANOL.rc
+++ b/CHCFR21_ESPANOL.rc
@@ -3354,6 +3354,7 @@ BEGIN
     IDS_INVALIDSENSORMATRIX "La matriz del sensor no es válida"
     IDS_MUSTSAVEINSUBDIR    "Debe guardar este archivo en el directorio actual para poder usarlo después."
     IDS_THC_SAVE_FAILED     "No se pudo guardar el archivo de corrección.\n\n%s"
+    IDS_THC_LOAD_FAILED     "No se pudo leer el archivo de corrección.\n\n%s"
     IDS_RUNCONTINUOUS       "Iniciar las medidas continuas - F8"
     IDS_ONEMEASURE          "Tomar una medida - F7"
     IDS_CONFIGURESENSOR     "Configurar el sensor"

--- a/CHCFR21_FRANCAIS.rc
+++ b/CHCFR21_FRANCAIS.rc
@@ -3478,6 +3478,7 @@ BEGIN
     IDS_INVALIDSENSORMATRIX "La matrice capteur est invalide"
     IDS_MUSTSAVEINSUBDIR    "Vous devez impérativement sauver cet étalon dans le répertoire indiqué pour qu'il soit pris en compte."
     IDS_THC_SAVE_FAILED     "Le fichier de correction n'a pas pu être enregistré.\n\n%s"
+    IDS_THC_LOAD_FAILED     "Le fichier de correction n'a pas pu être lu.\n\n%s"
     IDS_RUNCONTINUOUS       "Lance les mesures en continu - F8"
     IDS_ONEMEASURE          "Effectue une mesure - F7"
     IDS_CONFIGURESENSOR     "Configure le capteur"

--- a/CHCFR21_FRANCAIS.rc
+++ b/CHCFR21_FRANCAIS.rc
@@ -3477,6 +3477,7 @@ BEGIN
     IDS_ERRSENSOR           "Erreur capteur"
     IDS_INVALIDSENSORMATRIX "La matrice capteur est invalide"
     IDS_MUSTSAVEINSUBDIR    "Vous devez impérativement sauver cet étalon dans le répertoire indiqué pour qu'il soit pris en compte."
+    IDS_THC_SAVE_FAILED     "Le fichier de correction n'a pas pu être enregistré.\n\n%s"
     IDS_RUNCONTINUOUS       "Lance les mesures en continu - F8"
     IDS_ONEMEASURE          "Effectue une mesure - F7"
     IDS_CONFIGURESENSOR     "Configure le capteur"

--- a/CHCFR21_ITALIAN.rc
+++ b/CHCFR21_ITALIAN.rc
@@ -3431,6 +3431,7 @@ BEGIN
     IDS_ERRSENSOR           "Errore del sensore"
     IDS_INVALIDSENSORMATRIX "Matrice del sensore non valida"
     IDS_MUSTSAVEINSUBDIR    "È necessario salvare questo file nella directory corrente per usarlo in seguito."
+    IDS_THC_SAVE_FAILED     "Impossibile salvare il file di correzione.\n\n%s"
     IDS_RUNCONTINUOUS       "Esegui misure continue - F8"
     IDS_ONEMEASURE          "Prenda una misura - F7"
     IDS_CONFIGURESENSOR     "Configura il sensore"

--- a/CHCFR21_ITALIAN.rc
+++ b/CHCFR21_ITALIAN.rc
@@ -3432,6 +3432,7 @@ BEGIN
     IDS_INVALIDSENSORMATRIX "Matrice del sensore non valida"
     IDS_MUSTSAVEINSUBDIR    "È necessario salvare questo file nella directory corrente per usarlo in seguito."
     IDS_THC_SAVE_FAILED     "Impossibile salvare il file di correzione.\n\n%s"
+    IDS_THC_LOAD_FAILED     "Impossibile leggere il file di correzione.\n\n%s"
     IDS_RUNCONTINUOUS       "Esegui misure continue - F8"
     IDS_ONEMEASURE          "Prenda una misura - F7"
     IDS_CONFIGURESENSOR     "Configura il sensore"

--- a/ColorHCFRConfig.cpp
+++ b/ColorHCFRConfig.cpp
@@ -1217,6 +1217,210 @@ void CColorHCFRConfig::EnsurePathExists ( CString strPath )
 {
 	CreateDirectory ( strPath, NULL );
 }
+// ---- Sensor correction files (.thc) ----
+// Copy every .thc from one folder into the per-user folder. CopyFile with
+// bFailIfExists TRUE never overwrites, so a file already in the destination
+// always wins over an older copy found in the install tree.
+static void HcfrCopyThcFiles ( LPCSTR lpszSrcDir, LPCSTR lpszDestDir )
+{
+	char			szPattern [ MAX_PATH ];
+	WIN32_FIND_DATA	wfd;
+	HANDLE			hFind;
+	int				nLen;
+
+	nLen = _snprintf ( szPattern, sizeof ( szPattern ), "%s\\*.thc", lpszSrcDir );
+	if ( nLen < 0 || nLen >= (int) sizeof ( szPattern ) )
+		return;
+
+	hFind = FindFirstFile ( szPattern, & wfd );
+	if ( hFind == INVALID_HANDLE_VALUE )
+		return;
+
+	do
+	{
+		char	szSrc [ MAX_PATH ], szDst [ MAX_PATH ];
+		int		nSrc, nDst;
+
+		if ( wfd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY )
+			continue;
+
+		nSrc = _snprintf ( szSrc, sizeof ( szSrc ), "%s\\%s", lpszSrcDir, wfd.cFileName );
+		nDst = _snprintf ( szDst, sizeof ( szDst ), "%s%s", lpszDestDir, wfd.cFileName );
+		if ( nSrc > 0 && nSrc < (int) sizeof ( szSrc ) && nDst > 0 && nDst < (int) sizeof ( szDst ) )
+			CopyFile ( szSrc, szDst, TRUE );
+	} while ( FindNextFile ( hFind, & wfd ) );
+
+	FindClose ( hFind );
+}
+
+// Scan one install tree for the per-sensor Etalon_* folders earlier versions
+// used. Etalon_HCFR is the only one the installer populates, and its files are
+// corrections for the HCFR sensor, which this version cannot select - so it is
+// skipped, to keep some sixty shipped files out of every user's list. The UAC
+// VirtualStore mirror is the exception: nothing is redirected there unless the
+// user wrote it, so that tree is taken whole.
+static void HcfrScanForThc ( LPCSTR lpszBaseDir, LPCSTR lpszDestDir, BOOL bUserWritesOnly )
+{
+	char			szBase [ MAX_PATH ];
+	char			szPattern [ MAX_PATH ];
+	WIN32_FIND_DATA	wfd;
+	HANDLE			hFind;
+	int				nLen;
+
+	if ( lpszBaseDir == NULL || *lpszBaseDir == '\0' )
+		return;
+
+	// The caller's path may or may not carry a trailing backslash.
+	lstrcpyn ( szBase, lpszBaseDir, MAX_PATH );
+	nLen = strlen ( szBase );
+	while ( nLen > 1 && szBase [ nLen - 1 ] == '\\' && szBase [ nLen - 2 ] != ':' )
+		szBase [ -- nLen ] = '\0';
+
+	nLen = _snprintf ( szPattern, sizeof ( szPattern ), "%s\\Etalon_*", szBase );
+	if ( nLen < 0 || nLen >= (int) sizeof ( szPattern ) )
+		return;
+
+	hFind = FindFirstFile ( szPattern, & wfd );
+	if ( hFind == INVALID_HANDLE_VALUE )
+		return;
+
+	do
+	{
+		char	szSub [ MAX_PATH ];
+		int		nSub;
+
+		if ( ! ( wfd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY ) )
+			continue;
+		if ( ! bUserWritesOnly && _stricmp ( wfd.cFileName, "Etalon_HCFR" ) == 0 )
+			continue;
+
+		nSub = _snprintf ( szSub, sizeof ( szSub ), "%s\\%s", szBase, wfd.cFileName );
+		if ( nSub > 0 && nSub < (int) sizeof ( szSub ) )
+			HcfrCopyThcFiles ( szSub, lpszDestDir );
+	} while ( FindNextFile ( hFind, & wfd ) );
+
+	FindClose ( hFind );
+}
+
+// Bring across what earlier versions left in the install tree, and in the
+// VirtualStore mirror UAC redirected a standard user's writes to.
+static void HcfrMigrateThc ( LPCSTR lpszAppPath, LPCSTR lpszDestDir )
+{
+	HcfrScanForThc ( lpszAppPath, lpszDestDir, FALSE );
+
+	if ( lpszAppPath != NULL && lpszAppPath [ 0 ] != '\0' && lpszAppPath [ 1 ] == ':' )
+	{
+		const char *	pLocalAppData = getenv ( "LOCALAPPDATA" );
+
+		if ( pLocalAppData && *pLocalAppData )
+		{
+			char	szVirtual [ MAX_PATH ];
+			int		nLen;
+
+			// VirtualStore mirrors the install path minus its drive letter.
+			nLen = _snprintf ( szVirtual, sizeof ( szVirtual ), "%s\\VirtualStore\\%s", pLocalAppData, lpszAppPath + 3 );
+			if ( nLen > 0 && nLen < (int) sizeof ( szVirtual ) )
+				HcfrScanForThc ( szVirtual, lpszDestDir, TRUE );
+		}
+	}
+}
+
+// Once per user profile, recorded in the INI the same way the settings
+// migration is. Keying on the folder being empty instead would copy the old
+// files back the moment a user deleted the last of them, and would re-sweep
+// the install tree on every call for everyone who has nothing to migrate.
+static void HcfrMigrateThcOnce ( CColorHCFRConfig * pConfig, LPCSTR lpszAppPath, LPCSTR lpszDestDir )
+{
+	if ( pConfig -> GetProfileInt ( "Defaults", "EtalonMigrated", 0 ) != 0 )
+		return;
+
+	HcfrMigrateThc ( lpszAppPath, lpszDestDir );
+	pConfig -> WriteProfileInt ( "Defaults", "EtalonMigrated", 1 );
+}
+
+BOOL CColorHCFRConfig::GetEtalonPath ( CString & strPath )
+{
+	const char *	pAppData = getenv ( "APPDATA" );
+	char			szParent [ MAX_PATH ];
+	char			szEtalon [ MAX_PATH ];
+	DWORD			dwAttributes;
+	int				nLen;
+
+	if ( pAppData == NULL || *pAppData == '\0' )
+	{
+		// No roaming profile to write into. Name the historical location so the
+		// caller still has something to show, and report whether it is usable.
+		strPath = m_ApplicationPath;
+		strPath += "Etalon\\";
+		CreateDirectory ( strPath, NULL );
+		dwAttributes = GetFileAttributes ( strPath );
+		return ( dwAttributes != INVALID_FILE_ATTRIBUTES
+			  && ( dwAttributes & FILE_ATTRIBUTE_DIRECTORY ) != 0 );
+	}
+
+	// strPath is filled in on every path, including these: a caller that only
+	// has it to name in a message must never be handed an empty string.
+	nLen = _snprintf ( szParent, sizeof ( szParent ), "%s\\HCFR", pAppData );
+	if ( nLen < 0 || nLen >= (int) sizeof ( szParent ) )
+	{
+		strPath = pAppData;
+		strPath += "\\HCFR\\Etalon\\";
+		SetLastError ( ERROR_FILENAME_EXCED_RANGE );
+		return FALSE;
+	}
+	nLen = _snprintf ( szEtalon, sizeof ( szEtalon ), "%s\\Etalon", szParent );
+	if ( nLen < 0 || nLen >= (int) sizeof ( szEtalon ) )
+	{
+		strPath = szParent;
+		strPath += "\\Etalon\\";
+		SetLastError ( ERROR_FILENAME_EXCED_RANGE );
+		return FALSE;
+	}
+
+	strPath = szEtalon;
+	strPath += '\\';
+
+	// Only a directory will do: something else of that name would hand every
+	// later call a path it cannot use.
+	dwAttributes = GetFileAttributes ( szEtalon );
+	if ( dwAttributes != INVALID_FILE_ATTRIBUTES )
+	{
+		if ( ! ( dwAttributes & FILE_ATTRIBUTE_DIRECTORY ) )
+		{
+			SetLastError ( ERROR_DIRECTORY );
+			return FALSE;
+		}
+
+		// The folder exists, but that alone does not mean the files came across:
+		// the first run may have failed every copy, and a roaming profile arrives
+		// on a second machine already carrying the folder and none of its files.
+		// Retry while it still holds nothing, then leave it alone for good.
+		HcfrMigrateThcOnce ( this, m_ApplicationPath, strPath );
+		return TRUE;
+	}
+
+	// %APPDATA% always exists; the two levels below it may not.
+	CreateDirectory ( szParent, NULL );
+	if ( ! CreateDirectory ( szEtalon, NULL ) )
+	{
+		// ERROR_ALREADY_EXISTS covers a file of that name as well as a folder.
+		if ( GetLastError () != ERROR_ALREADY_EXISTS )
+			return FALSE;
+
+		dwAttributes = GetFileAttributes ( szEtalon );
+		if ( dwAttributes == INVALID_FILE_ATTRIBUTES
+		  || ! ( dwAttributes & FILE_ATTRIBUTE_DIRECTORY ) )
+		{
+			SetLastError ( ERROR_DIRECTORY );
+			return FALSE;
+		}
+		HcfrMigrateThcOnce ( this, m_ApplicationPath, strPath );
+		return TRUE;
+	}
+
+	HcfrMigrateThcOnce ( this, m_ApplicationPath, strPath );
+	return TRUE;
+}
 
 std::vector<int> cTargetR;
 std::vector<int> cTargetG;

--- a/ColorHCFRConfig.cpp
+++ b/ColorHCFRConfig.cpp
@@ -1218,12 +1218,104 @@ void CColorHCFRConfig::EnsurePathExists ( CString strPath )
 	CreateDirectory ( strPath, NULL );
 }
 // ---- Sensor correction files (.thc) ----
-// Copy every .thc from one folder into the per-user folder. CopyFile with
-// bFailIfExists TRUE never overwrites, so a file already in the destination
-// always wins over an older copy found in the install tree.
+// The part of a source folder's name that tells its files apart from another
+// folder's: "Etalon_Argyll" gives "Argyll".
+static void HcfrThcFolderTag ( LPCSTR lpszSrcDir, LPSTR lpszTag, int nTagSize )
+{
+	char			szDir [ MAX_PATH ];
+	const char *	pLeaf;
+	int				nLen;
+
+	lstrcpyn ( szDir, lpszSrcDir, MAX_PATH );
+	nLen = strlen ( szDir );
+	while ( nLen > 1 && szDir [ nLen - 1 ] == '\\' && szDir [ nLen - 2 ] != ':' )
+		szDir [ -- nLen ] = '\0';
+
+	pLeaf = strrchr ( szDir, '\\' );
+	pLeaf = pLeaf ? pLeaf + 1 : szDir;
+
+	// Every folder reaching here matched Etalon_*, but do not depend on it.
+	if ( _strnicmp ( pLeaf, "Etalon_", 7 ) == 0 )
+		pLeaf += 7;
+	if ( * pLeaf == '\0' )
+		pLeaf = "old";
+
+	lstrcpyn ( lpszTag, pLeaf, nTagSize );
+}
+
+// A file already at the destination with the same size and last-write time is
+// this same file, brought across by an earlier sweep: CopyFile preserves both.
+// The migration is meant to run once, but the flag recording it lives in the
+// INI, which a user can lose or start afresh, so a second sweep must not turn
+// everything it already copied into a numbered duplicate.
+static BOOL HcfrThcAlreadyCopied ( const WIN32_FIND_DATA * pSrc, LPCSTR lpszDst )
+{
+	WIN32_FILE_ATTRIBUTE_DATA	fad;
+
+	if ( ! GetFileAttributesEx ( lpszDst, GetFileExInfoStandard, & fad ) )
+		return FALSE;
+
+	return ( fad.nFileSizeHigh == pSrc -> nFileSizeHigh
+	      && fad.nFileSizeLow == pSrc -> nFileSizeLow
+	      && CompareFileTime ( & fad.ftLastWriteTime, & pSrc -> ftLastWriteTime ) == 0 );
+}
+
+// Copy one .thc into the per-user folder. Every sensor used to have a folder of
+// its own, so the same file name can appear in several of them; gathered into
+// one folder they collide. CopyFile with bFailIfExists TRUE would simply not
+// copy the second, leaving enumeration order to decide which of the two the
+// user keeps and saying nothing about the one that went. Name the collider
+// after the folder it came from - the very thing that told the two apart
+// before - rather than losing it.
+static void HcfrCopyOneThc ( LPCSTR lpszSrc, const WIN32_FIND_DATA * pwfd, LPCSTR lpszDestDir, LPCSTR lpszTag )
+{
+	char	szDst [ MAX_PATH ];
+	char	szBase [ MAX_PATH ];
+	char	szExt [ MAX_PATH ];
+	char *	pExt;
+	int		nLen;
+	int		nTry;
+
+	nLen = _snprintf ( szDst, sizeof ( szDst ), "%s%s", lpszDestDir, pwfd -> cFileName );
+	if ( nLen < 0 || nLen >= (int) sizeof ( szDst ) )
+		return;
+
+	if ( CopyFile ( lpszSrc, szDst, TRUE ) )
+		return;
+	if ( GetLastError () != ERROR_FILE_EXISTS || HcfrThcAlreadyCopied ( pwfd, szDst ) )
+		return;
+
+	// Keep the tag out of the extension, so the copy is still a .thc.
+	lstrcpyn ( szBase, pwfd -> cFileName, MAX_PATH );
+	szExt [ 0 ] = '\0';
+	pExt = strrchr ( szBase, '.' );
+	if ( pExt )
+	{
+		lstrcpyn ( szExt, pExt, MAX_PATH );
+		* pExt = '\0';
+	}
+
+	for ( nTry = 1 ; nTry <= 99 ; nTry ++ )
+	{
+		if ( nTry == 1 )
+			nLen = _snprintf ( szDst, sizeof ( szDst ), "%s%s (%s)%s", lpszDestDir, szBase, lpszTag, szExt );
+		else
+			nLen = _snprintf ( szDst, sizeof ( szDst ), "%s%s (%s %d)%s", lpszDestDir, szBase, lpszTag, nTry, szExt );
+
+		if ( nLen < 0 || nLen >= (int) sizeof ( szDst ) )
+			return;
+		if ( CopyFile ( lpszSrc, szDst, TRUE ) )
+			return;
+		if ( GetLastError () != ERROR_FILE_EXISTS || HcfrThcAlreadyCopied ( pwfd, szDst ) )
+			return;
+	}
+}
+
+// Copy every .thc from one folder into the per-user folder.
 static void HcfrCopyThcFiles ( LPCSTR lpszSrcDir, LPCSTR lpszDestDir )
 {
 	char			szPattern [ MAX_PATH ];
+	char			szTag [ MAX_PATH ];
 	WIN32_FIND_DATA	wfd;
 	HANDLE			hFind;
 	int				nLen;
@@ -1232,22 +1324,23 @@ static void HcfrCopyThcFiles ( LPCSTR lpszSrcDir, LPCSTR lpszDestDir )
 	if ( nLen < 0 || nLen >= (int) sizeof ( szPattern ) )
 		return;
 
+	HcfrThcFolderTag ( lpszSrcDir, szTag, sizeof ( szTag ) );
+
 	hFind = FindFirstFile ( szPattern, & wfd );
 	if ( hFind == INVALID_HANDLE_VALUE )
 		return;
 
 	do
 	{
-		char	szSrc [ MAX_PATH ], szDst [ MAX_PATH ];
-		int		nSrc, nDst;
+		char	szSrc [ MAX_PATH ];
+		int		nSrc;
 
 		if ( wfd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY )
 			continue;
 
 		nSrc = _snprintf ( szSrc, sizeof ( szSrc ), "%s\\%s", lpszSrcDir, wfd.cFileName );
-		nDst = _snprintf ( szDst, sizeof ( szDst ), "%s%s", lpszDestDir, wfd.cFileName );
-		if ( nSrc > 0 && nSrc < (int) sizeof ( szSrc ) && nDst > 0 && nDst < (int) sizeof ( szDst ) )
-			CopyFile ( szSrc, szDst, TRUE );
+		if ( nSrc > 0 && nSrc < (int) sizeof ( szSrc ) )
+			HcfrCopyOneThc ( szSrc, & wfd, lpszDestDir, szTag );
 	} while ( FindNextFile ( hFind, & wfd ) );
 
 	FindClose ( hFind );
@@ -1391,10 +1484,10 @@ BOOL CColorHCFRConfig::GetEtalonPath ( CString & strPath )
 			return FALSE;
 		}
 
-		// The folder exists, but that alone does not mean the files came across:
-		// the first run may have failed every copy, and a roaming profile arrives
-		// on a second machine already carrying the folder and none of its files.
-		// Retry while it still holds nothing, then leave it alone for good.
+		// The folder existing does not say the migration has run: an earlier run
+		// may have created it and then failed every copy, and the user can have
+		// made it by hand. Whether to sweep is decided by the once-flag in the
+		// INI and by nothing about the folder itself - see HcfrMigrateThcOnce.
 		HcfrMigrateThcOnce ( this, m_ApplicationPath, strPath );
 		return TRUE;
 	}

--- a/ColorHCFRConfig.h
+++ b/ColorHCFRConfig.h
@@ -196,6 +196,14 @@ public:
 	void DisplayHelp ( UINT nId, LPCSTR lpszTopic );
 	void EnsurePathExists ( CString strPath );
 
+	// Folder holding the sensor correction files (.thc). It lives under the
+	// user's profile and not in the install directory: that directory is
+	// read-only when installed under Program Files, and an uninstall removes
+	// everything in it, corrections the user made included. Returns FALSE when
+	// the folder does not exist and cannot be created; strPath is filled in
+	// either way so a caller can name the folder in a message.
+	BOOL GetEtalonPath ( CString & strPath );
+
 	// --- High-DPI support (Phase 0) --------------------------------------
 	// 96 DPI == 100% scaling. GetDpiForHWND prefers the per-monitor Win10
 	// GetDpiForWindow API (resolved dynamically because we target Win7 SDK

--- a/MainFrm.cpp
+++ b/MainFrm.cpp
@@ -996,17 +996,11 @@ LRESULT CMainFrame::OnDDEExecute(WPARAM wParam, LPARAM lParam)
 
 					if ( ! strParam.IsEmpty () )
 					{
-						CString strPath, strSubDir;
+						CString strPath;
 
 						g_bNewDocUseDDEInfo = TRUE;
 
-						strPath = GetConfig () -> m_ApplicationPath;
-						strSubDir = CSensorSelectionPropPage::GetThcFileSubDir ( g_NewDocSensorID );
-						if ( ! strSubDir.IsEmpty () )
-						{
-							strPath += strSubDir;
-							strPath += '\\';
-						}
+						GetConfig () -> GetEtalonPath ( strPath );
 						
 						g_ThcFileName = strPath + strParam + ".thc";
 

--- a/MultiFrm.cpp
+++ b/MultiFrm.cpp
@@ -2594,22 +2594,41 @@ BOOL CMultiFrame::DdeCmdExec ( CString & strCommand, BOOL bCanSendAckMsg, HWND h
 						// A write that throws here has no handler of its own: this is a
 						// script command, so report the failure through bOk instead of
 						// letting it unwind to MFC as "Command failed".
-						// Let Windows name the temporary: the caller supplies this path and
-						// nothing bounds its length, so appending could exceed MAX_PATH.
 						CString strTempPath;
 						CString strDir = str.Left ( str.ReverseFind ( '\\' ) + 1 );
-						char	szTempName [ MAX_PATH ];
 
 						if ( strDir.IsEmpty () )
 							strDir = ".\\";
-						if ( GetTempFileName ( strDir, "thc", 0, szTempName ) != 0 )
-							strTempPath = szTempName;
-						else
-							bOk = FALSE;
 
-						if ( bOk )
 						TRY
 						{
+							char	szTempName [ MAX_PATH ];
+
+							// Ask for write access on the target before writing anything,
+							// the same way the interactive save does. The MoveFileEx below
+							// needs rights on the folder and not on the file, so a
+							// correction whose own ACL denies this user write is replaced
+							// by the rename even though the user cannot open it to write.
+							// The CFile::modeCreate this code replaced was refused in that
+							// case, so without the probe a script command destroys a file
+							// 4.1.0 would not touch. The read-only attribute is not the
+							// case to reason about: MoveFileEx refuses that one by itself.
+							// Opening without modeCreate is what keeps the probe from
+							// truncating: MFC maps to CREATE_ALWAYS or OPEN_ALWAYS only
+							// when modeCreate is set, and to OPEN_EXISTING otherwise.
+							if ( GetFileAttributes ( str ) != INVALID_FILE_ATTRIBUTES )
+							{
+								CFile probeFile ( str, CFile::modeWrite );
+								probeFile.Close ();
+							}
+
+							// Let Windows name the temporary: the caller supplies this path
+							// and nothing bounds its length, so appending could exceed
+							// MAX_PATH.
+							if ( GetTempFileName ( strDir, "thc", 0, szTempName ) == 0 )
+								AfxThrowFileException ( CFileException::genericException, (LONG) GetLastError (), str );
+							strTempPath = szTempName;
+
 							CFile ThcFile ( strTempPath, CFile::modeCreate | CFile::modeWrite );
 							CArchive ar ( & ThcFile, CArchive::store );
 

--- a/MultiFrm.cpp
+++ b/MultiFrm.cpp
@@ -2578,13 +2578,9 @@ BOOL CMultiFrame::DdeCmdExec ( CString & strCommand, BOOL bCanSendAckMsg, HWND h
 				{
 					if ( strParam.Find ( '\\' ) < 0 )
 					{
-						// Build full calibration file name
-						str = GetConfig () -> m_ApplicationPath;
-						str += pSensor -> GetStandardSubDir ();
-						
-						GetConfig () -> EnsurePathExists ( str );
-						
-						str += '\\';
+						// Build full calibration file name. An unusable folder fails the
+						// command rather than being written past.
+						bOk = GetConfig () -> GetEtalonPath ( str );
 						str += strParam;
 					}
 					else
@@ -2593,9 +2589,47 @@ BOOL CMultiFrame::DdeCmdExec ( CString & strCommand, BOOL bCanSendAckMsg, HWND h
 						str = strParam;
 					}
 
-					CFile ThcFile ( str, CFile::modeCreate | CFile::modeWrite );
-					CArchive ar ( & ThcFile, CArchive::store );
-					pSensor -> Serialize(ar);
+					if ( bOk )
+					{
+						// A write that throws here has no handler of its own: this is a
+						// script command, so report the failure through bOk instead of
+						// letting it unwind to MFC as "Command failed".
+						// Let Windows name the temporary: the caller supplies this path and
+						// nothing bounds its length, so appending could exceed MAX_PATH.
+						CString strTempPath;
+						CString strDir = str.Left ( str.ReverseFind ( '\\' ) + 1 );
+						char	szTempName [ MAX_PATH ];
+
+						if ( strDir.IsEmpty () )
+							strDir = ".\\";
+						if ( GetTempFileName ( strDir, "thc", 0, szTempName ) != 0 )
+							strTempPath = szTempName;
+						else
+							bOk = FALSE;
+
+						if ( bOk )
+						TRY
+						{
+							CFile ThcFile ( strTempPath, CFile::modeCreate | CFile::modeWrite );
+							CArchive ar ( & ThcFile, CArchive::store );
+
+							pSensor -> Serialize(ar);
+
+							ar.Close ();
+							ThcFile.Close ();
+
+							if ( ! MoveFileEx ( strTempPath, str, MOVEFILE_REPLACE_EXISTING ) )
+								bOk = FALSE;
+						}
+						CATCH_ALL ( e )
+						{
+							bOk = FALSE;
+						}
+						END_CATCH_ALL
+
+						if ( ! bOk && ! strTempPath.IsEmpty () )
+							DeleteFile ( strTempPath );
+					}
 				}
 			}
 		}

--- a/NewDocPropertyPages.cpp
+++ b/NewDocPropertyPages.cpp
@@ -208,18 +208,11 @@ BOOL CSensorSelectionPropPage::OnWizardFinish()
 {
 	int				nSel;
 	CString			strPath;
-	CString			strSubDir;
 	CString			strFileName;
 
 	UpdateData(TRUE);	// To update values
 
-	strPath = GetConfig () -> m_ApplicationPath;
-	strSubDir = GetFileSubDir ();
-	if ( ! strSubDir.IsEmpty () )
-	{
-		strPath += strSubDir;
-		strPath += '\\';
-	}
+	GetConfig () -> GetEtalonPath ( strPath );
 	
 	nSel = m_trainingFileCombo.GetCurSel ();
 	if ( nSel >= 0 )
@@ -286,7 +279,6 @@ void CSensorSelectionPropPage::OnSelchangeSensorchoiceCombo()
 	
 	m_trainingFileCombo.ResetContent ();
 
-	strPath = GetConfig () -> m_ApplicationPath;
 	strSubDir = GetFileSubDir ();
 	
 	if ( ! strSubDir.IsEmpty () )
@@ -309,10 +301,7 @@ void CSensorSelectionPropPage::OnSelchangeSensorchoiceCombo()
 		GetDlgItem (IDC_SENSORTRAININGMODE_RADIO2) -> EnableWindow ( TRUE );
 		m_trainingFileCombo.EnableWindow ( TRUE );
 
-		strPath += strSubDir;
-		strPath += '\\';
-	
-		GetConfig () -> EnsurePathExists ( strPath );
+		GetConfig () -> GetEtalonPath ( strPath );
 
 		bFileFound = FALSE;
 		strSearch = strPath + "*.thc";

--- a/Sensors/OneDeviceSensor.cpp
+++ b/Sensors/OneDeviceSensor.cpp
@@ -392,12 +392,104 @@ void COneDeviceSensor::GetPropertiesSheetValues()
 	}
 }
 
+// Say why a correction file could not be read, naming the file. A CArchive
+// exception carries no file name of its own, so MFC's handler reported these
+// as "an unnamed file contains an incorrect schema"; fill the name in the way
+// CDocument::ReportSaveLoadException does for a file exception, then let MFC
+// describe the cause.
+static void ReportCalibrationLoadFailure ( LPCSTR lpszPath, CException * e )
+{
+	CString	strWhat ( lpszPath );
+	CString	strMsg;
+	char	szCause [ 512 ];
+
+	if ( e != NULL )
+	{
+		if ( e -> IsKindOf ( RUNTIME_CLASS ( CArchiveException ) ) )
+		{
+			CArchiveException *	pEx = (CArchiveException *) e;
+
+			if ( pEx -> m_strFileName.IsEmpty () )
+				pEx -> m_strFileName = lpszPath;
+		}
+		else if ( e -> IsKindOf ( RUNTIME_CLASS ( CFileException ) ) )
+		{
+			CFileException *	pEx = (CFileException *) e;
+
+			if ( pEx -> m_strFileName.IsEmpty () )
+				pEx -> m_strFileName = lpszPath;
+		}
+
+		if ( e -> GetErrorMessage ( szCause, sizeof ( szCause ) ) )
+		{
+			CString	strCause ( szCause );
+
+			strCause.TrimRight ( "\r\n" );
+			if ( ! strCause.IsEmpty () )
+				strWhat = strCause;
+		}
+	}
+
+	strMsg.Format ( IDS_THC_LOAD_FAILED, (LPCSTR) strWhat );
+	AfxMessageBox ( strMsg, MB_OK | MB_ICONEXCLAMATION );
+}
+
 void COneDeviceSensor::LoadCalibrationFile(CString & aFileName)
 {
-	CFile loadFile(aFileName,CFile::modeRead);
-	CArchive ar(&loadFile,CArchive::load);
-	COneDeviceSensor::Serialize(ar);
-	m_CalibrationFileName = loadFile.GetFileTitle ();
+	// Serialize's load branch overwrites the sensor field by field and frees
+	// m_pCalibrationInfo before the version-gated read, so a file that is
+	// rejected part-way through - a truncated one, or a schema this build does
+	// not know - leaves the sensor carrying pieces of it. Every caller applies
+	// the sensor matrix as soon as this returns, so hold the whole of the old
+	// state and put it back: a file that could not be read changes nothing.
+	Matrix				previousMatrix = m_sensorToXYZMatrix;
+	time_t				previousTime = m_calibrationTime;
+	float				previousIRELevel = m_calibrationIRELevel;
+	BOOL				bPreviousBlackComp = m_doBlackCompensation;
+	BOOL				bPreviousVerifyAdd = m_doVerifyAdditivity;
+	BOOL				bPreviousShowAdd = m_showAdditivityResults;
+	int					nPreviousMaxAddErr = m_maxAdditivityErrorPercent;
+	Matrix				previousPrimaries = m_primariesChromacities;
+	Matrix				previousWhite = m_whiteChromacity;
+	CString				strPreviousRef = m_calibrationReferenceName;
+	CString				strPreviousName = m_CalibrationFileName;
+	CCalibrationInfo *	pPreviousInfo = m_pCalibrationInfo;
+
+	// Detach it first: Serialize deletes whatever the member points at, and
+	// that is the copy we are keeping.
+	m_pCalibrationInfo = NULL;
+
+	TRY
+	{
+		CFile loadFile(aFileName,CFile::modeRead);
+		CArchive ar(&loadFile,CArchive::load);
+
+		COneDeviceSensor::Serialize(ar);
+
+		m_CalibrationFileName = loadFile.GetFileTitle ();
+
+		delete pPreviousInfo;
+	}
+	CATCH_ALL ( e )
+	{
+		delete m_pCalibrationInfo;
+
+		m_sensorToXYZMatrix = previousMatrix;
+		m_calibrationTime = previousTime;
+		m_calibrationIRELevel = previousIRELevel;
+		m_doBlackCompensation = bPreviousBlackComp;
+		m_doVerifyAdditivity = bPreviousVerifyAdd;
+		m_showAdditivityResults = bPreviousShowAdd;
+		m_maxAdditivityErrorPercent = nPreviousMaxAddErr;
+		m_primariesChromacities = previousPrimaries;
+		m_whiteChromacity = previousWhite;
+		m_calibrationReferenceName = strPreviousRef;
+		m_CalibrationFileName = strPreviousName;
+		m_pCalibrationInfo = pPreviousInfo;
+
+		ReportCalibrationLoadFailure ( aFileName, e );
+	}
+	END_CATCH_ALL
 }
 
 // Compare two directories as file system locations rather than as strings:
@@ -508,35 +600,19 @@ void COneDeviceSensor::SaveCalibrationFile()
 {
 	BOOL			bContinue = FALSE;
 	CString			strPath;
-	CString			strSubDir;
 	CString			strFileName;
-	LPSTR			lpStr;
-	DWORD			dwError;
-	DWORD			dwAttributes;
+	int				nDot;
 
-	strPath = GetConfig () -> m_ApplicationPath;
-	strSubDir = GetStandardSubDir ();
-	if ( ! strSubDir.IsEmpty () )
+	// Correction files live under the user's profile, not beside the exe: the
+	// install directory is read-only under Program Files, and an uninstall
+	// removes everything in it. GetEtalonPath creates the folder and says
+	// whether it is really there - carrying on regardless would leave the user
+	// in the reopen-until-cancel loop this is meant to end.
+	SetLastError ( ERROR_SUCCESS );
+	if ( ! GetConfig () -> GetEtalonPath ( strPath ) )
 	{
-		strPath += strSubDir;
-		strPath += '\\';
-
-		// That subdirectory is the only place the sensor selection page looks
-		// for training files, so create it before offering to save into it.
-		// EnsurePathExists cannot report failure, and under an installation in
-		// Program Files a standard user cannot create the folder at all, so ask
-		// whether it is there afterwards: carrying on regardless would leave the
-		// user in the reopen-until-cancel loop this is meant to end.
-		SetLastError ( ERROR_SUCCESS );
-		GetConfig () -> EnsurePathExists ( strPath );
-		dwError = GetLastError ();
-
-		dwAttributes = GetFileAttributes ( strPath );
-		if ( dwAttributes == INVALID_FILE_ATTRIBUTES || ! ( dwAttributes & FILE_ATTRIBUTE_DIRECTORY ) )
-		{
-			ReportCalibrationSaveFailure ( strPath, dwError );
-			return;
-		}
+		ReportCalibrationSaveFailure ( strPath, GetLastError () );
+		return;
 	}
 
 	do
@@ -560,15 +636,51 @@ void COneDeviceSensor::SaveCalibrationFile()
 			if ( IsSameDirectory ( strChosenDir, strPath ) )
 			{
 				CString	strPreviousName = m_CalibrationFileName;
+				CString	strTempPath;
 
 				// The folder can exist and still refuse the write, which is what a
 				// Program Files installation does to a standard user. Say so here
 				// rather than letting the exception reach MFC's default handler.
+				//
+				// Write to a temporary in the same folder and rename it into place:
+				// CFile::modeCreate truncates the target as it opens, so writing
+				// straight to it would destroy the correction the user already had
+				// before finding out whether the new one can be written at all.
 				TRY
 				{
-					CFile saveFile(strChosenPath,CFile::modeCreate|CFile::modeWrite);
+					char			szTempName [ MAX_PATH ];
+
+					// Ask for write access on the target before writing anything. The
+					// rename below replaces a file on the strength of directory rights
+					// alone, so without this a correction the user has write-protected
+					// would be silently replaced. modeNoTruncate keeps the probe from
+					// being the very truncation this temporary file exists to avoid.
+					if ( GetFileAttributes ( strChosenPath ) != INVALID_FILE_ATTRIBUTES )
+					{
+						CFile probeFile(strChosenPath,CFile::modeWrite|CFile::modeNoTruncate);
+						probeFile.Close ();
+					}
+
+					// Let Windows name the temporary. Appending to the chosen path could
+					// push it past MAX_PATH, because the dialog already accepts a name
+					// right up to that limit.
+					if ( GetTempFileName ( strChosenDir, "thc", 0, szTempName ) == 0 )
+						AfxThrowFileException ( CFileException::genericException, (LONG) GetLastError (), strChosenPath );
+					strTempPath = szTempName;
+
+					CFile saveFile(strTempPath,CFile::modeCreate|CFile::modeWrite);
 					CArchive ar(&saveFile,CArchive::store);
-					CString	strTitle = saveFile.GetFileTitle ();
+					CString	strTitle;
+					char			szTitle [ _MAX_FNAME ];
+
+					// The name CFile::GetFileTitle would give, taken from the path the
+					// file will carry once renamed into place. MFC wraps this API in a
+					// helper that is not public, so call it directly and fall back to the
+					// bare file name the same way that helper does.
+					if ( ::GetFileTitle ( strChosenPath, szTitle, (WORD) sizeof ( szTitle ) ) == 0 )
+						strTitle = szTitle;
+					else
+						strTitle = strChosenPath.Mid ( strChosenPath.ReverseFind ( '\\' ) + 1 );
 
 					// The archive records the correction this sensor was built from,
 					// and this file is that correction, so it stores an empty name.
@@ -580,14 +692,19 @@ void COneDeviceSensor::SaveCalibrationFile()
 					ar.Close ();
 					saveFile.Close ();
 
+					if ( ! MoveFileEx ( strTempPath, strChosenPath, MOVEFILE_REPLACE_EXISTING ) )
+						AfxThrowFileException ( CFileException::genericException, (LONG) GetLastError (), strChosenPath );
+
 					m_CalibrationFileName = strTitle;
 				}
 				CATCH_ALL ( e )
 				{
 					DWORD	dwSaveError = 0;
 
-					// Nothing reached the disk, so keep the name the sensor already
-					// had: the empty one above was only meant to reach the file.
+					// The file the user already had was never opened, so it still
+					// stands; only the temporary is discarded.
+					if ( ! strTempPath.IsEmpty () )
+						DeleteFile ( strTempPath );
 					m_CalibrationFileName = strPreviousName;
 
 					if ( e -> IsKindOf ( RUNTIME_CLASS ( CFileException ) ) )
@@ -606,10 +723,13 @@ void COneDeviceSensor::SaveCalibrationFile()
 				Msg += "\n\n";
 				Msg += strPath;
 				AfxMessageBox ( Msg );
+				// Drop the extension through CString, not by writing a NUL into its
+				// buffer: that leaves the stored length stale, and strPath + strFileName
+				// above concatenates by length, not to the first NUL.
 				strFileName = fileSaveDialog.GetFileName();
-				lpStr = strrchr ( (LPSTR)(LPCSTR) strFileName, '.' );
-				if ( lpStr )
-					lpStr [ 0 ] = '\0';
+				nDot = strFileName.ReverseFind ( '.' );
+				if ( nDot > 0 )
+					strFileName = strFileName.Left ( nDot );
 				bContinue = TRUE;
 			}
 		}

--- a/Sensors/OneDeviceSensor.cpp
+++ b/Sensors/OneDeviceSensor.cpp
@@ -651,13 +651,17 @@ void COneDeviceSensor::SaveCalibrationFile()
 					char			szTempName [ MAX_PATH ];
 
 					// Ask for write access on the target before writing anything. The
-					// rename below replaces a file on the strength of directory rights
-					// alone, so without this a correction the user has write-protected
-					// would be silently replaced. modeNoTruncate keeps the probe from
-					// being the very truncation this temporary file exists to avoid.
+					// rename below needs rights on the folder and not on the file, so a
+					// correction whose own ACL denies this user write would be replaced
+					// by it even though the user cannot open the file to write. The
+					// read-only attribute is not the case to reason about: MoveFileEx
+					// refuses that one by itself. Opening without modeCreate is what
+					// keeps the probe itself from truncating: MFC maps to CREATE_ALWAYS
+					// or OPEN_ALWAYS only when modeCreate is set, and to OPEN_EXISTING
+					// otherwise, so modeNoTruncate would have no say here.
 					if ( GetFileAttributes ( strChosenPath ) != INVALID_FILE_ATTRIBUTES )
 					{
-						CFile probeFile(strChosenPath,CFile::modeWrite|CFile::modeNoTruncate);
+						CFile probeFile(strChosenPath,CFile::modeWrite);
 						probeFile.Close ();
 					}
 

--- a/Sensors/OneDeviceSensor.cpp
+++ b/Sensors/OneDeviceSensor.cpp
@@ -400,6 +400,74 @@ void COneDeviceSensor::LoadCalibrationFile(CString & aFileName)
 	m_CalibrationFileName = loadFile.GetFileTitle ();
 }
 
+// Compare two directories as file system locations rather than as strings:
+// 8.3 short names, relative forms, subst drives, junctions and UNC shares all
+// spell the same folder differently.
+static BOOL IsSameDirectory ( LPCSTR lpszDir1, LPCSTR lpszDir2 )
+{
+	char						szDir [ 2 ] [ MAX_PATH ];
+	HANDLE						hDir [ 2 ];
+	BY_HANDLE_FILE_INFORMATION	fileInfo [ 2 ];
+	BOOL						bHaveInfo = TRUE;
+	int							i;
+
+	for ( i = 0; i < 2; i ++ )
+	{
+		LPCSTR	lpszSrc = ( i == 0 ? lpszDir1 : lpszDir2 );
+		DWORD	dwLen;
+		int		nLen;
+
+		// A path too long for the buffer leaves it untouched and returns the
+		// size it would need. Nothing here can canonicalize such a path, and
+		// a truncated copy would make two different folders look identical,
+		// so compare the two names exactly as they were given.
+		dwLen = GetFullPathName ( lpszSrc, MAX_PATH, szDir [ i ], NULL );
+		if ( dwLen == 0 || dwLen >= MAX_PATH )
+			return ( _stricmp ( lpszDir1, lpszDir2 ) == 0 );
+
+		// Drop the trailing backslash, except on a root like "C:\"
+		nLen = strlen ( szDir [ i ] );
+		while ( nLen > 1 && szDir [ i ] [ nLen - 1 ] == '\\' && szDir [ i ] [ nLen - 2 ] != ':' )
+			szDir [ i ] [ -- nLen ] = '\0';
+	}
+
+	// When both folders exist, compare the volume and file id the file system
+	// itself reports: that is immune to every way of spelling a path.
+	for ( i = 0; i < 2; i ++ )
+	{
+		hDir [ i ] = CreateFile ( szDir [ i ], 0, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL );
+
+		if ( hDir [ i ] == INVALID_HANDLE_VALUE || ! GetFileInformationByHandle ( hDir [ i ], & fileInfo [ i ] ) )
+			bHaveInfo = FALSE;
+	}
+
+	for ( i = 0; i < 2; i ++ )
+	{
+		if ( hDir [ i ] != INVALID_HANDLE_VALUE )
+			CloseHandle ( hDir [ i ] );
+	}
+
+	if ( bHaveInfo )
+	{
+		return ( fileInfo [ 0 ].dwVolumeSerialNumber == fileInfo [ 1 ].dwVolumeSerialNumber
+			  && fileInfo [ 0 ].nFileIndexHigh == fileInfo [ 1 ].nFileIndexHigh
+			  && fileInfo [ 0 ].nFileIndexLow == fileInfo [ 1 ].nFileIndexLow );
+	}
+
+	// One of them cannot be opened (it does not exist yet, or is not readable):
+	// fall back to a text comparison with any short name expanded.
+	for ( i = 0; i < 2; i ++ )
+	{
+		char	szLong [ MAX_PATH ];
+		DWORD	dwLen = GetLongPathName ( szDir [ i ], szLong, MAX_PATH );
+
+		if ( dwLen != 0 && dwLen < MAX_PATH )
+			lstrcpyn ( szDir [ i ], szLong, MAX_PATH );
+	}
+
+	return ( _stricmp ( szDir [ 0 ], szDir [ 1 ] ) == 0 );
+}
+
 void COneDeviceSensor::SaveCalibrationFile()
 {
 	BOOL			bContinue = FALSE;
@@ -414,21 +482,33 @@ void COneDeviceSensor::SaveCalibrationFile()
 	{
 		strPath += strSubDir;
 		strPath += '\\';
+
+		// That subdirectory is the only place the sensor selection page looks
+		// for training files, so create it before offering to save into it.
+		GetConfig () -> EnsurePathExists ( strPath );
 	}
 
 	do
 	{
 		bContinue = FALSE;
 
-		CFileDialog fileSaveDialog( FALSE, "thc", ( strFileName.IsEmpty () ? NULL : (LPCSTR) strFileName ), OFN_HIDEREADONLY | OFN_NOCHANGEDIR, "Sensor Training File (*.thc)|*.thc||" );
+		// Name the target folder in lpstrFile and not only in lpstrInitialDir:
+		// from Vista on, lpstrInitialDir loses to the shell's last visited
+		// folder once the dialog has been used, which would open the dialog
+		// somewhere the file cannot be saved.
+		CString	strInitialPath = strPath + strFileName;
+
+		CFileDialog fileSaveDialog( FALSE, "thc", (LPCSTR) strInitialPath, OFN_HIDEREADONLY | OFN_NOCHANGEDIR, "Sensor Training File (*.thc)|*.thc||" );
 		fileSaveDialog.m_ofn.lpstrInitialDir = (LPCSTR) strPath;
 
 		if(fileSaveDialog.DoModal() == IDOK)
 		{
-			strFileName = strPath + fileSaveDialog.GetFileName();
-			if ( strFileName.CompareNoCase ( fileSaveDialog.GetPathName() ) == 0 )
+			CString	strChosenPath = fileSaveDialog.GetPathName();
+			CString	strChosenDir = strChosenPath.Left ( strChosenPath.ReverseFind ( '\\' ) + 1 );
+
+			if ( IsSameDirectory ( strChosenDir, strPath ) )
 			{
-				CFile loadFile(fileSaveDialog.GetPathName(),CFile::modeCreate|CFile::modeWrite);
+				CFile loadFile(strChosenPath,CFile::modeCreate|CFile::modeWrite);
 				CArchive ar(&loadFile,CArchive::store);
 				
 				m_CalibrationFileName.Empty();
@@ -439,8 +519,12 @@ void COneDeviceSensor::SaveCalibrationFile()
 			}
 			else
 			{
+				// Name the folder in the message: "current directory" on its own
+				// leaves the user no way to tell where the file has to go.
 				CString Msg;
 				Msg.LoadString ( IDS_MUSTSAVEINSUBDIR );
+				Msg += "\n\n";
+				Msg += strPath;
 				AfxMessageBox ( Msg );
 				strFileName = fileSaveDialog.GetFileName();
 				lpStr = strrchr ( (LPSTR)(LPCSTR) strFileName, '.' );

--- a/Sensors/OneDeviceSensor.cpp
+++ b/Sensors/OneDeviceSensor.cpp
@@ -447,7 +447,13 @@ static BOOL IsSameDirectory ( LPCSTR lpszDir1, LPCSTR lpszDir2 )
 			CloseHandle ( hDir [ i ] );
 	}
 
-	if ( bHaveInfo )
+	// FAT32, exFAT and some network redirectors keep no per-file id and report
+	// zero for every entry, which would make two unrelated folders on one volume
+	// compare equal. Only an id that is actually there says anything; a zero one
+	// falls through to the text comparison below.
+	if ( bHaveInfo
+	  && ( fileInfo [ 0 ].nFileIndexHigh | fileInfo [ 0 ].nFileIndexLow ) != 0
+	  && ( fileInfo [ 1 ].nFileIndexHigh | fileInfo [ 1 ].nFileIndexLow ) != 0 )
 	{
 		return ( fileInfo [ 0 ].dwVolumeSerialNumber == fileInfo [ 1 ].dwVolumeSerialNumber
 			  && fileInfo [ 0 ].nFileIndexHigh == fileInfo [ 1 ].nFileIndexHigh
@@ -468,6 +474,36 @@ static BOOL IsSameDirectory ( LPCSTR lpszDir1, LPCSTR lpszDir2 )
 	return ( _stricmp ( szDir [ 0 ], szDir [ 1 ] ) == 0 );
 }
 
+// Say why a save failed, naming the path and the reason Windows gave. Without
+// this the exception unwinds to CWinThread::ProcessWndProcException and the
+// user is told only "Command failed".
+static void ReportCalibrationSaveFailure ( LPCSTR lpszPath, DWORD dwError )
+{
+	CString	strWhere ( lpszPath );
+	CString	strMsg;
+	LPSTR	lpszSysMsg = NULL;
+
+	if ( dwError != 0
+	  && FormatMessage ( FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+						   NULL, dwError, 0, (LPSTR) & lpszSysMsg, 0, NULL ) != 0
+	  && lpszSysMsg != NULL )
+	{
+		CString	strSysMsg ( lpszSysMsg );
+
+		LocalFree ( lpszSysMsg );
+		strSysMsg.TrimRight ( "\r\n" );
+
+		if ( ! strSysMsg.IsEmpty () )
+		{
+			strWhere += "\n\n";
+			strWhere += strSysMsg;
+		}
+	}
+
+	strMsg.Format ( IDS_THC_SAVE_FAILED, (LPCSTR) strWhere );
+	AfxMessageBox ( strMsg, MB_OK | MB_ICONEXCLAMATION );
+}
+
 void COneDeviceSensor::SaveCalibrationFile()
 {
 	BOOL			bContinue = FALSE;
@@ -475,6 +511,8 @@ void COneDeviceSensor::SaveCalibrationFile()
 	CString			strSubDir;
 	CString			strFileName;
 	LPSTR			lpStr;
+	DWORD			dwError;
+	DWORD			dwAttributes;
 
 	strPath = GetConfig () -> m_ApplicationPath;
 	strSubDir = GetStandardSubDir ();
@@ -485,7 +523,20 @@ void COneDeviceSensor::SaveCalibrationFile()
 
 		// That subdirectory is the only place the sensor selection page looks
 		// for training files, so create it before offering to save into it.
+		// EnsurePathExists cannot report failure, and under an installation in
+		// Program Files a standard user cannot create the folder at all, so ask
+		// whether it is there afterwards: carrying on regardless would leave the
+		// user in the reopen-until-cancel loop this is meant to end.
+		SetLastError ( ERROR_SUCCESS );
 		GetConfig () -> EnsurePathExists ( strPath );
+		dwError = GetLastError ();
+
+		dwAttributes = GetFileAttributes ( strPath );
+		if ( dwAttributes == INVALID_FILE_ATTRIBUTES || ! ( dwAttributes & FILE_ATTRIBUTE_DIRECTORY ) )
+		{
+			ReportCalibrationSaveFailure ( strPath, dwError );
+			return;
+		}
 	}
 
 	do
@@ -508,14 +559,43 @@ void COneDeviceSensor::SaveCalibrationFile()
 
 			if ( IsSameDirectory ( strChosenDir, strPath ) )
 			{
-				CFile loadFile(strChosenPath,CFile::modeCreate|CFile::modeWrite);
-				CArchive ar(&loadFile,CArchive::store);
-				
-				m_CalibrationFileName.Empty();
-				COneDeviceSensor::Serialize(ar);
+				CString	strPreviousName = m_CalibrationFileName;
 
-				m_CalibrationFileName = loadFile.GetFileTitle ();
-				
+				// The folder can exist and still refuse the write, which is what a
+				// Program Files installation does to a standard user. Say so here
+				// rather than letting the exception reach MFC's default handler.
+				TRY
+				{
+					CFile saveFile(strChosenPath,CFile::modeCreate|CFile::modeWrite);
+					CArchive ar(&saveFile,CArchive::store);
+					CString	strTitle = saveFile.GetFileTitle ();
+
+					// The archive records the correction this sensor was built from,
+					// and this file is that correction, so it stores an empty name.
+					m_CalibrationFileName.Empty();
+					COneDeviceSensor::Serialize(ar);
+
+					// Flush through the archive and the file while the exception can
+					// still be caught: both destructors swallow a late write error.
+					ar.Close ();
+					saveFile.Close ();
+
+					m_CalibrationFileName = strTitle;
+				}
+				CATCH_ALL ( e )
+				{
+					DWORD	dwSaveError = 0;
+
+					// Nothing reached the disk, so keep the name the sensor already
+					// had: the empty one above was only meant to reach the file.
+					m_CalibrationFileName = strPreviousName;
+
+					if ( e -> IsKindOf ( RUNTIME_CLASS ( CFileException ) ) )
+						dwSaveError = (DWORD) ( (CFileException *) e ) -> m_lOsError;
+
+					ReportCalibrationSaveFailure ( strChosenPath, dwSaveError );
+				}
+				END_CATCH_ALL
 			}
 			else
 			{

--- a/Sensors/OneDeviceSensor.cpp
+++ b/Sensors/OneDeviceSensor.cpp
@@ -434,14 +434,15 @@ static void ReportCalibrationLoadFailure ( LPCSTR lpszPath, CException * e )
 	AfxMessageBox ( strMsg, MB_OK | MB_ICONEXCLAMATION );
 }
 
-void COneDeviceSensor::LoadCalibrationFile(CString & aFileName)
+BOOL COneDeviceSensor::LoadCalibrationFile(CString & aFileName)
 {
 	// Serialize's load branch overwrites the sensor field by field and frees
 	// m_pCalibrationInfo before the version-gated read, so a file that is
 	// rejected part-way through - a truncated one, or a schema this build does
-	// not know - leaves the sensor carrying pieces of it. Every caller applies
-	// the sensor matrix as soon as this returns, so hold the whole of the old
-	// state and put it back: a file that could not be read changes nothing.
+	// not know - leaves the sensor carrying pieces of it. So hold the whole of
+	// the old state and put it back: a file that could not be read changes
+	// nothing, and FALSE says so to the caller that has to decide whether the
+	// document changed with it.
 	Matrix				previousMatrix = m_sensorToXYZMatrix;
 	time_t				previousTime = m_calibrationTime;
 	float				previousIRELevel = m_calibrationIRELevel;
@@ -454,6 +455,7 @@ void COneDeviceSensor::LoadCalibrationFile(CString & aFileName)
 	CString				strPreviousRef = m_calibrationReferenceName;
 	CString				strPreviousName = m_CalibrationFileName;
 	CCalibrationInfo *	pPreviousInfo = m_pCalibrationInfo;
+	BOOL				bLoaded = FALSE;
 
 	// Detach it first: Serialize deletes whatever the member points at, and
 	// that is the copy we are keeping.
@@ -469,6 +471,8 @@ void COneDeviceSensor::LoadCalibrationFile(CString & aFileName)
 		m_CalibrationFileName = loadFile.GetFileTitle ();
 
 		delete pPreviousInfo;
+
+		bLoaded = TRUE;
 	}
 	CATCH_ALL ( e )
 	{
@@ -490,6 +494,8 @@ void COneDeviceSensor::LoadCalibrationFile(CString & aFileName)
 		ReportCalibrationLoadFailure ( aFileName, e );
 	}
 	END_CATCH_ALL
+
+	return bLoaded;
 }
 
 // Compare two directories as file system locations rather than as strings:

--- a/Sensors/OneDeviceSensor.h
+++ b/Sensors/OneDeviceSensor.h
@@ -84,7 +84,7 @@ public:
 
 	virtual void Serialize(CArchive& archive); 
 
-	virtual void LoadCalibrationFile(CString & aFileName);
+	virtual BOOL LoadCalibrationFile(CString & aFileName);
 	virtual void SaveCalibrationFile();
 
 	virtual void SetPropertiesSheetValues();

--- a/Sensors/Sensor.h
+++ b/Sensors/Sensor.h
@@ -67,7 +67,9 @@ public:
 
 	//virtual BOOL CalibrateSensor(CGenerator *apGenerator);
 	//virtual BOOL CalibrateSensor(Matrix & measures, Matrix & references, CColor & WhiteTest, CColor & WhiteRef, CColor & BlackTest, CColor & BlackRef);
-	virtual void LoadCalibrationFile(CString & aFileName) { return ; }
+	// TRUE when the sensor is left carrying a correction. A sensor that does
+	// not use correction files has nothing to fail at, so it reports success.
+	virtual BOOL LoadCalibrationFile(CString & aFileName) { return TRUE; }
 	virtual void SaveCalibrationFile() { return ; }
 
 	void SetSensorMatrix(Matrix aMatrix) { m_sensorToXYZMatrix=aMatrix; m_calibrationTime=time(NULL);}

--- a/datasetdoc.cpp
+++ b/datasetdoc.cpp
@@ -5085,12 +5085,23 @@ void CDataSetDoc::OnLoadCalibrationFile()
 	if( propSheet.DoModal() == IDOK )
 	{
 
+		BOOL	bLoaded = TRUE;
+
 		if(page.m_sensorTrainingMode != 1)
-			m_pSensor->LoadCalibrationFile(page.m_trainingFileName);
-		m_pSensor->SetSensorMatrixMod(Matrix::IdentityMatrix(3));
-		m_measure.ApplySensorAdjustmentMatrix( m_pSensor->GetSensorMatrix() );
-		UpdateAllViews ( NULL, UPD_EVERYTHING );
-		SetModifiedFlag(TRUE);
+			bLoaded = m_pSensor->LoadCalibrationFile(page.m_trainingFileName);
+
+		// A correction file that could not be read has left the sensor exactly
+		// as it was, so the document must not be touched either. Going on would
+		// stamp a calibration time for a calibration that never happened -
+		// SetSensorMatrixMod sets m_calibrationTime - and mark the document
+		// modified over it.
+		if ( bLoaded )
+		{
+			m_pSensor->SetSensorMatrixMod(Matrix::IdentityMatrix(3));
+			m_measure.ApplySensorAdjustmentMatrix( m_pSensor->GetSensorMatrix() );
+			UpdateAllViews ( NULL, UPD_EVERYTHING );
+			SetModifiedFlag(TRUE);
+		}
 	}
 }
 

--- a/resource.h
+++ b/resource.h
@@ -1569,6 +1569,7 @@
 #define IDS_CC_COLORNAMEREF             42013
 #define IDS_GRAPH_TRK_NEARBLACK         42014
 #define IDS_GRAPH_TRK_NEARWHITE         42015
+#define IDS_THC_SAVE_FAILED             42016
 #define IDS_CONTRAST                    41777
 #define IDS_OFFSET                      41778
 #define IDS_CONFIRMTRAINING             41779

--- a/resource.h
+++ b/resource.h
@@ -1570,6 +1570,7 @@
 #define IDS_GRAPH_TRK_NEARBLACK         42014
 #define IDS_GRAPH_TRK_NEARWHITE         42015
 #define IDS_THC_SAVE_FAILED             42016
+#define IDS_THC_LOAD_FAILED             42017
 #define IDS_CONTRAST                    41777
 #define IDS_OFFSET                      41778
 #define IDS_CONFIRMTRAINING             41779


### PR DESCRIPTION
A user reports that saving a meter correction file (Sensor -> *Save meter correction
file...*) fails with

> You must save this file in current directory to use it later.

and that there is no way to satisfy it: the message never says which directory it means,
and the save dialog reopens on every attempt until you cancel.

`COneDeviceSensor::SaveCalibrationFile` requires the file to land in
`<exe folder>\Etalon_<sensor>\`, but it never creates that folder. Everything else that
touches these files does: the sensor selection page calls `EnsurePathExists` before it
lists `.thc` files, and so does the scripted `SaveCalibrationFile` command in
`MultiFrm.cpp`. Only the interactive save left it out. When the folder is missing the shell
cannot open the dialog there, so the user lands somewhere else, the path comparison fails,
and the message gives them nothing to act on.

The comparison itself was also stricter than it looks. It concatenated
`<required dir>` + the returned file name and compared that to the returned full path as
text, so an 8.3 short name, a junction or a UNC spelling of the correct folder all read as
the wrong folder.

## What changed

- Create the sensor subdirectory before offering the dialog, the way the load side already
  does.
- Name the required folder in the message, after the existing sentence. This is done in
  code, so no `.rc` string had to change in any of the five languages.
- Compare the chosen folder to the required one by the volume serial and file id the file
  system reports (`CreateFile` with `FILE_FLAG_BACKUP_SEMANTICS` +
  `GetFileInformationByHandle`), falling back to a long-name text compare when a folder
  cannot be opened. A path that does not fit `MAX_PATH` cannot be canonicalized at all, so
  that case compares the two names exactly as given rather than a truncated prefix of each,
  which would make two different folders look like the same one.
- Pass the target folder in `lpstrFile` as well as `lpstrInitialDir`. MFC splits
  `lpstrFile` and calls `IFileDialog::SetFolder` with the directory half
  (`atlmfc/src/mfc/dlgfile.cpp`), and `SetFolder` overrides the shell's last-visited
  folder, which `lpstrInitialDir` alone does not once the dialog has been used.

## Verification

Debug and Release, Win32, both 0 errors; `OneDeviceSensor.cpp` compiles with 0 warnings in
both (its object file deleted first, both exe timestamps confirmed to advance).
`ColorMathTest verify` exits 0.

`IsSameDirectory` was extracted verbatim into a standalone harness and passes 10 cases
(identical, trailing backslash, 8.3 short name, different folders, existing vs missing,
missing vs itself, two different missing, junction to the same folder, and two paths longer
than `MAX_PATH` -- one compared with itself, one with a different long path). A UNC spelling
(`\\localhost\C$\...`) of the same folder was checked separately and also compares equal.
The previous text comparison was compiled alongside it and fails the 8.3 and junction cases.
A `subst` drive is the one alias not measured: `subst` is unavailable in this environment.

The whole flow was then driven in the real application, with no hardware: a new document on
the simulated sensor with an existing correction file loaded, the `Etalon_Simulation` folder
deleted, then a save into a deliberately wrong folder followed by a save with a bare file
name. On this branch all eight checks pass -- the folder is created by the save path, the
message carries the full path, and the file lands in the required folder. The same script
run against the parent commit fails exactly three of them: the folder is never created, the
message is the bare sentence with no path, and the save never lands anywhere. That is the
reported bug reproduced and then fixed.

## Not in this PR

The restriction itself is left alone: the file still has to go in the sensor subdirectory,
because that is the only place the load combo ever looks. Whether to relax that and simply
copy the file there is worth deciding separately.
